### PR TITLE
feat: ability to convert non-inclusive-range-type to their inclusive version

### DIFF
--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1010,10 +1010,10 @@ mod test {
         *,
     };
     use crate::{
+        proofs::query::QueryItem::RangeAfter,
         test_utils::make_tree_seq,
         tree::{NoopCommit, PanicSource, RefWalker, Tree},
     };
-    use crate::proofs::query::QueryItem::RangeAfter;
 
     fn make_3_node_tree() -> Tree {
         let mut tree = Tree::new(vec![5], vec![5])
@@ -1893,6 +1893,40 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![5]..vec![7])];
+        let (proof, absence) = walker
+            .create_full_proof(queryitems.as_slice())
+            .expect("create_proof errored");
+
+        let mut iter = proof.iter();
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::Hash([
+                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
+                145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KVHash([
+                236, 141, 96, 8, 244, 103, 232, 110, 117, 105, 162, 111, 148, 9, 59, 195, 2, 250,
+                165, 180, 215, 137, 202, 221, 38, 98, 93, 247, 54, 180, 242, 116
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
+    }
+
+    #[test]
+    fn range_after_to_proof_inclusive() {
+        let mut tree = make_6_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![5]..=vec![7])];
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1810,6 +1810,68 @@ mod test {
         );
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn range_to_proof() {
+        let mut tree = make_6_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let queryitems = vec![QueryItem::RangeTo(..vec![6])];
+        let (proof, absence) = walker
+            .create_full_proof(queryitems.as_slice())
+            .expect("create_proof errored");
+
+        let mut iter = proof.iter();
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KV(
+                vec![2],
+                vec![2],
+            )))
+        );
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KV(
+                vec![3],
+                vec![3],
+            )))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KV(
+                vec![4],
+                vec![4],
+            )))
+        );
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KV(
+                vec![5],
+                vec![5],
+            )))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KV(
+                vec![7],
+                vec![7],
+            )))
+        );
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KVHash([
+                236, 141, 96, 8, 244, 103, 232, 110, 117, 105, 162, 111, 148, 9, 59, 195, 2, 250,
+                165, 180, 215, 137, 202, 221, 38, 98, 93, 247, 54, 180, 242, 116
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1719,10 +1719,10 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert_eq!(
             iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![0, 0, 0, 0, 0, 0, 0, 7],
-                vec![123; 60]
-            )))
+            Some(&Op::Push(Node::KVHash([
+                38, 213, 80, 36, 8, 4, 244, 209, 26, 114, 140, 196, 141, 53, 145, 149, 195, 48,
+                104, 86, 66, 93, 141, 180, 22, 229, 231, 250, 58, 27, 167, 97
+            ])))
         );
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1616,6 +1616,11 @@ mod test {
             QueryItem::Range(vec![20]..vec![30])
         );
         assert!(QueryItem::Range(vec![20]..vec![30]) > QueryItem::Range(vec![10]..vec![20]));
+        assert_eq!(
+            QueryItem::RangeToInclusive(..=vec![15]),
+            QueryItem::Key(vec![5]),
+        );
+        assert!(QueryItem::RangeAfter(vec![5]..) > QueryItem::RangeInclusive(vec![1]..=vec![5]));
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1986,16 +1986,25 @@ mod test {
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");
-        dbg!(&proof);
 
         let mut iter = proof.iter();
         assert_eq!(
             iter.next(),
             Some(&Op::Push(Node::Hash([
-                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
-                145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
+                121, 235, 207, 195, 143, 58, 159, 120, 166, 33, 151, 45, 178, 124, 91, 233, 201, 4,
+                241, 127, 41, 198, 197, 228, 19, 190, 36, 173, 183, 73, 104, 30
             ])))
         );
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KVHash([
+                126, 128, 159, 241, 207, 26, 88, 61, 163, 18, 218, 189, 45, 220, 124, 96, 118, 68,
+                61, 95, 230, 75, 145, 218, 178, 227, 63, 137, 79, 153, 182, 12
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![4], vec![4]))));
+        assert_eq!(iter.next(), Some(&Op::Child));
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
@@ -2014,7 +2023,7 @@ mod test {
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(
             res,
-            vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8]),]
+            vec![(vec![4], vec![4]), (vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8])]
         );
     }
 

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1888,6 +1888,40 @@ mod test {
     }
 
     #[test]
