### PR TITLE
fix: compress subtree can no longer be attacked

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -285,18 +285,12 @@ impl GroveDb {
         P: IntoIterator<Item = &'a [u8]>,
     {
         let segments_iter = path.into_iter().chain(key.into_iter());
-        let mut segments_count: usize = 0;
         let mut res = Vec::new();
-        let mut lengthes = Vec::new();
 
         for s in segments_iter {
-            segments_count += 1;
+            res.extend_from_slice(s.len().to_le_bytes().as_slice());
             res.extend_from_slice(s);
-            lengthes.extend(s.len().to_ne_bytes());
         }
-
-        res.extend(segments_count.to_ne_bytes());
-        res.extend(lengthes);
         res = blake3::hash(&res).as_bytes().to_vec();
         res
     }

--- a/grovedb/src/operations/delete.rs
+++ b/grovedb/src/operations/delete.rs
@@ -84,13 +84,13 @@ impl GroveDb {
             let subtrees = self.get_subtrees();
             let delete_element = || -> Result<(), Error> {
                 // TODO: we shouldn't handle this context manually each time
-                let (mut parent_merk, _prefix) = subtrees.get(path_iter.clone(), transaction)?;
+                let (mut parent_merk, prefix) = subtrees.get(path_iter.clone(), transaction)?;
                 Element::delete(&mut parent_merk, &key, transaction)?;
-                // if let Some(prefix) = prefix {
-                //     subtrees.insert_temp_tree_with_prefix(prefix, parent_merk, transaction);
-                // } else {
+                if let Some(prefix) = prefix {
+                    subtrees.insert_temp_tree_with_prefix(prefix, parent_merk, transaction);
+                } else {
                     subtrees.insert_temp_tree(path_iter.clone(), parent_merk, transaction);
-                // }
+                }
                 Ok(())
             };
 

--- a/grovedb/src/operations/delete.rs
+++ b/grovedb/src/operations/delete.rs
@@ -1,6 +1,6 @@
 use storage::rocksdb_storage::OptimisticTransactionDBTransaction;
 
-use crate::{Element, Error, GroveDb};
+use crate::{Element, Error, GroveDb, PathQuery};
 
 impl GroveDb {
     pub fn delete_up_tree_while_empty<'a, P>(
@@ -84,13 +84,13 @@ impl GroveDb {
             let subtrees = self.get_subtrees();
             let delete_element = || -> Result<(), Error> {
                 // TODO: we shouldn't handle this context manually each time
-                let (mut parent_merk, prefix) = subtrees.get(path_iter.clone(), transaction)?;
+                let (mut parent_merk, _prefix) = subtrees.get(path_iter.clone(), transaction)?;
                 Element::delete(&mut parent_merk, &key, transaction)?;
-                if let Some(prefix) = prefix {
-                    subtrees.insert_temp_tree_with_prefix(prefix, parent_merk, transaction);
-                } else {
+                // if let Some(prefix) = prefix {
+                //     subtrees.insert_temp_tree_with_prefix(prefix, parent_merk, transaction);
+                // } else {
                     subtrees.insert_temp_tree(path_iter.clone(), parent_merk, transaction);
-                }
+                // }
                 Ok(())
             };
 

--- a/grovedb/src/operations/delete.rs
+++ b/grovedb/src/operations/delete.rs
@@ -26,7 +26,7 @@ impl GroveDb {
         let mut delete_count: u16 = 1;
         if let Some(last) = path_iter.next_back() {
             let deleted_parent =
-                self.delete_up_tree_while_empty(path_iter, last, stop_path_height, transaction)?;
+                self.delete_up_tree_while_empty(path_iter.collect::<Vec<&[u8]>>(), last, stop_path_height, transaction)?;
             delete_count += deleted_parent;
         }
         Ok(delete_count)

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -990,10 +990,18 @@ fn test_subtree_pairs_iterator() {
 fn test_compress_path_not_possible_collision() {
     let path_a = [b"aa".as_ref(), b"b"];
     let path_b = [b"a".as_ref(), b"ab"];
+    let empty_key : Vec<u8> = Vec::new();
     assert_ne!(
         GroveDb::compress_subtree_key(path_a, None),
         GroveDb::compress_subtree_key(path_b, None)
     );
+
+    // support empty keys
+    assert_ne!(
+        GroveDb::compress_subtree_key(path_a, None),
+        GroveDb::compress_subtree_key(path_a, Some(empty_key.as_slice()))
+    );
+
     assert_eq!(
         GroveDb::compress_subtree_key(path_a, None),
         GroveDb::compress_subtree_key(path_a, None),


### PR DESCRIPTION
There was a small attack possible as length could be bigger than 255 causing a commutativity between a very big path and a small path to result in same value.