### PR TITLE
feat: `is_transaction_started` method

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -446,6 +446,12 @@ impl GroveDb {
         Ok(())
     }
 
+    /// Returns true if transaction is started. For more details on the
+    /// transaction usage, please check [`GroveDb::start_transaction`]
+    pub fn is_transaction_started(&self) -> bool {
+        return self.is_readonly;
+    }
+
     /// Commits previously started db transaction. For more details on the
     /// transaction usage, please check [`GroveDb::start_transaction`]
     pub fn commit_transaction(

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -863,6 +863,25 @@ fn transaction_insert_should_return_error_when_trying_to_insert_while_transactio
 }
 
 #[test]
+fn transaction_is_started_should_return_true_if_transaction_was_started() {
+    let mut db = make_grovedb();
+
+    db.start_transaction();
+
+    let result = db.is_transaction_started();
+    assert!(result, "transaction is not started");
+}
+
+#[test]
+fn transaction_is_started_should_return_false_if_transaction_was_not_started() {
+    let mut db = make_grovedb();
+
+    let result = db.is_transaction_started();
+
+    assert!(!result, "transaction is started");
+}
+
+#[test]
 fn test_subtree_pairs_iterator() {
     let mut db = make_grovedb();
     let element = Element::Item(b"ayy".to_vec());


### PR DESCRIPTION
Implement `is_transaction_started` method to check if transaction is already started or not