+    fn range_after_to_proof() {
+        let mut tree = make_6_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let queryitems = vec![QueryItem::RangeAfterTo(vec![5]..vec![7])];
+        let (proof, absence) = walker
+            .create_full_proof(queryitems.as_slice())
+            .expect("create_proof errored");
+
+        let mut iter = proof.iter();
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::Hash([
+                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
+                145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KVHash([
+                236, 141, 96, 8, 244, 103, 232, 110, 117, 105, 162, 111, 148, 9, 59, 195, 2, 250,
+                165, 180, 215, 137, 202, 221, 38, 98, 93, 247, 54, 180, 242, 116
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
+        assert_eq!(absence, (false, false));
+    }
+
+    #[test]
     fn range_proof_missing_upper_bound() {
         let mut tree = make_tree_seq(10);
         let mut walker = RefWalker::new(&mut tree, PanicSource {});

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -2315,10 +2315,10 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert_eq!(
             iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![0, 0, 0, 0, 0, 0, 0, 7],
-                vec![123; 60]
-            )))
+            Some(&Op::Push(Node::KVHash([
+                38, 213, 80, 36, 8, 4, 244, 209, 26, 114, 140, 196, 141, 53, 145, 149, 195, 48,
+                104, 86, 66, 93, 141, 180, 22, 229, 231, 250, 58, 27, 167, 97
+            ])))
         );
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -2023,7 +2023,12 @@ mod test {
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(
             res,
-            vec![(vec![4], vec![4]), (vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8])]
+            vec![
+                (vec![4], vec![4]),
+                (vec![5], vec![5]),
+                (vec![7], vec![7]),
+                (vec![8], vec![8])
+            ]
         );
     }
 
@@ -2032,7 +2037,7 @@ mod test {
         let mut tree = make_6_node_tree();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
-        let queryitems = vec![QueryItem::RangeAfterTo(vec![5]..vec![7])];
+        let queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");
@@ -2041,10 +2046,20 @@ mod test {
         assert_eq!(
             iter.next(),
             Some(&Op::Push(Node::Hash([
-                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
-                145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
+                121, 235, 207, 195, 143, 58, 159, 120, 166, 33, 151, 45, 178, 124, 91, 233, 201, 4,
+                241, 127, 41, 198, 197, 228, 19, 190, 36, 173, 183, 73, 104, 30
             ])))
         );
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KVHash([
+                126, 128, 159, 241, 207, 26, 88, 61, 163, 18, 218, 189, 45, 220, 124, 96, 118, 68,
+                61, 95, 230, 75, 145, 218, 178, 227, 63, 137, 79, 153, 182, 12
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![4], vec![4]))));
+        assert_eq!(iter.next(), Some(&Op::Child));
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
@@ -2059,6 +2074,15 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (false, false));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(res, vec![(vec![4], vec![4]), (vec![5], vec![5]),]);
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1028,12 +1028,15 @@ mod test {
         let mut three_tree = Tree::new(vec![3], vec![3])
             .attach(true, Some(two_tree))
             .attach(false, Some(four_tree));
-        three_tree.commit(&mut NoopCommit {}).expect("commit failed");
+        three_tree
+            .commit(&mut NoopCommit {})
+            .expect("commit failed");
 
         let seven_tree = Tree::new(vec![7], vec![7]);
-        let mut eight_tree = Tree::new(vec![8], vec![8])
-            .attach(true, Some(seven_tree));
-        eight_tree.commit(&mut NoopCommit {}).expect("commit failed");
+        let mut eight_tree = Tree::new(vec![8], vec![8]).attach(true, Some(seven_tree));
+        eight_tree
+            .commit(&mut NoopCommit {})
+            .expect("commit failed");
 
         let mut root_tree = Tree::new(vec![5], vec![5])
             .attach(true, Some(three_tree))
@@ -1768,9 +1771,7 @@ mod test {
         let mut tree = make_6_node_tree();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
-        let queryitems = vec![QueryItem::RangeFrom(
-            vec![5]..
-        )];
+        let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");
@@ -1779,35 +1780,18 @@ mod test {
         assert_eq!(
             iter.next(),
             Some(&Op::Push(Node::Hash([
-                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199, 145,
-                156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
+                85, 217, 56, 226, 204, 53, 103, 145, 201, 33, 178, 80, 207, 194, 104, 128, 199,
+                145, 156, 208, 152, 255, 209, 24, 140, 222, 204, 193, 211, 26, 118, 58
             ])))
         );
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![5],
-                vec![5],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![7],
-                vec![7],
-            )))
-        );
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![8],
-                vec![8],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![8], vec![8]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (false, true));
     }
 
     #[test]
