### PR TITLE
feat: subtree pairs iterator

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -235,6 +235,14 @@ impl GroveDb {
         }
     }
 
+    pub fn elements_iterator(&self, path: &[&[u8]]) -> Result<subtree::ElementsIterator, Error> {
+        let merk = self
+            .subtrees
+            .get(&Self::compress_path(path, None))
+            .ok_or(Error::InvalidPath("no subtree found under that path"))?;
+        Ok(Element::iterator(merk.raw_iter()))
+    }
+
     /// Get tree item without following references
     fn get_raw(&self, path: &[&[u8]], key: &[u8]) -> Result<subtree::Element, Error> {
         let merk = self

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -1,9 +1,12 @@
 //! Module for subtrees handling.
 //! Subtrees handling is isolated so basically this module is about adapting
 //! Merk API to GroveDB needs.
-use merk::Op;
+use merk::{tree::Tree, Op};
 use serde::{Deserialize, Serialize};
-use storage::rocksdb_storage::PrefixedRocksDbStorage;
+use storage::{
+    rocksdb_storage::{PrefixedRocksDbStorage, RawPrefixedIterator},
+    RawIterator, Store,
+};
 
 use crate::{Error, Merk};
 
@@ -55,6 +58,35 @@ impl Element {
             )];
         merk.apply(&batch, &[])
             .map_err(|e| Error::CorruptedData(e.to_string()))
