### PR TITLE
feat: Simple checkpoint

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -10,11 +10,11 @@ use std::{
 
 use merk::{self, Merk};
 use rs_merkle::{algorithms::Sha256, MerkleTree};
-pub use subtree::Element;
 use storage::{
     rocksdb_storage::{PrefixedRocksDbStorage, PrefixedRocksDbStorageError},
     Storage,
 };
+pub use subtree::Element;
 
 /// Limit of possible indirections
 const MAX_REFERENCE_HOPS: usize = 10;

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -26,24 +26,18 @@ const ROOT_LEAFS_SERIALIZED_KEY: &[u8] = b"rootLeafsSerialized";
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("rocksdb error")]
-    RocksDBError(#[from] PrefixedRocksDbStorageError),
-    #[error("unable to open Merk db")]
-    MerkError(merk::Error),
-    #[error("invalid path: {0}")]
-    InvalidPath(&'static str),
-    #[error("unable to decode")]
-    BincodeError(#[from] bincode::Error),
+    // Input data errors
     #[error("cyclic reference path")]
     CyclicReference,
     #[error("reference hops limit exceeded")]
     ReferenceLimit,
-}
-
-impl From<merk::Error> for Error {
-    fn from(e: merk::Error) -> Self {
-        Error::MerkError(e)
-    }
+    #[error("invalid path: {0}")]
+    InvalidPath(&'static str),
+    // Irrecoverable errors
+    #[error("storage error: {0}")]
+    StorageError(#[from] PrefixedRocksDbStorageError),
+    #[error("data corruption error: {0}")]
+    CorruptedData(String),
 }
 
 pub struct GroveDb {
@@ -69,10 +63,14 @@ impl GroveDb {
         let mut subtrees = HashMap::new();
         // TODO: owned `get` is not required for deserialization
         if let Some(prefixes_serialized) = meta_storage.get_meta(SUBTRESS_SERIALIZED_KEY)? {
-            let subtrees_prefixes: Vec<Vec<u8>> = bincode::deserialize(&prefixes_serialized)?;
+            let subtrees_prefixes: Vec<Vec<u8>> = bincode::deserialize(&prefixes_serialized)
+                .map_err(|_| {
+                    Error::CorruptedData(String::from("unable to deserialize prefixes"))
+                })?;
             for prefix in subtrees_prefixes {
                 let subtree_merk =
-                    Merk::open(PrefixedRocksDbStorage::new(db.clone(), prefix.to_vec())?)?;
+                    Merk::open(PrefixedRocksDbStorage::new(db.clone(), prefix.to_vec())?)
+                        .map_err(|e| Error::CorruptedData(e.to_string()))?;
                 subtrees.insert(prefix.to_vec(), subtree_merk);
             }
         }
@@ -81,7 +79,9 @@ impl GroveDb {
         let root_leaf_keys: HashMap<Vec<u8>, usize> = if let Some(root_leaf_keys_serialized) =
             meta_storage.get_meta(ROOT_LEAFS_SERIALIZED_KEY)?
         {
-            bincode::deserialize(&root_leaf_keys_serialized)?
+            bincode::deserialize(&root_leaf_keys_serialized).map_err(|_| {
+                Error::CorruptedData(String::from("unable to deserialize root leafs"))
+            })?
         } else {
             HashMap::new()
         };
@@ -95,13 +95,25 @@ impl GroveDb {
         })
     }
 
+    pub fn checkpoint<P: AsRef<Path>>(&self, path: P) -> Result<GroveDb, Error> {
+        storage::rocksdb_storage::Checkpoint::new(&self.db)
+            .and_then(|x| x.create_checkpoint(&path))
+            .map_err(PrefixedRocksDbStorageError::RocksDbError)?;
+        GroveDb::open(path)
+    }
+
     fn store_subtrees_keys_data(&self) -> Result<(), Error> {
         let prefixes: Vec<Vec<u8>> = self.subtrees.keys().map(|x| x.clone()).collect();
-        self.meta_storage
-            .put_meta(SUBTRESS_SERIALIZED_KEY, &bincode::serialize(&prefixes)?)?;
+        self.meta_storage.put_meta(
+            SUBTRESS_SERIALIZED_KEY,
+            &bincode::serialize(&prefixes)
+                .map_err(|_| Error::CorruptedData(String::from("unable to serialize prefixes")))?,
+        )?;
         self.meta_storage.put_meta(
             ROOT_LEAFS_SERIALIZED_KEY,
-            &bincode::serialize(&self.root_leaf_keys)?,
+            &bincode::serialize(&self.root_leaf_keys).map_err(|_| {
+                Error::CorruptedData(String::from("unable to serialize root leafs"))
+            })?,
         )?;
         Ok(())
     }
@@ -140,7 +152,8 @@ impl GroveDb {
                             Merk::open(PrefixedRocksDbStorage::new(
                                 self.db.clone(),
                                 compressed_path_subtree,
-                            )?)?,
+                            )?)
+                            .map_err(|e| Error::CorruptedData(e.to_string()))?,
                         ))
                     };
                 if path.is_empty() {

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -239,3 +239,62 @@ fn test_root_tree_leafs_are_noted() {
     assert_eq!(db.root_leaf_keys, hm);
     assert_eq!(db.root_tree.leaves_len(), 2);
 }
+
+#[test]
+fn test_checkpoint() {
+    let mut db = make_grovedb();
+    let element1 = Element::Item(b"ayy".to_vec());
+
+    db.insert(&[], b"key1".to_vec(), Element::empty_tree())
+        .expect("cannot insert a subtree 1 into GroveDB");
+    db.insert(&[b"key1"], b"key2".to_vec(), Element::empty_tree())
+        .expect("cannot insert a subtree 2 into GroveDB");
+    db.insert(&[b"key1", b"key2"], b"key3".to_vec(), element1.clone())
+        .expect("cannot insert an item into GroveDB");
+
+    assert_eq!(
+        db.get(&[b"key1", b"key2"], b"key3")
+            .expect("cannot get from grovedb"),
+        element1
+    );
+
+    let checkpoint_tempdir = TempDir::new("checkpoint").expect("cannot open tempdir");
+    let mut checkpoint = db
+        .checkpoint(checkpoint_tempdir.path().join("checkpoint"))
+        .expect("cannot create a checkpoint");
+
+    assert_eq!(
+        db.get(&[b"key1", b"key2"], b"key3")
+            .expect("cannot get from grovedb"),
+        element1
+    );
+    assert_eq!(
+        checkpoint
+            .get(&[b"key1", b"key2"], b"key3")
+            .expect("cannot get from checkpoint"),
+        element1
+    );
+
+    let element2 = Element::Item(b"ayy2".to_vec());
+    let element3 = Element::Item(b"ayy3".to_vec());
+
+    checkpoint
+        .insert(&[b"key1"], b"key4".to_vec(), element2.clone())
+        .expect("cannot insert into checkpoint");
+
+    db.insert(&[b"key1"], b"key4".to_vec(), element3.clone())
+        .expect("cannot insert into GroveDB");
+
+    assert_eq!(
+        checkpoint
+            .get(&[b"key1"], b"key4")
+            .expect("cannot get from checkpoint"),
+        element2,
+    );
+
+    assert_eq!(
+        db.get(&[b"key1"], b"key4")
+            .expect("cannot get from GroveDB"),
+        element3
+    );
+}

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -297,4 +297,21 @@ fn test_checkpoint() {
             .expect("cannot get from GroveDB"),
         element3
     );
+
+    checkpoint
+        .insert(&[b"key1"], b"key5".to_vec(), element3.clone())
+        .expect("cannot insert into checkpoint");
+
+    db.insert(&[b"key1"], b"key6".to_vec(), element3.clone())
+        .expect("cannot insert into GroveDB");
+
+    assert!(matches!(
+        checkpoint.get(&[b"key1"], b"key6"),
+        Err(Error::InvalidPath(_))
+    ));
+
+    assert!(matches!(
+        db.get(&[b"key1"], b"key5"),
+        Err(Error::InvalidPath(_))
+    ));
 }

--- a/merk/Cargo.toml
+++ b/merk/Cargo.toml
@@ -10,8 +10,9 @@ license = "MIT"
 tempdir = "0.3.7"
 storage = { path = "../storage" }
 thiserror = "1.0.30"
-failure = "0.1.8"
 rocksdb = "0.17.0"
+anyhow = "1.0.51"
+failure = "0.1.8"
 
 [dependencies.time]
 version = "0.1.42"

--- a/merk/src/lib.rs
+++ b/merk/src/lib.rs
@@ -1,7 +1,5 @@
 #![feature(map_first_last)]
 
-/// Error and Result types.
-mod error;
 /// The top-level store API.
 #[cfg(feature = "full")]
 mod merk;
@@ -18,7 +16,6 @@ pub mod test_utils;
 /// The core tree data structure.
 pub mod tree;
 
-pub use error::{Error, Result};
 #[allow(deprecated)]
 pub use proofs::query::verify_query;
 pub use proofs::query::{execute_proof, verify};

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -183,7 +183,6 @@ where
 #[cfg(test)]
 mod tests {
     use storage::rocksdb_storage::{default_rocksdb, PrefixedRocksDbStorage};
-
     use tempdir::TempDir;
 
     use super::*;

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -183,6 +183,7 @@ where
 #[cfg(test)]
 mod tests {
     use storage::rocksdb_storage::{default_rocksdb, PrefixedRocksDbStorage};
+
     use tempdir::TempDir;
 
     use super::*;

--- a/merk/src/proofs/chunk.rs
+++ b/merk/src/proofs/chunk.rs
@@ -1,18 +1,14 @@
+use anyhow::{bail, Result};
 use storage::RawIterator;
 #[cfg(feature = "full")]
 use {
     super::tree::{execute, Tree as ProofTree},
     crate::tree::Hash,
     crate::tree::Tree,
-    failure::bail,
-    rocksdb::DBRawIterator,
 };
 
 use super::{Node, Op};
-use crate::{
-    error::Result,
-    tree::{Fetch, RefWalker},
-};
+use crate::tree::{Fetch, RefWalker};
 
 /// The minimum number of layers the trunk will be guaranteed to have before
 /// splitting into multiple chunks. If the tree's height is less than double

--- a/merk/src/proofs/encoding.rs
+++ b/merk/src/proofs/encoding.rs
@@ -1,10 +1,10 @@
 use std::io::{Read, Write};
 
+use anyhow::{anyhow, Result};
 use ed::{Decode, Encode, Terminated};
-use failure::bail;
 
 use super::{Node, Op};
-use crate::{error::Result, tree::HASH_LENGTH};
+use crate::tree::HASH_LENGTH;
 
 impl Encode for Op {
     fn encode_into<W: Write>(&self, dest: &mut W) -> ed::Result<()> {
@@ -71,7 +71,8 @@ impl Decode for Op {
             }
             0x10 => Op::Parent,
             0x11 => Op::Child,
-            _ => bail!("Proof has unexpected value"),
+            // TODO: get rid of `failure` with improvements to ed API (or removing dependency on ed)
+            _ => failure::bail!("Proof has unexpected value"),
         })
     }
 }
@@ -81,6 +82,7 @@ impl Terminated for Op {}
 impl Op {
     fn encode_into<W: Write>(&self, dest: &mut W) -> Result<()> {
         Encode::encode_into(self, dest)
+            .map_err(|e| anyhow!("failed to encode an proofs::Op structure ({})", e))
     }
 
     fn encoding_length(&self) -> usize {
@@ -89,6 +91,7 @@ impl Op {
 
     pub fn decode(bytes: &[u8]) -> Result<Self> {
         Decode::decode(bytes)
+            .map_err(|e| anyhow!("failed to decode an proofs::Op structure ({})", e))
     }
 }
 

--- a/merk/src/proofs/query/map.rs
+++ b/merk/src/proofs/query/map.rs
@@ -3,10 +3,9 @@ use std::{
     ops::{Bound, RangeBounds},
 };
 
-use failure::{bail, ensure, format_err};
+use anyhow::{anyhow, bail, ensure, Result};
 
 use super::super::Node;
-use crate::Result;
 
 /// `MapBuilder` allows a consumer to construct a `Map` by inserting the nodes
 /// contained in a proof, in key-order.
@@ -200,7 +199,7 @@ impl<'a> Iterator for Range<'a> {
         // if nodes weren't contiguous, we cannot verify that we have all values
         // in the desired range
         if !skip_exclusion_check && !contiguous {
-            return Some(Err(format_err!("Proof is missing data for query")));
+            return Some(Err(anyhow!("Proof is missing data for query")));
         }
 
         // passed checks, return entry

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -6,16 +6,13 @@ use std::{
     ops::{Range, RangeInclusive},
 };
 
-use failure::bail;
+use anyhow::{bail, Result};
 pub use map::*;
 #[cfg(feature = "full")]
 use {super::Op, std::collections::LinkedList};
 
 use super::{tree::execute, Decoder, Node};
-use crate::{
-    error::Result,
-    tree::{Fetch, Hash, Link, RefWalker},
-};
+use crate::tree::{Fetch, Hash, Link, RefWalker};
 
 /// `Query` represents one or more keys or ranges of keys, which can be used to
 /// resolve a proof which will include all of the requested values.

--- a/merk/src/proofs/tree.rs
+++ b/merk/src/proofs/tree.rs
@@ -1,10 +1,7 @@
-use failure::bail;
+use anyhow::{bail, Result};
 
 use super::{Node, Op};
-use crate::{
-    error::Result,
-    tree::{kv_hash, node_hash, Hash, NULL_HASH},
-};
+use crate::tree::{kv_hash, node_hash, Hash, NULL_HASH};
 
 /// Contains a tree's child node and its hash. The hash can always be assumed to
 /// be up-to-date.
@@ -143,13 +140,13 @@ impl Tree {
         Node::Hash(self.hash()).into()
     }
 
-    #[cfg(feature = "full")]
-    pub(crate) fn key(&self) -> &[u8] {
-        match self.node {
-            Node::KV(ref key, _) => key,
-            _ => panic!("Expected node to be type KV"),
-        }
-    }
+    // #[cfg(feature = "full")]
+    // pub(crate) fn key(&self) -> &[u8] {
+    //     match self.node {
+    //         Node::KV(ref key, _) => key,
+    //         _ => panic!("Expected node to be type KV"),
+    //     }
+    // }
 }
 
 /// `LayerIter` iterates over the nodes in a `Tree` at a given depth. Nodes are

--- a/merk/src/test_utils/crash_merk.rs
+++ b/merk/src/test_utils/crash_merk.rs
@@ -3,10 +3,11 @@ use std::{
     rc::Rc,
 };
 
+use anyhow::Result;
 use storage::rocksdb_storage::{default_rocksdb, PrefixedRocksDbStorage};
 use tempdir::TempDir;
 
-use crate::{Merk, Result};
+use crate::Merk;
 
 /// Wraps a Merk instance and drops it without flushing once it goes out of
 /// scope.
@@ -31,7 +32,9 @@ impl CrashMerk {
     }
 
     pub fn crash(&mut self) {
-        self.path.take().map(|x| drop(x));
+        if let Some(a) = self.path.take() {
+            drop(a)
+        }
     }
 }
 

--- a/merk/src/test_utils/temp_merk.rs
+++ b/merk/src/test_utils/temp_merk.rs
@@ -1,6 +1,5 @@
 use std::{
     ops::{Deref, DerefMut},
-    path::Path,
     rc::Rc,
 };
 
@@ -28,6 +27,12 @@ impl TempMerk {
             path,
             _db: db,
         }
+    }
+}
+
+impl Default for TempMerk {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/merk/src/tree/commit.rs
+++ b/merk/src/tree/commit.rs
@@ -1,5 +1,6 @@
+use anyhow::Result;
+
 use super::Tree;
-use crate::error::Result;
 
 /// To be used when committing a tree (writing it to a store after applying the
 /// changes).

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -1,8 +1,8 @@
+use anyhow::{anyhow, Error};
 use ed::{Decode, Encode};
 use storage::{Storage, Store};
 
 use super::Tree;
-use crate::error::Error;
 
 impl Store for Tree {
     type Error = Error;
@@ -12,7 +12,7 @@ impl Store for Tree {
     }
 
     fn decode(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Decode::decode(bytes)
+        Decode::decode(bytes).map_err(|e| anyhow!("failed to decode a Tree structure ({})", e))
     }
 
     fn get<S>(storage: S, key: &[u8]) -> Result<Option<Self>, Self::Error>

--- a/merk/src/tree/link.rs
+++ b/merk/src/tree/link.rs
@@ -175,28 +175,28 @@ impl Link {
         }
     }
 
-    #[inline]
-    #[cfg(feature = "full")]
-    pub(crate) fn child_heights_mut(&mut self) -> &mut (u8, u8) {
-        match self {
-            Link::Reference {
-                ref mut child_heights,
-                ..
-            } => child_heights,
-            Link::Modified {
-                ref mut child_heights,
-                ..
-            } => child_heights,
-            Link::Uncommitted {
-                ref mut child_heights,
-                ..
-            } => child_heights,
-            Link::Loaded {
-                ref mut child_heights,
-                ..
-            } => child_heights,
-        }
-    }
+    // #[inline]
+    // #[cfg(feature = "full")]
+    // pub(crate) fn child_heights_mut(&mut self) -> &mut (u8, u8) {
+    //     match self {
+    //         Link::Reference {
+    //             ref mut child_heights,
+    //             ..
+    //         } => child_heights,
+    //         Link::Modified {
+    //             ref mut child_heights,
+    //             ..
+    //         } => child_heights,
+    //         Link::Uncommitted {
+    //             ref mut child_heights,
+    //             ..
+    //         } => child_heights,
+    //         Link::Loaded {
+    //             ref mut child_heights,
+    //             ..
+    //         } => child_heights,
+    //     }
+    // }
 }
 
 impl Encode for Link {

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -12,6 +12,7 @@ mod walk;
 
 use std::cmp::max;
 
+use anyhow::Result;
 pub use commit::{Commit, NoopCommit};
 use ed::{Decode, Encode};
 pub use hash::{kv_hash, node_hash, Hash, HASH_LENGTH, NULL_HASH};
@@ -19,8 +20,6 @@ use kv::KV;
 pub use link::Link;
 pub use ops::{BatchEntry, MerkBatch, Op, PanicSource};
 pub use walk::{Fetch, RefWalker, Walker};
-
-use super::error::Result;
 
 // TODO: remove need for `TreeInner`, and just use `Box<Self>` receiver for
 // relevant methods

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -1,9 +1,9 @@
 use std::{collections::LinkedList, fmt};
 
+use anyhow::Result;
 use Op::*;
 
 use super::{Fetch, Link, Tree, Walker};
-use crate::error::Result;
 
 /// An operation to be applied to a key in the store.
 pub enum Op {

--- a/merk/src/tree/walk/fetch.rs
+++ b/merk/src/tree/walk/fetch.rs
@@ -1,5 +1,6 @@
+use anyhow::Result;
+
 use super::super::{Link, Tree};
-use crate::error::Result;
 
 /// A source of data to be used by the tree when encountering a pruned node.
 /// This typcially means fetching the tree node from a backing store by its key,

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -1,11 +1,12 @@
 mod fetch;
 mod ref_walker;
 
+use anyhow::Result;
 pub use fetch::Fetch;
 pub use ref_walker::RefWalker;
 
 use super::{Link, Tree};
-use crate::{error::Result, owner::Owner};
+use crate::owner::Owner;
 
 /// Allows traversal of a `Tree`, fetching from the given source when traversing
 /// to a pruned node, detaching children as they are traversed.

--- a/merk/src/tree/walk/ref_walker.rs
+++ b/merk/src/tree/walk/ref_walker.rs
@@ -1,8 +1,9 @@
+use anyhow::Result;
+
 use super::{
     super::{Link, Tree},
     Fetch,
 };
-use crate::error::Result;
 
 /// Allows read-only traversal of a `Tree`, fetching from the given source when
 /// traversing to a pruned node. The fetched nodes are then retained in memory

--- a/node-grove/src/converter.rs
+++ b/node-grove/src/converter.rs
@@ -1,15 +1,18 @@
-use grovedb::{Element};
-use neon::{prelude::*, borrow::Borrow};
+use grovedb::Element;
+use neon::{borrow::Borrow, prelude::*};
 
 fn element_to_string(element: Element) -> String {
     match element {
-        Element::Item(_) => { "item".to_string() }
-        Element::Reference(_) => { "reference".to_string() }
-        Element::Tree(_) => { "tree".to_string() }
+        Element::Item(_) => "item".to_string(),
+        Element::Reference(_) => "reference".to_string(),
+        Element::Tree(_) => "tree".to_string(),
     }
 }
 
-pub fn js_object_to_element<'a, C: Context<'a>>(js_object: Handle<JsObject>, cx: &mut C) -> NeonResult<Element> {
+pub fn js_object_to_element<'a, C: Context<'a>>(
+    js_object: Handle<JsObject>,
+    cx: &mut C,
+) -> NeonResult<Element> {
     let js_element_string = js_object.get(cx, "type")?.to_string(cx)?;
     let value = js_object.get(cx, "value")?;
 
@@ -20,32 +23,32 @@ pub fn js_object_to_element<'a, C: Context<'a>>(js_object: Handle<JsObject>, cx:
             let js_buffer = value.downcast_or_throw::<JsBuffer, _>(cx)?;
             let item = js_buffer_to_vec_u8(js_buffer, cx);
             Ok(Element::Item(item))
-        },
+        }
         "reference" => {
             let js_array = value.downcast_or_throw::<JsArray, _>(cx)?;
             let reference = js_array_of_buffers_to_vec(js_array, cx)?;
             Ok(Element::Reference(reference))
-        },
+        }
         "tree" => {
             let js_buffer = value.downcast_or_throw::<JsBuffer, _>(cx)?;
             let tree_vec = js_buffer_to_vec_u8(js_buffer, cx);
-            Ok(Element::Tree(
-                tree_vec
-                    .try_into()
-                    .or_else(|v: Vec<u8>| {
-                        cx.throw_error(
-                            format!("Tree buffer is expected to be 32 bytes long, but got {}", v.len())
-                        )
-                    })?
-            ))
+            Ok(Element::Tree(tree_vec.try_into().or_else(
+                |v: Vec<u8>| {
+                    cx.throw_error(format!(
+                        "Tree buffer is expected to be 32 bytes long, but got {}",
+                        v.len()
+                    ))
+                },
+            )?))
         }
-        _ => {
-            cx.throw_error(format!("Unexpected element type {}", element_string))
-        }
+        _ => cx.throw_error(format!("Unexpected element type {}", element_string)),
     }
 }
 