@@ -1821,44 +1805,14 @@ mod test {
             .expect("create_proof errored");
 
         let mut iter = proof.iter();
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![2],
-                vec![2],
-            )))
-        );
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![3],
-                vec![3],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![2], vec![2]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![3], vec![3]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![4],
-                vec![4],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![4], vec![4]))));
         assert_eq!(iter.next(), Some(&Op::Child));
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![5],
-                vec![5],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
-        assert_eq!(
-            iter.next(),
-            Some(&Op::Push(Node::KV(
-                vec![7],
-                vec![7],
-            )))
-        );
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
         assert_eq!(
             iter.next(),
             Some(&Op::Push(Node::KVHash([
@@ -1869,6 +1823,7 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
+        assert_eq!(absence, (true, false));
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1956,6 +1956,33 @@ mod test {
     }
 
     #[test]
+    fn range_full_proof() {
+        let mut tree = make_6_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let queryitems = vec![QueryItem::RangeFull(..)];
+        let (proof, absence) = walker
+            .create_full_proof(queryitems.as_slice())
+            .expect("create_proof errored");
+
+        let mut iter = proof.iter();
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![2], vec![2]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![3], vec![3]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![4], vec![4]))));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![8], vec![8]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+
+        assert!(iter.next().is_none());
+        assert_eq!(absence, (true, true));
+    }
+
+    #[test]
     fn range_proof_missing_upper_bound() {
         let mut tree = make_tree_seq(10);
         let mut walker = RefWalker::new(&mut tree, PanicSource {});

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1952,7 +1952,7 @@ mod test {
         let mut tree = make_6_node_tree();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
-        let queryitems = vec![RangeAfter(vec![5]..)];
+        let queryitems = vec![QueryItem::RangeAfter(vec![4]..)];
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");
@@ -1984,6 +1984,7 @@ mod test {
         tree.hash()).unwrap(); assert_eq!(
             res,
             vec![
+                (vec![5], vec![5]),
                 (vec![7], vec![7]),
                 (vec![8], vec![8]),
             ]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -2153,6 +2153,25 @@ mod test {
 
         assert!(iter.next().is_none());
         assert_eq!(absence, (true, true));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(
+            res,
+            vec![
+                (vec![2], vec![2]),
+                (vec![3], vec![3]),
+                (vec![4], vec![4]),
+                (vec![5], vec![5]),
+                (vec![7], vec![7]),
+                (vec![8], vec![8])
+            ]
+        );
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1860,6 +1860,7 @@ mod test {
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");
+        dbg!(&proof);
 
         let mut iter = proof.iter();
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![2], vec![2]))));
@@ -1869,15 +1870,13 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
         assert_eq!(iter.next(), Some(&Op::Parent));
-        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
         assert_eq!(
             iter.next(),
-            Some(&Op::Push(Node::KVHash([
-                236, 141, 96, 8, 244, 103, 232, 110, 117, 105, 162, 111, 148, 9, 59, 195, 2, 250,
-                165, 180, 215, 137, 202, 221, 38, 98, 93, 247, 54, 180, 242, 116
+            Some(&Op::Push(Node::Hash([
+                133, 188, 175, 131, 60, 89, 221, 135, 133, 53, 205, 110, 58, 56, 128, 58, 1, 227,
+                75, 122, 83, 20, 125, 44, 149, 44, 62, 130, 252, 134, 105, 200
             ])))
         );
-        assert_eq!(iter.next(), Some(&Op::Parent));
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (true, false));

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -943,7 +943,7 @@ pub fn verify_query(
                     }
                 }
 
-                if key.as_slice() >= query_item.upper_bound().0 {
+                if query_item.upper_bound().0 != b"" && key.as_slice() >= query_item.upper_bound().0 {
                     // at or past upper bound of range (or this was an exact
                     // match on a single-key queryitem), advance to next query
                     // item
@@ -1793,6 +1793,22 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (false, true));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(
+            res,
+            vec![
+                (vec![5], vec![5]),
+                (vec![7], vec![7]),
+                (vec![8], vec![8]),
+            ]
+        );
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -777,7 +777,7 @@ where
 
         let (left_items, right_items) = match search {
             Ok(index) => {
-                let item = &query[index];
+                let item = &query[index].to_inclusive();
                 let left_bound = item.lower_bound().0;
                 let right_bound = item.upper_bound().0;
 

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -956,9 +956,9 @@ pub fn verify_query(
         if let Node::KV(key, value) = node {
             while let Some(item) = query.peek() {
                 // get next item in query
-                let query_item = *item;
+                let query_item = (*item).to_inclusive();
                 // we have not reached next queried part of tree
-                if *query_item > key.as_slice() {
+                if query_item > key.as_slice() {
                     // continue to next push
                     break;
                 }
@@ -1860,7 +1860,6 @@ mod test {
         let (proof, absence) = walker
             .create_full_proof(queryitems.as_slice())
             .expect("create_proof errored");
-        dbg!(&proof);
 
         let mut iter = proof.iter();
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![2], vec![2]))));
@@ -1975,21 +1974,20 @@ mod test {
         assert!(iter.next().is_none());
         assert_eq!(absence, (false, true));
 
-        // let mut bytes = vec![];
-        // encode_into(proof.iter(), &mut bytes);
-        // let mut query = Query::new();
-        // for item in queryitems {
-        //     query.insert_item(item);
-        // }
-        // let res = verify_query(bytes.as_slice(), &query,
-        // tree.hash()).unwrap(); assert_eq!(
-        //     res,
-        //     vec![
-        //         (vec![5], vec![5]),
-        //         (vec![7], vec![7]),
-        //         (vec![8], vec![8]),
-        //     ]
-        // );
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query,
+        tree.hash()).unwrap(); assert_eq!(
+            res,
+            vec![
+                (vec![7], vec![7]),
+                (vec![8], vec![8]),
+            ]
+        );
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -2082,7 +2082,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4]), (vec![5], vec![5]),]);
+        assert_eq!(res, vec![(vec![4], vec![4]), (vec![5], vec![5])]);
     }
 
     #[test]
@@ -2117,6 +2117,15 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (false, false));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(res, vec![(vec![7], vec![7])]);
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -943,7 +943,8 @@ pub fn verify_query(
                     }
                 }
 
-                if query_item.upper_bound().0 != b"" && key.as_slice() >= query_item.upper_bound().0 {
+                if query_item.upper_bound().0 != b"" && key.as_slice() >= query_item.upper_bound().0
+                {
                     // at or past upper bound of range (or this was an exact
                     // match on a single-key queryitem), advance to next query
                     // item
@@ -1803,11 +1804,7 @@ mod test {
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(
             res,
-            vec![
-                (vec![5], vec![5]),
-                (vec![7], vec![7]),
-                (vec![8], vec![8]),
-            ]
+            vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8]),]
         );
     }
 
