### PR TITLE
feat: delete operation for elements and trees

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -9,14 +9,10 @@ use std::{
 };
 
 pub use merk::proofs::{query::QueryItem, Query};
-use merk::{
-    self,
-    proofs::query::Map,
-    Merk,
-};
+use merk::{self, proofs::query::Map, Merk};
 use rs_merkle::{algorithms::Sha256, Hasher, MerkleProof, MerkleTree};
 use storage::{
-    rocksdb_storage::{PrefixedRocksDbStorage, PrefixedRocksDbStorageError},
+    rocksdb_storage::{self, PrefixedRocksDbStorage, PrefixedRocksDbStorageError},
     Storage,
 };
 pub use subtree::Element;
@@ -150,6 +146,71 @@ impl GroveDb {
         }
         let res = MerkleTree::<Sha256>::from_leaves(&leaf_hashes);
         res
+    }
+
+    pub fn delete(&mut self, path: &[&[u8]], key: Vec<u8>) -> Result<(), Error> {
+        let element = self.get_raw(path, &key)?;
+        if path.is_empty() {
+            // Attempt to delete a root tree leaf
+            Err(Error::InvalidPath(
+                "root tree leafs currently cannot be deleted",
+            ))
+        } else {
+            let mut merk = self
+                .subtrees
+                .get_mut(&Self::compress_subtree_key(path, None))
+                .ok_or(Error::InvalidPath("no subtree found under that path"))?;
+            Element::delete(&mut merk, key.clone())?;
+            if let Element::Tree(_) = element {
+                // TODO: dumb traversal should not be tolerated
+                let mut concat_path: Vec<Vec<u8>> = path.iter().map(|x| x.to_vec()).collect();
+                concat_path.push(key);
+                let subtrees_paths = self.find_subtrees(concat_path)?;
+                for subtree_path in subtrees_paths {
+                    // TODO: eventually we need to do something about this nested slices
+                    let subtree_path_ref: Vec<&[u8]> =
+                        subtree_path.iter().map(|x| x.as_slice()).collect();
+                    let prefix = Self::compress_subtree_key(&subtree_path_ref, None);
+                    if let Some(subtree) = self.subtrees.remove(&prefix) {
+                        subtree.clear().map_err(|e| {
+                            Error::CorruptedData(format!(
+                                "unable to cleanup tree from storage: {}",
+                                e
+                            ))
+                        })?;
+                    }
+                }
+            }
+            self.propagate_changes(path)?;
+            Ok(())
+        }
+    }
+
+    // TODO: dumb traversal should not be tolerated
+    /// Finds keys which are trees for a given subtree recursively.
+    /// One element means a key of a `merk`, n > 1 elements mean relative path
+    /// for a deeply nested subtree.
+    fn find_subtrees(&self, path: Vec<Vec<u8>>) -> Result<Vec<Vec<Vec<u8>>>, Error> {
+        let mut queue: Vec<Vec<Vec<u8>>> = vec![path.clone()];
+        let mut result: Vec<Vec<Vec<u8>>> = vec![path.clone()];
+
+        while let Some(q) = queue.pop() {
+            // TODO: eventually we need to do something about this nested slices
+            let q_ref: Vec<&[u8]> = q.iter().map(|x| x.as_slice()).collect();
+            let mut iter = self.elements_iterator(&q_ref)?;
+            while let Some((key, value)) = iter.next()? {
+                match value {
+                    Element::Tree(_) => {
+                        let mut sub_path = q.clone();
+                        sub_path.push(key);
+                        queue.push(sub_path.clone());
+                        result.push(sub_path);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(result)
     }
 
     // TODO: split the function into smaller ones

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -29,6 +29,14 @@ impl Element {
         Element::Tree(Default::default())
     }
 
+    /// Delete an element from Merk under a key
+    pub fn delete(merk: &mut Merk<PrefixedRocksDbStorage>, key: Vec<u8>) -> Result<(), Error> {
+        // TODO: delete references on this element
+        let batch = [(key, Op::Delete)];
+        merk.apply(&batch, &[])
+            .map_err(|e| Error::CorruptedData(e.to_string()))
+    }
+
     /// Get an element from Merk under a key; path should be resolved and proper
     /// Merk should be loaded by this moment
     pub fn get(merk: &Merk<PrefixedRocksDbStorage>, key: &[u8]) -> Result<Element, Error> {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -161,6 +161,8 @@ pub trait RawIterator {
 
     fn next(&mut self);
 
+    fn prev(&mut self);
+
     fn value(&self) -> Option<&[u8]>;
 
     fn key(&self) -> Option<&[u8]>;

--- a/storage/src/rocksdb_storage.rs
+++ b/storage/src/rocksdb_storage.rs
@@ -217,6 +217,10 @@ impl RawIterator for RawPrefixedIterator<'_> {
         self.rocksdb_iterator.next();
     }
 
+    fn prev(&mut self) {
+        self.rocksdb_iterator.prev();
+    }
+
     fn value(&self) -> Option<&[u8]> {
         if self.valid() {
             self.rocksdb_iterator.value()


### PR DESCRIPTION
This PR improves GroveDB's API with `delete` method.
Currently it supports two scenarios:
1. Delete a subtree item (scalar/reference)
2. Delete a subtree, this recursively deletes all subtrees of a subtree too, currently it requires full traversal

Note that references on deleted object will stay and become invalid