### PR TITLE
feat: addition of more range types

### DIFF
--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1010,10 +1010,10 @@ mod test {
         *,
     };
     use crate::{
+        proofs::query::QueryItem::RangeAfter,
         test_utils::make_tree_seq,
         tree::{NoopCommit, PanicSource, RefWalker, Tree},
     };
-    use crate::proofs::query::QueryItem::RangeAfter;
 
     fn make_3_node_tree() -> Tree {
         let mut tree = Tree::new(vec![5], vec![5])
@@ -1893,6 +1893,40 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![5]..vec![7])];
+        let (proof, absence) = walker
+            .create_full_proof(queryitems.as_slice())
+            .expect("create_proof errored");
+
+        let mut iter = proof.iter();
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::Hash([
+                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
+                145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KVHash([
+                236, 141, 96, 8, 244, 103, 232, 110, 117, 105, 162, 111, 148, 9, 59, 195, 2, 250,
+                165, 180, 215, 137, 202, 221, 38, 98, 93, 247, 54, 180, 242, 116
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
+    }
+
+    #[test]
+    fn range_after_to_proof_inclusive() {
+        let mut tree = make_6_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![5]..=vec![7])];
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1810,6 +1810,68 @@ mod test {
         );
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn range_to_proof() {
+        let mut tree = make_6_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let queryitems = vec![QueryItem::RangeTo(..vec![6])];
+        let (proof, absence) = walker
+            .create_full_proof(queryitems.as_slice())
+            .expect("create_proof errored");
+
+        let mut iter = proof.iter();
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KV(
+                vec![2],
+                vec![2],
+            )))
+        );
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KV(
+                vec![3],
+                vec![3],
+            )))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KV(
+                vec![4],
+                vec![4],
+            )))
+        );
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KV(
+                vec![5],
+                vec![5],
+            )))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KV(
+                vec![7],
+                vec![7],
+            )))
+        );
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KVHash([
+                236, 141, 96, 8, 244, 103, 232, 110, 117, 105, 162, 111, 148, 9, 59, 195, 2, 250,
+                165, 180, 215, 137, 202, 221, 38, 98, 93, 247, 54, 180, 242, 116
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1888,6 +1888,40 @@ mod test {
     }
 
     #[test]
+    fn range_after_to_proof() {
+        let mut tree = make_6_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let queryitems = vec![QueryItem::RangeAfterTo(vec![5]..vec![7])];
+        let (proof, absence) = walker
+            .create_full_proof(queryitems.as_slice())
+            .expect("create_proof errored");
+
+        let mut iter = proof.iter();
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::Hash([
+                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
+                145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KVHash([
+                236, 141, 96, 8, 244, 103, 232, 110, 117, 105, 162, 111, 148, 9, 59, 195, 2, 250,
+                165, 180, 215, 137, 202, 221, 38, 98, 93, 247, 54, 180, 242, 116
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
+    }
+
+    #[test]
     fn range_proof_missing_upper_bound() {
         let mut tree = make_tree_seq(10);
         let mut walker = RefWalker::new(&mut tree, PanicSource {});

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -940,7 +940,10 @@ pub fn verify_query(
                 if *query_item > key.as_slice() {
                     // continue to next push
                     break;
-                } else if start_non_inclusive && lower_bound.is_some() && lower_bound.unwrap() == key.as_slice() {
+                } else if start_non_inclusive
+                    && lower_bound.is_some()
+                    && lower_bound.unwrap() == key.as_slice()
+                {
                     // we intersect with the query_item but at the start which is non inclusive
                     // continue to the next push
                     break;
@@ -1834,7 +1837,7 @@ mod test {
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(
             res,
-            vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8]),]
+            vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8])]
         );
     }
 
@@ -1945,24 +1948,27 @@ mod test {
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");
-        dbg!(&proof);
 
-        // let mut iter = proof.iter();
-        // assert_eq!(
-        //     iter.next(),
-        //     Some(&Op::Push(Node::Hash([
-        //         85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
-        //         145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
-        //     ])))
-        // );
-        // assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
-        // assert_eq!(iter.next(), Some(&Op::Parent));
-        // assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
-        // assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![8], vec![8]))));
-        // assert_eq!(iter.next(), Some(&Op::Parent));
-        // assert_eq!(iter.next(), Some(&Op::Child));
-        // assert!(iter.next().is_none());
-        // assert_eq!(absence, (false, true));
+        let mut iter = proof.iter();
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::Hash([
+                121, 235, 207, 195, 143, 58, 159, 120, 166, 33, 151, 45, 178, 124, 91, 233, 201, 4,
+                241, 127, 41, 198, 197, 228, 19, 190, 36, 173, 183, 73, 104, 30
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![3], vec![3]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![4], vec![4]))));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![8], vec![8]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
+        assert_eq!(absence, (false, true));
 
         let mut bytes = vec![];
         encode_into(proof.iter(), &mut bytes);
@@ -1970,8 +1976,8 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query,
-        tree.hash()).unwrap(); assert_eq!(
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(
             res,
             vec![
                 (vec![4], vec![4]),

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1028,12 +1028,15 @@ mod test {
         let mut three_tree = Tree::new(vec![3], vec![3])
             .attach(true, Some(two_tree))
             .attach(false, Some(four_tree));
-        three_tree.commit(&mut NoopCommit {}).expect("commit failed");
+        three_tree
+            .commit(&mut NoopCommit {})
+            .expect("commit failed");
 
         let seven_tree = Tree::new(vec![7], vec![7]);
-        let mut eight_tree = Tree::new(vec![8], vec![8])
-            .attach(true, Some(seven_tree));
-        eight_tree.commit(&mut NoopCommit {}).expect("commit failed");
+        let mut eight_tree = Tree::new(vec![8], vec![8]).attach(true, Some(seven_tree));
+        eight_tree
+            .commit(&mut NoopCommit {})
+            .expect("commit failed");
 
         let mut root_tree = Tree::new(vec![5], vec![5])
             .attach(true, Some(three_tree))
@@ -1768,9 +1771,7 @@ mod test {
         let mut tree = make_6_node_tree();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
-        let queryitems = vec![QueryItem::RangeFrom(
-            vec![5]..
-        )];
+        let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");
@@ -1779,35 +1780,18 @@ mod test {
         assert_eq!(
             iter.next(),
             Some(&Op::Push(Node::Hash([
-                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199, 145,
-                156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
+                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
+                145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
             ])))
         );
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![5],
-                vec![5],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![7],
-                vec![7],
-            )))
-        );
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![8],
-                vec![8],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![8], vec![8]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (false, true));
     }
 
     #[test]
@@ -1821,44 +1805,14 @@ mod test {
             .expect("create_proof errored");
 
         let mut iter = proof.iter();
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![2],
-                vec![2],
-            )))
-        );
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![3],
-                vec![3],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![2], vec![2]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![3], vec![3]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![4],
-                vec![4],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![4], vec![4]))));
         assert_eq!(iter.next(), Some(&Op::Child));
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![5],
-                vec![5],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![7],
-                vec![7],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
         assert_eq!(
             iter.next(),
             Some(&Op::Push(Node::KVHash([
@@ -1869,6 +1823,7 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (true, false));
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -934,9 +934,15 @@ pub fn verify_query(
             while let Some(item) = query.peek() {
                 // get next item in query
                 let query_item = *item;
+                let (lower_bound, start_non_inclusive) = query_item.lower_bound();
+
                 // we have not reached next queried part of tree
                 if *query_item > key.as_slice() {
                     // continue to next push
+                    break;
+                } else if start_non_inclusive && lower_bound.is_some() && lower_bound.unwrap() == key.as_slice() {
+                    // we intersect with the query_item but at the start which is non inclusive
+                    // continue to the next push
                     break;
                 }
 
@@ -1935,43 +1941,45 @@ mod test {
         let mut tree = make_6_node_tree();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
-        let queryitems = vec![RangeAfter(vec![5]..)];
+        let queryitems = vec![RangeAfter(vec![3]..)];
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");
+        dbg!(&proof);
 
-        let mut iter = proof.iter();
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::Hash([
-                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
-                145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
-            ])))
-        );
-        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
-        assert_eq!(iter.next(), Some(&Op::Parent));
-        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
-        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![8], vec![8]))));
-        assert_eq!(iter.next(), Some(&Op::Parent));
-        assert_eq!(iter.next(), Some(&Op::Child));
-        assert!(iter.next().is_none());
-        assert_eq!(absence, (false, true));
-
-        // let mut bytes = vec![];
-        // encode_into(proof.iter(), &mut bytes);
-        // let mut query = Query::new();
-        // for item in queryitems {
-        //     query.insert_item(item);
-        // }
-        // let res = verify_query(bytes.as_slice(), &query,
-        // tree.hash()).unwrap(); assert_eq!(
-        //     res,
-        //     vec![
-        //         (vec![5], vec![5]),
-        //         (vec![7], vec![7]),
-        //         (vec![8], vec![8]),
-        //     ]
+        // let mut iter = proof.iter();
+        // assert_eq!(
+        //     iter.next(),
+        //     Some(&Op::Push(Node::Hash([
+        //         85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
+        //         145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
+        //     ])))
         // );
