### PR TITLE
feat: better path errors

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -56,7 +56,6 @@ pub enum Error {
     CorruptedPath(&'static str),
 
     // Query errors
-
     #[error("invalid query: {0}")]
     InvalidQuery(&'static str),
     #[error("missing parameter: {0}")]

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -39,10 +39,24 @@ pub enum Error {
     InternalError(&'static str),
     #[error("invalid proof: {0}")]
     InvalidProof(&'static str),
+
+    // Path errors
+
+    // The path key not found could represent a valid query, just where the path key isn't there
     #[error("invalid path key: {0}")]
-    InvalidPathKey(String),
+    PathKeyNotFound(String),
+    // The path not found could represent a valid query, just where the path isn't there
+    #[error("path not found: {0}")]
+    PathNotFound(&'static str),
+    // The invalid path represents a logical error from the client library
     #[error("invalid path: {0}")]
     InvalidPath(&'static str),
+    // The corrupted path represents a consistency error in internal groveDB logic
+    #[error("corrupted path: {0}")]
+    CorruptedPath(&'static str),
+
+    // Query errors
+
     #[error("invalid query: {0}")]
     InvalidQuery(&'static str),
     #[error("missing parameter: {0}")]
@@ -359,7 +373,7 @@ impl GroveDb {
     ///
     /// // This action exists only inside the transaction for now
     /// let result = db.get([TEST_LEAF], subtree_key, None);
-    /// assert!(matches!(result, Err(Error::InvalidPathKey(_))));
+    /// assert!(matches!(result, Err(Error::PathKeyNotFound(_))));
     ///
     /// // To access values inside the transaction, transaction needs to be passed to the `db::get`
     /// let result_with_transaction = db.get([TEST_LEAF], subtree_key, Some(&db_transaction))?;

--- a/grovedb/src/operations/get.rs
+++ b/grovedb/src/operations/get.rs
@@ -43,7 +43,7 @@ impl GroveDb {
                 current_element =
                     self.get_raw(path_slice.iter().map(|x| x.as_slice()), key, transaction)?;
             } else {
-                return Err(Error::InvalidPath("empty path"));
+                return Err(Error::CorruptedPath("empty path"));
             }
             visited.insert(path);
             match current_element {

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -118,14 +118,16 @@ impl GroveDb {
         let subtrees = self.get_subtrees();
         let path_iter = path.into_iter();
         // First, check if a subtree exists to create a new subtree under it
-        subtrees.borrow_mut(path_iter.clone(), transaction).map_err(|e| {
-            // When adding if the path does not exist, this means it is an invalid path
-            if let Error::PathNotFound(str) = e {
-                Error::InvalidPath(str)
-            } else {
-                e
-            }
-        })?;
+        subtrees
+            .borrow_mut(path_iter.clone(), transaction)
+            .map_err(|e| {
+                // When adding if the path does not exist, this means it is an invalid path
+                if let Error::PathNotFound(str) = e {
+                    Error::InvalidPath(str)
+                } else {
+                    e
+                }
+            })?;
 
         let (subtree_prefix, subtree_merk) =
             create_merk_with_prefix(self.db.clone(), path_iter.clone(), key)?;

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -118,7 +118,14 @@ impl GroveDb {
         let subtrees = self.get_subtrees();
         let path_iter = path.into_iter();
         // First, check if a subtree exists to create a new subtree under it
-        subtrees.borrow_mut(path_iter.clone(), transaction)?;
+        subtrees.borrow_mut(path_iter.clone(), transaction).map_err(|e| {
+            // When adding if the path does not exist, this means it is an invalid path
+            if let Error::PathNotFound(str) = e {
+                Error::InvalidPath(str)
+            } else {
+                e
+            }
+        })?;
 
         let (subtree_prefix, subtree_merk) =
             create_merk_with_prefix(self.db.clone(), path_iter.clone(), key)?;

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -73,7 +73,7 @@ impl Element {
             merk.get(key.as_ref())
                 .map_err(|e| Error::CorruptedData(e.to_string()))?
                 .ok_or_else(|| {
-                    Error::InvalidPathKey(format!("key not found in Merk: {}", hex::encode(key)))
+                    Error::PathKeyNotFound(format!("key not found in Merk: {}", hex::encode(key)))
                 })?
                 .as_slice(),
         )

--- a/grovedb/src/subtrees.rs
+++ b/grovedb/src/subtrees.rs
@@ -120,7 +120,7 @@ impl Subtrees<'_> {
                 let path_iter = path.into_iter();
                 let tree_prefix = GroveDb::compress_subtree_key(path_iter.clone(), None);
                 if self.deleted_subtrees.borrow().contains(&tree_prefix) {
-                    return Err(Error::InvalidPath("no subtree found under that path"));
+                    return Err(Error::PathNotFound("no subtree found under that path"));
                 }
                 if self.temp_subtrees.borrow().contains_key(&tree_prefix) {
                     // get the merk out
@@ -174,7 +174,7 @@ impl Subtrees<'_> {
                 return if self.root_leaf_keys.contains_key(key.as_ref()) {
                     Ok(subtree)
                 } else {
-                    Err(Error::InvalidPath("no subtree found for root path"))
+                    Err(Error::PathNotFound("no subtree found for root path"))
                 };
             }
 
@@ -182,13 +182,13 @@ impl Subtrees<'_> {
             let (parent_tree, has_keys) = self.get_subtree_with_key_info(parent_path, None)?;
             if !has_keys {
                 // parent tree can't be empty, hence invalid path
-                Err(Error::InvalidPath(
+                Err(Error::PathNotFound(
                     "no subtree found as parent in path is empty",
                 ))
             } else {
                 // Check that it contains the child as an empty tree
                 let elem = Element::get(&parent_tree, key).map_err(|_| {
-                    Error::InvalidPath("no subtree found as parent does not contain child")
+                    Error::PathNotFound("no subtree found as parent does not contain child")
                 })?;
                 match elem {
                     Element::Tree(_) => Ok(subtree),
@@ -215,7 +215,7 @@ impl Subtrees<'_> {
             self.storage.clone(),
             subtree_prefix,
         )?)
-        .map_err(|_| Error::InvalidPath("no subtree found under that path"))?;
+        .map_err(|_| Error::PathNotFound("no subtree found under that path"))?;
         let has_keys = !merk.is_empty_tree(None);
         Ok((merk, has_keys))
     }

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -761,7 +761,7 @@ fn transaction_insert_item_with_transaction_should_use_transaction() {
 
     // Check that there's no such key in the DB
     let result = db.get([TEST_LEAF], item_key, None);
-    assert!(matches!(result, Err(Error::InvalidPathKey(_))));
+    assert!(matches!(result, Err(Error::PathKeyNotFound(_))));
 
     let element1 = Element::Item(b"ayy".to_vec());
 
@@ -771,7 +771,7 @@ fn transaction_insert_item_with_transaction_should_use_transaction() {
     // The key was inserted inside the transaction, so it shouldn't be possible
     // to get it back without committing or using transaction
     let result = db.get([TEST_LEAF], item_key, None);
-    assert!(matches!(result, Err(Error::InvalidPathKey(_))));
+    assert!(matches!(result, Err(Error::PathKeyNotFound(_))));
     // Check that the element can be retrieved when transaction is passed
     let result_with_transaction = db
         .get([TEST_LEAF], item_key, Some(&transaction))
@@ -800,7 +800,7 @@ fn transaction_insert_tree_with_transaction_should_use_transaction() {
 
     // Check that there's no such key in the DB
     let result = db.get([TEST_LEAF], subtree_key, None);
-    assert!(matches!(result, Err(Error::InvalidPathKey(_))));
+    assert!(matches!(result, Err(Error::PathKeyNotFound(_))));
 
     db.insert(
         [TEST_LEAF],
@@ -811,7 +811,7 @@ fn transaction_insert_tree_with_transaction_should_use_transaction() {
     .expect("cannot insert an item into GroveDB");
 
     let result = db.get([TEST_LEAF], subtree_key, None);
-    assert!(matches!(result, Err(Error::InvalidPathKey(_))));
+    assert!(matches!(result, Err(Error::PathKeyNotFound(_))));
 
     let result_with_transaction = db
         .get([TEST_LEAF], subtree_key, Some(&db_transaction))
@@ -866,7 +866,7 @@ fn transaction_should_be_aborted_when_rollback_is_called() {
     db.rollback_transaction(&transaction).unwrap();
 
     let result = db.get([TEST_LEAF], item_key, Some(&transaction));
-    assert!(matches!(result, Err(Error::InvalidPathKey(_))));
+    assert!(matches!(result, Err(Error::PathKeyNotFound(_))));
 }
 
 #[test]
@@ -917,7 +917,7 @@ fn transaction_should_be_aborted() {
 
     // Transactional data shouldn't be committed to the main database
     let result = db.get([TEST_LEAF], item_key, None);
-    assert!(matches!(result, Err(Error::InvalidPathKey(_))));
+    assert!(matches!(result, Err(Error::PathKeyNotFound(_))));
 }
 
 #[test]
@@ -1010,7 +1010,7 @@ fn test_element_deletion() {
     assert!(db.delete([TEST_LEAF], b"key", None).is_ok());
     assert!(matches!(
         db.get([TEST_LEAF], b"key", None),
-        Err(Error::InvalidPathKey(_))
+        Err(Error::PathKeyNotFound(_))
     ));
     assert_ne!(root_hash, db.root_tree.root().unwrap());
 }
@@ -1144,7 +1144,7 @@ fn test_subtree_deletion() {
         .expect("unable to delete subtree");
     assert!(matches!(
         db.get([TEST_LEAF, b"key1", b"key2"], b"key3", None),
-        Err(Error::InvalidPath(_))
+        Err(Error::PathNotFound(_))
     ));
     // assert_eq!(db.subtrees.len(), 3); // TEST_LEAF, ANOTHER_TEST_LEAF
     // TEST_LEAF.key4 stay
@@ -1239,12 +1239,12 @@ fn test_subtree_deletion_if_empty() {
             b"level3-A",
             Some(&transaction)
         ),
-        Err(Error::InvalidPath(_))
+        Err(Error::PathNotFound(_))
     ));
 
     assert!(matches!(
         db.get([TEST_LEAF, b"level1-A"], b"level2-A", Some(&transaction)),
-        Err(Error::InvalidPathKey(_))
+        Err(Error::PathKeyNotFound(_))
     ));
 
     assert!(matches!(
@@ -1310,12 +1310,12 @@ fn test_subtree_deletion_if_empty_without_transaction() {
 
     assert!(matches!(
         db.get([TEST_LEAF, b"level1-A", b"level2-A"], b"level3-A", None,),
-        Err(Error::InvalidPath(_))
+        Err(Error::PathNotFound(_))
     ));
 
     assert!(matches!(
         db.get([TEST_LEAF, b"level1-A"], b"level2-A", None),
-        Err(Error::InvalidPathKey(_))
+        Err(Error::PathKeyNotFound(_))
     ));
 
     assert!(matches!(
@@ -2427,12 +2427,12 @@ fn test_subtree_deletion_with_transaction() {
         .expect("unable to delete subtree");
     assert!(matches!(
         db.get([TEST_LEAF, b"key1", b"key2"], b"key3", Some(&transaction)),
-        Err(Error::InvalidPath(_))
+        Err(Error::PathNotFound(_))
     ));
     transaction.commit().expect("cannot commit transaction");
     assert!(matches!(
         db.get([TEST_LEAF], b"key1", None),
-        Err(Error::InvalidPathKey(_))
+        Err(Error::PathKeyNotFound(_))
     ));
     assert!(matches!(db.get([TEST_LEAF], b"key4", None), Ok(_)));
 }


### PR DESCRIPTION
This PR decomposes path errors into 4 categories.
InvalidPath : the path is not valid/does not exist, and it represents a logical error by the client.
PathNotFound: the path does not exist, but it doesn't represent a logical error by the client. Meaning that the query was valid, but an intermediate path was just not present.
PathKeyNotFound: the path was found, but the key was not, the query was valid but there was nothing there.
CorruptedPath : GroveDB internal error, not a logical error by the client.