### PR TITLE
refactor: mark a number of functions as const

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -68,7 +68,7 @@ pub struct SizedQuery {
 }
 
 impl SizedQuery {
-    pub fn new(query: Query, limit: Option<u16>, offset: Option<u16>) -> SizedQuery {
+    pub const fn new(query: Query, limit: Option<u16>, offset: Option<u16>) -> SizedQuery {
         SizedQuery {
             query,
             limit,
@@ -78,11 +78,11 @@ impl SizedQuery {
 }
 
 impl PathQuery {
-    pub fn new(path: Vec<Vec<u8>>, query: SizedQuery) -> PathQuery {
+    pub const fn new(path: Vec<Vec<u8>>, query: SizedQuery) -> PathQuery {
         PathQuery { path, query }
     }
 
-    pub fn new_unsized(path: Vec<Vec<u8>>, query: Query) -> PathQuery {
+    pub const fn new_unsized(path: Vec<Vec<u8>>, query: Query) -> PathQuery {
         let query = SizedQuery::new(query, None, None);
         PathQuery { path, query }
     }
@@ -364,7 +364,7 @@ impl GroveDb {
 
     /// Returns true if transaction is started. For more details on the
     /// transaction usage, please check [`GroveDb::start_transaction`]
-    pub fn is_transaction_started(&self) -> bool {
+    pub const fn is_transaction_started(&self) -> bool {
         self.is_readonly
     }
 

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -256,7 +256,7 @@ impl QueryItem {
         }
     }
 
-    pub fn lower_unbounded(&self) -> bool {
+    pub const fn lower_unbounded(&self) -> bool {
         match self {
             QueryItem::Key(_) => false,
             QueryItem::Range(_) => false,
@@ -286,7 +286,7 @@ impl QueryItem {
         }
     }
 
-    pub fn upper_unbounded(&self) -> bool {
+    pub const fn upper_unbounded(&self) -> bool {
         match self {
             QueryItem::Key(_) => false,
             QueryItem::Range(_) => false,
@@ -363,7 +363,7 @@ impl QueryItem {
         }
     }
 
-    pub fn is_range(&self) -> bool {
+    pub const fn is_range(&self) -> bool {
         !matches!(self, QueryItem::Key(_))
     }
 
@@ -685,7 +685,7 @@ impl Link {
     /// Creates a `Node::Hash` from this link. Panics if the link is of variant
     /// `Link::Modified` since its hash has not yet been computed.
     #[cfg(feature = "full")]
-    fn to_hash_node(&self) -> Node {
+    const fn to_hash_node(&self) -> Node {
         let hash = match self {
             Link::Reference { hash, .. } => hash,
             Link::Modified { .. } => {

--- a/merk/src/proofs/tree.rs
+++ b/merk/src/proofs/tree.rs
@@ -93,7 +93,7 @@ impl Tree {
     }
 
     /// Returns an immutable reference to the child on the given side, if any.
-    pub fn child(&self, left: bool) -> Option<&Child> {
+    pub const fn child(&self, left: bool) -> Option<&Child> {
         if left {
             self.left.as_ref()
         } else {
@@ -130,8 +130,11 @@ impl Tree {
     /// given side, if any. If there is no child, returns the null hash
     /// (zero-filled).
     #[inline]
-    fn child_hash(&self, left: bool) -> Hash {
-        self.child(left).map_or(NULL_HASH, |c| c.hash)
+    const fn child_hash(&self, left: bool) -> Hash {
+        match self.child(left){
+            Some(c) => c.hash,
+            _ => NULL_HASH,
+        }
     }
 
     /// Consumes the tree node, calculates its hash, and returns a `Node::Hash`

--- a/merk/src/test_utils/mod.rs
+++ b/merk/src/test_utils/mod.rs
@@ -62,19 +62,16 @@ pub fn apply_to_memonly(maybe_tree: Option<Tree>, batch: &MerkBatch<Vec<u8>>) ->
         })
 }
 
-pub fn seq_key(n: u64) -> Vec<u8> {
-    let mut key = vec![0; 0];
-    key.write_u64::<BigEndian>(n)
-        .expect("writing to key failed");
-    key
+pub const fn seq_key(n: u64) -> [u8; 8] {
+    n.to_be_bytes()
 }
 
 pub fn put_entry(n: u64) -> BatchEntry<Vec<u8>> {
-    (seq_key(n), Op::Put(vec![123; 60]))
+    (seq_key(n).to_vec(), Op::Put(vec![123; 60]))
 }
 
 pub fn del_entry(n: u64) -> BatchEntry<Vec<u8>> {
-    (seq_key(n), Op::Delete)
+    (seq_key(n).to_vec(), Op::Delete)
 }
 
 pub fn make_batch_seq(range: Range<u64>) -> Vec<BatchEntry<Vec<u8>>> {

--- a/merk/src/tree/iter.rs
+++ b/merk/src/tree/iter.rs
@@ -14,7 +14,7 @@ impl<'a> StackItem<'a> {
     /// Creates a new `StackItem` for the given tree. The `traversed` state will
     /// be `false` since the children and self have not been visited yet, but
     /// will default to `true` for sides that do not have a child.
-    fn new(tree: &'a Tree) -> Self {
+    const fn new(tree: &'a Tree) -> Self {
         StackItem {
             tree,
             traversed: (

--- a/merk/src/tree/kv.rs
+++ b/merk/src/tree/kv.rs
@@ -57,7 +57,7 @@ impl KV {
 
     /// Returns the hash.
     #[inline]
-    pub fn hash(&self) -> &Hash {
+    pub const fn hash(&self) -> &Hash {
         &self.hash
     }
 

--- a/merk/src/tree/link.rs
+++ b/merk/src/tree/link.rs
@@ -53,7 +53,7 @@ pub enum Link {
 impl Link {
     /// Creates a `Link::Modified` from the given `Tree`.
     #[inline]
-    pub fn from_modified_tree(tree: Tree) -> Self {
+    pub const fn from_modified_tree(tree: Tree) -> Self {
         let pending_writes = 1 + tree.child_pending_writes(true) + tree.child_pending_writes(false);
 
         Link::Modified {
@@ -71,25 +71,25 @@ impl Link {
 
     /// Returns `true` if the link is of the `Link::Reference` variant.
     #[inline]
-    pub fn is_reference(&self) -> bool {
+    pub const fn is_reference(&self) -> bool {
         matches!(self, Link::Reference { .. })
     }
 
     /// Returns `true` if the link is of the `Link::Modified` variant.
     #[inline]
-    pub fn is_modified(&self) -> bool {
+    pub const fn is_modified(&self) -> bool {
         matches!(self, Link::Modified { .. })
     }
 
     /// Returns `true` if the link is of the `Link::Uncommitted` variant.
     #[inline]
-    pub fn is_uncommitted(&self) -> bool {
+    pub const fn is_uncommitted(&self) -> bool {
         matches!(self, Link::Uncommitted { .. })
     }
 
     /// Returns `true` if the link is of the `Link::Loaded` variant.
     #[inline]
-    pub fn is_stored(&self) -> bool {
+    pub const fn is_stored(&self) -> bool {
         matches!(self, Link::Loaded { .. })
     }
 
@@ -107,7 +107,7 @@ impl Link {
     /// Returns the `Tree` instance of the tree referenced by the link. If the
     /// link is of variant `Link::Reference`, the returned value will be `None`.
     #[inline]
-    pub fn tree(&self) -> Option<&Tree> {
+    pub const fn tree(&self) -> Option<&Tree> {
         match self {
             // TODO: panic for Reference, don't return Option?
             Link::Reference { .. } => None,
@@ -121,7 +121,7 @@ impl Link {
     /// of variant `Link::Modified` since we have not yet recomputed the tree's
     /// hash.
     #[inline]
-    pub fn hash(&self) -> &Hash {
+    pub const fn hash(&self) -> &Hash {
         match self {
             Link::Modified { .. } => panic!("Cannot get hash from modified link"),
             Link::Reference { hash, .. } => hash,
@@ -134,7 +134,15 @@ impl Link {
     /// if any (note: not the height of the referenced tree itself). Return
     /// value is `(left_child_height, right_child_height)`.
     #[inline]
-    pub fn height(&self) -> u8 {
+    pub const fn height(&self) -> u8 {
+        const fn max(a: u8, b: u8) -> u8 {
+            if a >= b {
+                a
+            } else {
+                b
+            }
+        }
+
         let (left_height, right_height) = match self {
             Link::Reference { child_heights, .. } => *child_heights,
             Link::Modified { child_heights, .. } => *child_heights,
@@ -146,7 +154,7 @@ impl Link {
 
     /// Returns the balance factor of the tree referenced by the link.
     #[inline]
-    pub fn balance_factor(&self) -> i8 {
+    pub const fn balance_factor(&self) -> i8 {
         let (left_height, right_height) = match self {
             Link::Reference { child_heights, .. } => *child_heights,
             Link::Modified { child_heights, .. } => *child_heights,

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -99,14 +99,14 @@ impl Tree {
 
     /// Returns the hash of the root node's key/value pair.
     #[inline]
-    pub fn kv_hash(&self) -> &Hash {
+    pub const fn kv_hash(&self) -> &Hash {
         self.inner.kv.hash()
     }
 
     /// Returns a reference to the root node's `Link` on the given side, if any.
     /// If there is no child, returns `None`.
     #[inline]
-    pub fn link(&self, left: bool) -> Option<&Link> {
+    pub const fn link(&self, left: bool) -> Option<&Link> {
         if left {
             self.inner.left.as_ref()
         } else {
@@ -128,7 +128,7 @@ impl Tree {
     /// Returns a reference to the root node's child on the given side, if any.
     /// If there is no child, returns `None`.
     #[inline]
-    pub fn child(&self, left: bool) -> Option<&Self> {
+    pub const fn child(&self, left: bool) -> Option<&Self> {
         match self.link(left) {
             None => None,
             Some(link) => link.tree(),
@@ -151,8 +151,11 @@ impl Tree {
     /// Returns the hash of the root node's child on the given side, if any. If
     /// there is no child, returns the null hash (zero-filled).
     #[inline]
-    pub fn child_hash(&self, left: bool) -> &Hash {
-        self.link(left).map_or(&NULL_HASH, |link| link.hash())
+    pub const fn child_hash(&self, left: bool) -> &Hash {
+        match self.link(left) {
+            Some(link) => link.hash(),
+            _ => &NULL_HASH,
+        }
     }
 
     /// Computes and returns the hash of the root node.
@@ -168,7 +171,7 @@ impl Tree {
     /// Returns the number of pending writes for the child on the given side, if
     /// any. If there is no child, returns 0.
     #[inline]
-    pub fn child_pending_writes(&self, left: bool) -> usize {
+    pub const fn child_pending_writes(&self, left: bool) -> usize {
         match self.link(left) {
             Some(Link::Modified { pending_writes, .. }) => *pending_writes,
             _ => 0,
@@ -178,12 +181,15 @@ impl Tree {
     /// Returns the height of the child on the given side, if any. If there is
     /// no child, returns 0.
     #[inline]
-    pub fn child_height(&self, left: bool) -> u8 {
-        self.link(left).map_or(0, |child| child.height())
+    pub const fn child_height(&self, left: bool) -> u8 {
+        match self.link(left){
+            Some(child) => child.height(),
+            _ => 0,
+        }
     }
 
     #[inline]
-    pub fn child_heights(&self) -> (u8, u8) {
+    pub const fn child_heights(&self) -> (u8, u8) {
         (self.child_height(true), self.child_height(false))
     }
 
@@ -200,7 +206,7 @@ impl Tree {
     /// left child (if any). For example, a balance factor of 2 means the right
     /// subtree is 2 levels taller than the left subtree.
     #[inline]
-    pub fn balance_factor(&self) -> i8 {
+    pub const fn balance_factor(&self) -> i8 {
         let left_height = self.child_height(true) as i8;
         let right_height = self.child_height(false) as i8;
         right_height - left_height
@@ -406,7 +412,7 @@ impl Tree {
     }
 }
 
-pub fn side_to_str(left: bool) -> &'static str {
+pub const fn side_to_str(left: bool) -> &'static str {
     if left {
         "left"
     } else {


### PR DESCRIPTION
When a function can be const, it probably should be const. This way it can be called at compile time, and it makes it clear to the caller that nothing on the heap is being touched.