+        // assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
+        // assert_eq!(iter.next(), Some(&Op::Parent));
+        // assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        // assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![8], vec![8]))));
+        // assert_eq!(iter.next(), Some(&Op::Parent));
+        // assert_eq!(iter.next(), Some(&Op::Child));
+        // assert!(iter.next().is_none());
+        // assert_eq!(absence, (false, true));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query,
+        tree.hash()).unwrap(); assert_eq!(
+            res,
+            vec![
+                (vec![4], vec![4]),
+                (vec![5], vec![5]),
+                (vec![7], vec![7]),
+                (vec![8], vec![8]),
+            ]
+        );
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -2032,13 +2032,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
-        assert_eq!(
-            res,
-            vec![
-                (vec![4], vec![4]),
-                (vec![5], vec![5]),
-            ]
-        );
+        assert_eq!(res, vec![(vec![4], vec![4]), (vec![5], vec![5]),]);
     }
 
     #[test]
@@ -2046,19 +2040,23 @@ mod test {
         let mut tree = make_6_node_tree();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
-        let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![5]..=vec![7])];
+        let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![7])];
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");
 
         let mut iter = proof.iter();
-        assert_eq!(
+        (
             iter.next(),
             Some(&Op::Push(Node::Hash([
-                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
-                145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
-            ])))
+                121, 235, 207, 195, 143, 58, 159, 120, 166, 33, 151, 45, 178, 124, 91, 233, 201, 4,
+                241, 127, 41, 198, 197, 228, 19, 190, 36, 173, 183, 73, 104, 30,
+            ]))),
         );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![3], vec![3]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![4], vec![4]))));