@@ -1841,6 +1838,23 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (true, false));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(
+            res,
+            vec![
+                (vec![2], vec![2]),
+                (vec![3], vec![3]),
+                (vec![4], vec![4]),
+                (vec![5], vec![5]),
+            ]
+        );
     }
 
     #[test]
@@ -1873,6 +1887,23 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (true, false));
+
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new();
+        for item in queryitems {
+            query.insert_item(item);
+        }
+        let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
+        assert_eq!(
+            res,
+            vec![
+                (vec![2], vec![2]),
+                (vec![3], vec![3]),
+                (vec![4], vec![4]),
+                (vec![5], vec![5]),
+            ]
+        );
     }
 
     #[test]
@@ -1901,6 +1932,22 @@ mod test {
         assert_eq!(iter.next(), Some(&Op::Child));
         assert!(iter.next().is_none());
         assert_eq!(absence, (false, true));
+
+        // let mut bytes = vec![];
+        // encode_into(proof.iter(), &mut bytes);
+        // let mut query = Query::new();
+        // for item in queryitems {
+        //     query.insert_item(item);
+        // }
+        // let res = verify_query(bytes.as_slice(), &query,
+        // tree.hash()).unwrap(); assert_eq!(
+        //     res,
+        //     vec![
+        //         (vec![5], vec![5]),
+        //         (vec![7], vec![7]),
+        //         (vec![8], vec![8]),
+        //     ]
+        // );
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -302,16 +302,14 @@ impl QueryItem {
     }
 
     pub fn to_inclusive(&self) -> Self {
-        fn increment_byte_array(input: Vec<u8>) -> Vec<u8> {
-            let mut input = input.clone();
+        fn increment_byte_array(mut input: Vec<u8>) -> Vec<u8> {
             if let Some(item) = input.iter_mut().rfind(|x| **x < u8::MAX) {
                 *item += 1;
             }
             input
         }
 
-        fn decrement_byte_array(input: Vec<u8>) -> Vec<u8> {
-            let mut input = input.clone();
+        fn decrement_byte_array(mut input: Vec<u8>) -> Vec<u8> {
             if let Some(item) = input.iter_mut().rfind(|x| **x > u8::MIN) {
                 *item -= 1;
             }
@@ -1079,7 +1077,6 @@ mod test {
         *,
     };
     use crate::{
-        proofs::query::QueryItem::RangeAfter,
         test_utils::make_tree_seq,
         tree::{NoopCommit, PanicSource, RefWalker, Tree},
     };

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -738,12 +738,9 @@ where
                 let left_bound = item.lower_bound().0;
                 let right_bound = item.upper_bound().0;
 
-                dbg!(left_bound == b"");
-                dbg!(right_bound == b"");
-
                 // if range starts before this node's key, include it in left
                 // child's query
-                let left_query = if left_bound < self.tree().key() {
+                let left_query = if left_bound < self.tree().key() || left_bound == b"" {
                     &query[..=index]
                 } else {
                     &query[..index]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -738,6 +738,9 @@ where
                 let left_bound = item.lower_bound().0;
                 let right_bound = item.upper_bound().0;
 
+                dbg!(left_bound == b"");
+                dbg!(right_bound == b"");
+
                 // if range starts before this node's key, include it in left
                 // child's query
                 let left_query = if left_bound < self.tree().key() {
@@ -748,7 +751,7 @@ where
 
                 // if range ends after this node's key, include it in right
                 // child's query
-                let right_query = if right_bound > self.tree().key() {
+                let right_query = if right_bound > self.tree().key() || right_bound == b"" {
                     &query[index..]
                 } else {
                     &query[index + 1..]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1827,6 +1827,38 @@ mod test {
     }
 
     #[test]
+    fn range_to_proof_inclusive() {
+        let mut tree = make_6_node_tree();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+        let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
+        let (proof, absence) = walker
+            .create_full_proof(queryitems.as_slice())
+            .expect("create_proof errored");
+
+        let mut iter = proof.iter();
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![2], vec![2]))));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![3], vec![3]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![4], vec![4]))));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![5], vec![5]))));
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![7], vec![7]))));
+        assert_eq!(
+            iter.next(),
+            Some(&Op::Push(Node::KVHash([
+                236, 141, 96, 8, 244, 103, 232, 110, 117, 105, 162, 111, 148, 9, 59, 195, 2, 250,
+                165, 180, 215, 137, 202, 221, 38, 98, 93, 247, 54, 180, 242, 116
+            ])))
+        );
+        assert_eq!(iter.next(), Some(&Op::Parent));
+        assert_eq!(iter.next(), Some(&Op::Child));
+        assert!(iter.next().is_none());
+        assert_eq!(absence, (true, false));
+    }
+
+    #[test]
     fn range_proof_missing_upper_bound() {
         let mut tree = make_tree_seq(10);
         let mut walker = RefWalker::new(&mut tree, PanicSource {});


### PR DESCRIPTION
**Problem with non inclusive range types**

A query is a collection of sorted unique keys

given a node, all elements that stem from it’s right edge are greater than it, all elements that stem from the left edge are smaller than it.

when a query is applied to a node, you want to split the query into two, (elements less than the current node) and (elements greater than the current node) and then pass those keys to the corresponding subtrees.

range queries makes things more interesting as they are a collection of keys treated as a single entity. 

Take a node key 5 and a range 3..=8

the range contains 5, but also has elements greater than and less than 5, the range is passed both to the left subtree and the right subtree as it contains elements of interest for both trees.

left - (3..=8) right - (3..=8)

take another range 3..=5 (it has elements smaller than 5, but no element larger than 5 hence no reason to pass the range to the right subtree)

The previous algorithm used to split the query is given below:


                let item = &query[index];
                
                // get the bounds of the query item
                let left_bound = item.lower_bound();
                let right_bound = item.upper_bound().0;
      
                // check if the range still has elements of interest for the left subtree
                let left_query = if left_bound < self.tree().key() {
                    // if it does include it
                    &query[..=index]
                } else {
                    // doesn't, exclude it
                    &query[..index]
                };

                 // check if the range still has elements of interest for the right subtree
                let right_query = if right_bound > self.tree().key() {
                    &query[index..]
                } else {
                    &query[index + 1..]
                };

                (left_query, right_query)

When the query item is a non inclusive range type e.g. 3..5, the algorithm thinks the bounds are [3-5] instead of [3-4], leading to the same proof for 3..=5. (which isn't correct behaviour)

This PR implements a solution that extracts the exact bound (converting it to an inclusive range), before making bounds critical decision.

To achieve this, I made the assumption that byte arrays increase and decrease by 1 bit. 