### PR TITLE
feat: add `root_hash` method

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -225,6 +225,19 @@ impl GroveDb {
     //     GroveDb::open(path)
     // }
 
+    /// Returns root hash of GroveDb.
+    /// Will be `None` if GroveDb is empty.
+    pub fn root_hash(
+        &self,
+        db_transaction: Option<&OptimisticTransactionDBTransaction>,
+    ) -> Option<[u8; 32]> {
+        if db_transaction.is_some() {
+            self.temp_root_tree.root()
+        } else {
+            self.root_tree.root()
+        }
+    }
+
     fn store_subtrees_keys_data(
         &self,
         db_transaction: Option<&OptimisticTransactionDBTransaction>,

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -1896,3 +1896,38 @@ fn test_get_range_query_with_limit_and_offset() {
     let mut last_value = (1996 as u32).to_be_bytes().to_vec();
     assert_eq!(elements[elements.len() - 1], Element::Item(last_value));
 }
+
+#[test]
+fn test_root_hash() {
+    let mut db = make_grovedb();
+    // Check hashes are different if tree is edited
+    let old_root_hash = db.root_hash(None);
+    db.insert(
+        &[TEST_LEAF],
+        b"key1".to_vec(),
+        Element::Item(b"ayy".to_vec()),
+        None,
+    )
+    .expect("unable to insert an item");
+    let new_root_hash = db.root_hash(None);
+    assert_ne!(old_root_hash, db.root_hash(None));
+
+    // Check isolation
+    let storage = db.storage();
+    let transaction = storage.transaction();
+    db.start_transaction();
+
+    db.insert(
+        &[TEST_LEAF],
+        b"key2".to_vec(),
+        Element::Item(b"ayy".to_vec()),
+        Some(&transaction),
+    )
+    .expect("unable to insert an item");
+    let root_hash_outside = db.root_hash(None);
+    assert_ne!(db.root_hash(Some(&transaction)), root_hash_outside);
+
+    assert_eq!(db.root_hash(None), root_hash_outside);
+    db.commit_transaction(transaction);
+    assert_ne!(db.root_hash(None), root_hash_outside);
+}

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -124,9 +124,9 @@ impl Query {
         self.insert_item(range);
     }
 
-    /// Adds a range after the first value, until a certain non included value to the query,
-    /// so that all the entries in the tree with keys in the range will be included
-    /// in the resulting proof.
+    /// Adds a range after the first value, until a certain non included value
+    /// to the query, so that all the entries in the tree with keys in the
+    /// range will be included in the resulting proof.
     ///
     /// If a range including the range already exists in the query, this will
     /// have no effect. If the query already includes a range that overlaps with
@@ -136,9 +136,9 @@ impl Query {
         self.insert_item(range);
     }
 
-    /// Adds a range after the first value, until a certain included value to the query,
-    /// so that all the entries in the tree with keys in the range will be included
-    /// in the resulting proof.
+    /// Adds a range after the first value, until a certain included value to
+    /// the query, so that all the entries in the tree with keys in the
+    /// range will be included in the resulting proof.
     ///
     /// If a range including the range already exists in the query, this will
     /// have no effect. If the query already includes a range that overlaps with


### PR DESCRIPTION
this PR adds `root_hash` method for GroveDb with respect to transactions