+        assert_eq!(iter.next(), Some(&Op::Child));
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
@@ -2073,6 +2071,18 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (false, false));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(
+            res,
+            vec![(vec![4], vec![4]), (vec![5], vec![5]), (vec![7], vec![7])]
+        );
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1956,6 +1956,33 @@ mod test {
     }
 
     #[test]
+    fn range_full_proof() {
+        let mut tree = make_6_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let queryitems = vec![QueryItem::RangeFull(..)];
+        let (proof, absence) = walker
+            .create_full_proof(queryitems.as_slice())
+            .expect("create_proof errored");
+
+        let mut iter = proof.iter();
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![2], vec![2]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![3], vec![3]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![4], vec![4]))));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![8], vec![8]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+
+        assert!(iter.next().is_none());
+        assert_eq!(absence, (true, true));
+    }
+
+    #[test]
     fn range_proof_missing_upper_bound() {
         let mut tree = make_tree_seq(10);
         let mut walker = RefWalker::new(&mut tree, PanicSource {});

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -2110,6 +2110,25 @@ mod test {
 
         assert!(iter.next().is_none());
         assert_eq!(absence, (true, true));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(
+            res,
+            vec![
+                (vec![2], vec![2]),
+                (vec![3], vec![3]),
+                (vec![4], vec![4]),
+                (vec![5], vec![5]),
+                (vec![7], vec![7]),
+                (vec![8], vec![8]),
+            ]
+        );
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -943,7 +943,7 @@ pub fn verify_query(
                     }
                 }
 
-                if key.as_slice() >= query_item.upper_bound().0 {
+                if query_item.upper_bound().0 != b"" && key.as_slice() >= query_item.upper_bound().0 {
                     // at or past upper bound of range (or this was an exact
                     // match on a single-key queryitem), advance to next query
                     // item
@@ -1793,6 +1793,22 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (false, true));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(
+            res,
+            vec![
+                (vec![5], vec![5]),
+                (vec![7], vec![7]),
+                (vec![8], vec![8]),
+            ]
+        );
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -943,7 +943,8 @@ pub fn verify_query(
                     }
                 }
 
-                if query_item.upper_bound().0 != b"" && key.as_slice() >= query_item.upper_bound().0 {
+                if query_item.upper_bound().0 != b"" && key.as_slice() >= query_item.upper_bound().0
+                {
                     // at or past upper bound of range (or this was an exact
                     // match on a single-key queryitem), advance to next query
                     // item
@@ -1803,11 +1804,7 @@ mod test {
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(
             res,
-            vec![
-                (vec![5], vec![5]),
-                (vec![7], vec![7]),
-                (vec![8], vec![8]),
-            ]
+            vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8]),]
         );
     }
 