+    }
+
+    pub fn iterator(mut raw_iter: RawPrefixedIterator) -> ElementsIterator {
+        raw_iter.seek_to_first();
+        ElementsIterator { raw_iter }
+    }
+}
+
+pub struct ElementsIterator<'a> {
+    raw_iter: RawPrefixedIterator<'a>,
+}
+
+impl<'a> ElementsIterator<'a> {
+    pub fn next(&mut self) -> Result<Option<(&[u8], Element)>, Error> {
+        Ok(if self.raw_iter.valid() {
+            self.raw_iter.next();
+            if let Some((key, value)) = self.raw_iter.key().zip(self.raw_iter.value()) {
+                let tree = <Tree as Store>::decode(value)
+                    .map_err(|e| Error::CorruptedData(e.to_string()))?;
+                let element: Element = bincode::deserialize(tree.value()).map_err(|_| {
+                    Error::CorruptedData(String::from("unable to deserialize element"))
+                })?;
+                Some((key, element))
+            } else {
+                None
+            }
+        } else {
+            None
+        })
     }
 }
 

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -71,15 +71,16 @@ pub struct ElementsIterator<'a> {
 }
 
 impl<'a> ElementsIterator<'a> {
-    pub fn next(&mut self) -> Result<Option<(&[u8], Element)>, Error> {
+    pub fn next(&mut self) -> Result<Option<(Vec<u8>, Element)>, Error> {
         Ok(if self.raw_iter.valid() {
-            self.raw_iter.next();
             if let Some((key, value)) = self.raw_iter.key().zip(self.raw_iter.value()) {
                 let tree = <Tree as Store>::decode(value)
                     .map_err(|e| Error::CorruptedData(e.to_string()))?;
                 let element: Element = bincode::deserialize(tree.value()).map_err(|_| {
                     Error::CorruptedData(String::from("unable to deserialize element"))
                 })?;
+                let key = key.to_vec();
+                self.raw_iter.next();
                 Some((key, element))
             } else {
                 None

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -372,7 +372,10 @@ impl Commit for MerkCommitter {
 
 #[cfg(test)]
 mod test {
-    use storage::rocksdb_storage::{default_rocksdb, PrefixedRocksDbStorage};
+    use storage::{
+        rocksdb_storage::{default_rocksdb, PrefixedRocksDbStorage},
+        RawIterator,
+    };
     use tempdir::TempDir;
 
     use super::{Merk, MerkSource, RefWalker};
@@ -539,7 +542,7 @@ mod test {
 
     #[test]
     fn reopen_iter() {
-        fn collect(iter: &mut rocksdb::DBRawIterator, nodes: &mut Vec<(Vec<u8>, Vec<u8>)>) {
+        fn collect(iter: &mut impl RawIterator, nodes: &mut Vec<(Vec<u8>, Vec<u8>)>) {
             while iter.valid() {
                 nodes.push((iter.key().unwrap().to_vec(), iter.value().unwrap().to_vec()));
                 iter.next();

--- a/storage/src/rocksdb_storage.rs
+++ b/storage/src/rocksdb_storage.rs
@@ -236,7 +236,6 @@ impl RawIterator for RawPrefixedIterator<'_> {
     }
 
     fn valid(&self) -> bool {
-        // TODO: things may break if we continue concat prefix and key just like that
         self.rocksdb_iterator
             .key()
             .map(|k| k.starts_with(self.prefix))

--- a/storage/src/rocksdb_storage.rs
+++ b/storage/src/rocksdb_storage.rs
@@ -96,7 +96,7 @@ impl PrefixedRocksDbStorage {
 impl Storage for PrefixedRocksDbStorage {
     type Batch<'a> = PrefixedRocksDbBatch<'a>;
     type Error = PrefixedRocksDbStorageError;
-    type RawIterator<'a> = rocksdb::DBRawIterator<'a>;
+    type RawIterator<'a> = RawPrefixedIterator<'a>;
 
     fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {
         self.db
@@ -191,33 +191,56 @@ impl Storage for PrefixedRocksDbStorage {
     }
 
     fn raw_iter<'a>(&'a self) -> Self::RawIterator<'a> {
-        self.db.raw_iterator()
+        RawPrefixedIterator {
+            rocksdb_iterator: self.db.raw_iterator(),
+            prefix: &self.prefix,
+        }
     }
 }
 
-impl RawIterator for rocksdb::DBRawIterator<'_> {
+pub struct RawPrefixedIterator<'a> {
+    rocksdb_iterator: DBRawIterator<'a>,
+    prefix: &'a [u8],
+}
+
+impl RawIterator for RawPrefixedIterator<'_> {
     fn seek_to_first(&mut self) {
-        DBRawIterator::seek_to_first(self)
+        self.rocksdb_iterator.seek(self.prefix);
     }
 
     fn seek(&mut self, key: &[u8]) {
-        DBRawIterator::seek(self, key)
+        self.rocksdb_iterator
+            .seek(make_prefixed_key(self.prefix.to_vec(), key));
     }
 
     fn next(&mut self) {
-        DBRawIterator::next(self)
+        self.rocksdb_iterator.next();
     }
 
     fn value(&self) -> Option<&[u8]> {
-        DBRawIterator::value(self)
+        if self.valid() {
+            self.rocksdb_iterator.value()
+        } else {
+            None
+        }
     }
 
     fn key(&self) -> Option<&[u8]> {
-        DBRawIterator::key(self)
+        if self.valid() {
+            self.rocksdb_iterator
+                .key()
+                .map(|k| k.split_at(self.prefix.len()).1)
+        } else {
+            None
+        }
     }
 
     fn valid(&self) -> bool {
-        DBRawIterator::valid(self)
+        // TODO: things may break if we continue concat prefix and key just like that
+        self.rocksdb_iterator
+            .key()
+            .map(|k| k.starts_with(self.prefix))
+            .unwrap_or(false)
     }
 }
 
@@ -487,5 +510,65 @@ mod tests {
                 .unwrap(),
             b"yeet"
         );
+    }
+
+    #[test]
+    fn test_raw_iterator() {
+        let tmp_dir = TempDir::new("test_raw_iterator").expect("unable to open a tempdir");
+        let db = default_rocksdb(tmp_dir.path());
+
+        let storage = PrefixedRocksDbStorage::new(db.clone(), b"someprefix".to_vec())
+            .expect("cannot create a prefixed storage");
+        storage
+            .put(b"key1", b"value1")
+            .expect("expected successful insertion");
+        storage
+            .put(b"key0", b"value0")
+            .expect("expected successful insertion");
+        storage
+            .put(b"key3", b"value3")
+            .expect("expected successful insertion");
+        storage
+            .put(b"key2", b"value2")
+            .expect("expected successful insertion");
+
+        // Other storages are required to put something into rocksdb with other prefix
+        // to see if there will be any conflicts and boundaries are met
+        let another_storage_before =
+            PrefixedRocksDbStorage::new(db.clone(), b"anothersomeprefix".to_vec())
+                .expect("cannot create a prefixed storage");
+        another_storage_before
+            .put(b"key1", b"value1")
+            .expect("expected successful insertion");
+        another_storage_before
+            .put(b"key5", b"value5")
+            .expect("expected successful insertion");
+        let another_storage_after = PrefixedRocksDbStorage::new(db, b"zanothersomeprefix".to_vec())
+            .expect("cannot create a prefixed storage");
+        another_storage_after
+            .put(b"key1", b"value1")
+            .expect("expected successful insertion");
+        another_storage_after
+            .put(b"key5", b"value5")
+            .expect("expected successful insertion");
+
+        let expected: [(&'static [u8], &'static [u8]); 4] = [
+            (b"key0", b"value0"),
+            (b"key1", b"value1"),
+            (b"key2", b"value2"),
+            (b"key3", b"value3"),
+        ];
+        let mut expected_iter = expected.into_iter();
+
+        let mut iter = storage.raw_iter();
+        iter.seek_to_first();
+        while iter.valid() {
+            assert_eq!(
+                (iter.key().unwrap(), iter.value().unwrap()),
+                expected_iter.next().unwrap()
+            );
+            iter.next();
+        }
+        assert!(expected_iter.next().is_none());
     }
 }


### PR DESCRIPTION
This PR contains two changes:
## Path compression
It alters how path compression works, previously collisions may occur for cases like `[a, ab] vs [aa, b]`, also subtree keys shared the same prefix as parent trees which is harmful for iteration over subtree elements as there is no way to find out where to stop, now they're not.

New path compression algorithm (for subtree key):
1. Concat all path segments as before
2. Append number of segments
3. Append lengths of each segment
4. hash it

Subtree elements' keys use the same approach, but appending their key after hashing happened, this way their order is preserved and they're located sequentially in DB.

## Subtree elements iterator
This allows for a given subtree to iterate over key-value pairs sorted by key, values are `Element` object