### PR TITLE
add `get_query` method

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -316,6 +316,22 @@ impl GroveDb {
         }
     }
 
+    pub fn get_query(
+        &mut self,
+        path_queries: &[PathQuery],
+    ) -> Result<Vec<subtree::Element>, Error> {
+        let mut result = Vec::new();
+        for query in path_queries {
+            let merk = self
+                .subtrees
+                .get(&Self::compress_subtree_key(query.path, None))
+                .ok_or(Error::InvalidPath("no subtree found under that path"))?;
+            let subtree_results = subtree::Element::get_query(merk, &query.query)?;
+            result.extend_from_slice(&subtree_results);
+        }
+        Ok(result)
+    }
+
     pub fn elements_iterator(&self, path: &[&[u8]]) -> Result<subtree::ElementsIterator, Error> {
         let merk = self
             .subtrees

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -31,7 +31,7 @@ impl Query {
         self.items.len()
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &QueryItem> {
+    pub fn iter(&self) -> impl Iterator<Item = &QueryItem> {
         self.items.iter()
     }
 


### PR DESCRIPTION
This PR adds `get_query` method which adds an ability to get elements from GroveDB using same `PathQuery` as used for proof generation.
Current implementation uses raw iterator.