@@ -1841,6 +1838,23 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (true, false));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(
+            res,
+            vec![
+                (vec![2], vec![2]),
+                (vec![3], vec![3]),
+                (vec![4], vec![4]),
+                (vec![5], vec![5]),
+            ]
+        );
     }
 
     #[test]
@@ -1873,6 +1887,23 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (true, false));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(
+            res,
+            vec![
+                (vec![2], vec![2]),
+                (vec![3], vec![3]),
+                (vec![4], vec![4]),
+                (vec![5], vec![5]),
+            ]
+        );
     }
 
     #[test]
@@ -1901,6 +1932,22 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (false, true));
+
+        // let mut bytes = vec![];
+        // encode_into(proof.iter(), &mut bytes);
+        // let mut query = Query::new();
+        // for item in queryitems {
+        //     query.insert_item(item);
+        // }
+        // let res = verify_query(bytes.as_slice(), &query,
+        // tree.hash()).unwrap(); assert_eq!(
+        //     res,
+        //     vec![
+        //         (vec![5], vec![5]),
+        //         (vec![7], vec![7]),
+        //         (vec![8], vec![8]),
+        //     ]
+        // );
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -738,12 +738,9 @@ where
                 let left_bound = item.lower_bound().0;
                 let right_bound = item.upper_bound().0;
 
-                dbg!(left_bound == b"");
-                dbg!(right_bound == b"");
-
                 // if range starts before this node's key, include it in left
                 // child's query
-                let left_query = if left_bound < self.tree().key() {
+                let left_query = if left_bound < self.tree().key() || left_bound == b"" {
                     &query[..=index]
                 } else {
                     &query[..index]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -738,6 +738,9 @@ where
                 let left_bound = item.lower_bound().0;
                 let right_bound = item.upper_bound().0;
 
+                dbg!(left_bound == b"");
+                dbg!(right_bound == b"");
+
                 // if range starts before this node's key, include it in left
                 // child's query
                 let left_query = if left_bound < self.tree().key() {
@@ -748,7 +751,7 @@ where
 
                 // if range ends after this node's key, include it in right
                 // child's query
-                let right_query = if right_bound > self.tree().key() {
+                let right_query = if right_bound > self.tree().key() || right_bound == b"" {
                     &query[index..]
                 } else {
                     &query[index + 1..]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1827,6 +1827,38 @@ mod test {
     }
 
     #[test]
+    fn range_to_proof_inclusive() {
+        let mut tree = make_6_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
+        let (proof, absence) = walker
+            .create_full_proof(queryitems.as_slice())
+            .expect("create_proof errored");
+
+        let mut iter = proof.iter();
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![2], vec![2]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![3], vec![3]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![4], vec![4]))));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KVHash([
+                236, 141, 96, 8, 244, 103, 232, 110, 117, 105, 162, 111, 148, 9, 59, 195, 2, 250,
+                165, 180, 215, 137, 202, 221, 38, 98, 93, 247, 54, 180, 242, 116
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
+        assert_eq!(absence, (true, false));
+    }
+
+    #[test]
     fn range_proof_missing_upper_bound() {
         let mut tree = make_tree_seq(10);
         let mut walker = RefWalker::new(&mut tree, PanicSource {});


### PR DESCRIPTION
Merk currently supports proofs for:
- key
- range
- range_inclusive

This pr adds:
- range_to
- range_to_inclusive
- range_from
- range_after
- range_after_to
- range_after_to_inclusive
- range_full