-pub fn element_to_js_object<'a, C: Context<'a>>(element: Element, cx: &mut C) -> NeonResult<Handle<'a, JsValue>> {
+pub fn element_to_js_object<'a, C: Context<'a>>(
+    element: Element,
+    cx: &mut C,
+) -> NeonResult<Handle<'a, JsValue>> {
     let js_object = cx.empty_object();
     let js_type_string = cx.string(element_to_string(element.clone()));
     js_object.set(cx, "type", js_type_string)?;
@@ -84,7 +87,10 @@ pub fn js_buffer_to_vec_u8<'a, C: Context<'a>>(js_buffer: Handle<JsBuffer>, cx: 
     key_slice.to_vec()
 }
 
-pub fn js_array_of_buffers_to_vec<'a, C: Context<'a>>(js_array: Handle<JsArray>, cx: &mut C) -> NeonResult<Vec<Vec<u8>>> {
+pub fn js_array_of_buffers_to_vec<'a, C: Context<'a>>(
+    js_array: Handle<JsArray>,
+    cx: &mut C,
+) -> NeonResult<Vec<Vec<u8>>> {
     let buf_vec = js_array.to_vec(cx)?;
     let mut vec: Vec<Vec<u8>> = Vec::new();
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -10,3 +10,6 @@ num_cpus = "1.13.0"
 rocksdb = "0.17.0"
 tempdir = "0.3.7"
 thiserror = "1.0.30"
+
+[dev-dependencies]
+tempdir = "0.3.7"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -8,7 +8,5 @@ edition = "2021"
 [dependencies]
 num_cpus = "1.13.0"
 rocksdb = "0.17.0"
-thiserror = "1.0.30"
-
-[dev-dependencies]
 tempdir = "0.3.7"
+thiserror = "1.0.30"

--- a/storage/src/rocksdb_storage.rs
+++ b/storage/src/rocksdb_storage.rs
@@ -1,8 +1,8 @@
 //! Storage implementation using RocksDB
 use std::{path::Path, rc::Rc};
 
+pub use rocksdb::{checkpoint::Checkpoint, Error, DB};
 use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, DBRawIterator, WriteBatch};
-pub use rocksdb::{Error, DB};
 
 use crate::{Batch, RawIterator, Storage};
 


### PR DESCRIPTION
This PR adds an ability to make a checkpoint of current GroveDB state, basically by reusing RocksDB checkpointing funcitonality;
Also there is an attempt to deprecate `failure` crate and to do a little cleanup of error handling story