### PR TITLE
refactor: move get_context methods to trait

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -206,24 +206,24 @@ impl GroveDb {
             if let Some(tx) = transaction {
                 let subtree_storage = self
                     .db
-                    .get_prefixed_transactional_context_from_path(path_iter.clone(), tx);
+                    .get_transactional_storage_context(path_iter.clone(), tx);
                 let subtree = Merk::open(subtree_storage)
                     .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))?;
                 let element = Element::Tree(subtree.root_hash());
                 let key = path_iter.next_back().expect("next element is `Some`");
                 let parent_storage = self
                     .db
-                    .get_prefixed_transactional_context_from_path(path_iter.clone(), tx);
+                    .get_transactional_storage_context(path_iter.clone(), tx);
                 let mut parent_tree = Merk::open(parent_storage)
                     .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))?;
                 element.insert(&mut parent_tree, key.as_ref())?;
             } else {
-                let subtree_storage = self.db.get_prefixed_context_from_path(path_iter.clone());
+                let subtree_storage = self.db.get_storage_context(path_iter.clone());
                 let subtree = Merk::open(subtree_storage)
                     .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))?;
                 let element = Element::Tree(subtree.root_hash());
                 let key = path_iter.next_back().expect("next element is `Some`");
-                let parent_storage = self.db.get_prefixed_context_from_path(path_iter.clone());
+                let parent_storage = self.db.get_storage_context(path_iter.clone());
                 let mut parent_tree = Merk::open(parent_storage)
                     .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))?;
                 element.insert(&mut parent_tree, key.as_ref())?;

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -1,5 +1,5 @@
 use merk::Merk;
-use storage::StorageContext;
+use storage::{Storage, StorageContext};
 
 use crate::{
     util::{merk_optional_tx, meta_storage_context_optional_tx},
@@ -82,10 +82,10 @@ impl GroveDb {
         if let Some(tx) = transaction {
             let parent_storage = self
                 .db
-                .get_prefixed_transactional_context_from_path(path_iter.clone(), tx);
+                .get_transactional_storage_context(path_iter.clone(), tx);
             let mut parent_subtree = Merk::open(parent_storage)
                 .map_err(|_| crate::Error::CorruptedData("cannot open a subtree".to_owned()))?;
-            let child_storage = self.db.get_prefixed_transactional_context_from_path(
+            let child_storage = self.db.get_transactional_storage_context(
                 path_iter.clone().chain(std::iter::once(key)),
                 tx,
             );
@@ -94,12 +94,12 @@ impl GroveDb {
             let element = Element::Tree(child_subtree.root_hash());
             element.insert(&mut parent_subtree, key)?;
         } else {
-            let parent_storage = self.db.get_prefixed_context_from_path(path_iter.clone());
+            let parent_storage = self.db.get_storage_context(path_iter.clone());
             let mut parent_subtree = Merk::open(parent_storage)
                 .map_err(|_| crate::Error::CorruptedData("cannot open a subtree".to_owned()))?;
             let child_storage = self
                 .db
-                .get_prefixed_context_from_path(path_iter.clone().chain(std::iter::once(key)));
+                .get_storage_context(path_iter.clone().chain(std::iter::once(key)));
             let child_subtree = Merk::open(child_storage)
                 .map_err(|_| crate::Error::CorruptedData("cannot open a subtree".to_owned()))?;
             let element = Element::Tree(child_subtree.root_hash());

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -8,7 +8,7 @@ use merk::{
     Op,
 };
 use serde::{Deserialize, Serialize};
-use storage::{rocksdb_storage::RocksDbStorage, RawIterator, StorageContext};
+use storage::{rocksdb_storage::RocksDbStorage, RawIterator, Storage, StorageContext};
 
 use crate::{
     util::{merk_optional_tx, storage_context_optional_tx},
@@ -472,7 +472,7 @@ mod tests {
         let db = make_grovedb();
 
         let storage = &db.db;
-        let storage_context = storage.get_prefixed_context_from_path([TEST_LEAF]);
+        let storage_context = storage.get_storage_context([TEST_LEAF]);
         let mut merk = Merk::open(storage_context).expect("cannot open Merk");
 
         Element::Item(b"ayyd".to_vec())
@@ -550,7 +550,7 @@ mod tests {
         let db = make_grovedb();
 
         let storage = &db.db;
-        let storage_context = storage.get_prefixed_context_from_path([TEST_LEAF]);
+        let storage_context = storage.get_storage_context([TEST_LEAF]);
         let mut merk = Merk::open(storage_context).expect("cannot open Merk");
 
         Element::Item(b"ayyd".to_vec())
@@ -606,7 +606,7 @@ mod tests {
         let db = make_grovedb();
 
         let storage = &db.db;
-        let storage_context = storage.get_prefixed_context_from_path([TEST_LEAF]);
+        let storage_context = storage.get_storage_context([TEST_LEAF]);
         let mut merk = Merk::open(storage_context).expect("cannot open Merk");
 
         Element::Item(b"ayyd".to_vec())
@@ -674,7 +674,7 @@ mod tests {
         let db = make_grovedb();
 
         let storage = &db.db;
-        let storage_context = storage.get_prefixed_context_from_path([TEST_LEAF]);
+        let storage_context = storage.get_storage_context([TEST_LEAF]);
         let mut merk = Merk::open(storage_context).expect("cannot open Merk");
 
         Element::Item(b"ayyd".to_vec())

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -920,10 +920,7 @@ fn test_subtree_pairs_iterator() {
     // let mut iter = db
     //     .elements_iterator(&[TEST_LEAF, b"subtree1"], None)
     //     .expect("cannot create iterator");
-    let storage_context = db
-        .db
-        .db
-        .get_prefixed_context_from_path([TEST_LEAF, b"subtree1"]);
+    let storage_context = db.db.db.get_storage_context([TEST_LEAF, b"subtree1"]);
     let mut iter = Element::iterator(storage_context.raw_iter());
     assert_eq!(iter.next().unwrap(), Some((b"key1".to_vec(), element)));
     assert_eq!(iter.next().unwrap(), Some((b"key2".to_vec(), element2)));
@@ -1014,10 +1011,7 @@ fn test_get_subtree() {
     // Retrieve subtree instance
     // Check if it returns the same instance that was inserted
     {
-        let subtree_storage = db
-            .db
-            .db
-            .get_prefixed_context_from_path([TEST_LEAF, b"key1", b"key2"]);
+        let subtree_storage = db.db.db.get_storage_context([TEST_LEAF, b"key1", b"key2"]);
         let subtree = Merk::open(subtree_storage).expect("cannot open merk");
         let result_element = Element::get(&subtree, b"key3").unwrap();
         assert_eq!(result_element, Element::Item(b"ayy".to_vec()));
@@ -1042,19 +1036,16 @@ fn test_get_subtree() {
     .expect("successful value insert");
 
     // Retrieve subtree instance with transaction
-    let subtree_storage = db.db.db.get_prefixed_transactional_context_from_path(
-        [TEST_LEAF, b"key1", b"innertree"],
-        &transaction,
-    );
+    let subtree_storage = db
+        .db
+        .db
+        .get_transactional_storage_context([TEST_LEAF, b"key1", b"innertree"], &transaction);
     let subtree = Merk::open(subtree_storage).expect("cannot open merk");
     let result_element = Element::get(&subtree, b"key4").unwrap();
     assert_eq!(result_element, Element::Item(b"ayy".to_vec()));
 
     // Should be able to retrieve instances created before transaction
-    let subtree_storage = db
-        .db
-        .db
-        .get_prefixed_context_from_path([TEST_LEAF, b"key1", b"key2"]);
+    let subtree_storage = db.db.db.get_storage_context([TEST_LEAF, b"key1", b"key2"]);
     let subtree = Merk::open(subtree_storage).expect("cannot open merk");
     let result_element = Element::get(&subtree, b"key3").unwrap();
     assert_eq!(result_element, Element::Item(b"ayy".to_vec()));

--- a/grovedb/src/util.rs
+++ b/grovedb/src/util.rs
@@ -2,14 +2,17 @@
 /// (transactional or not) using path argument.
 macro_rules! storage_context_optional_tx {
     ($db:expr, $path:expr, $transaction:ident, $storage:ident, { $($body:tt)* }) => {
-        if let Some(tx) = $transaction {
-            let $storage = $db
-                .get_prefixed_transactional_context_from_path($path, tx);
-            $($body)*
-        } else {
-            let $storage = $db
-                .get_prefixed_context_from_path($path);
-            $($body)*
+        {
+            use ::storage::Storage;
+            if let Some(tx) = $transaction {
+                let $storage = $db
+                    .get_transactional_storage_context($path, tx);
+                $($body)*
+            } else {
+                let $storage = $db
+                    .get_storage_context($path);
+                $($body)*
+            }
         }
     };
 }
@@ -18,14 +21,17 @@ macro_rules! storage_context_optional_tx {
 /// prefix.
 macro_rules! meta_storage_context_optional_tx {
     ($db:expr, $transaction:ident, $storage:ident, { $($body:tt)* }) => {
-        if let Some(tx) = $transaction {
-            let $storage = $db
-                .get_prefixed_transactional_context(Vec::new(), tx);
-            $($body)*
-        } else {
-            let $storage = $db
-                .get_prefixed_context(Vec::new());
-            $($body)*
+        {
+            use ::storage::Storage;
+            if let Some(tx) = $transaction {
+                let $storage = $db
+                    .get_transactional_storage_context(::std::iter::empty(), tx);
+                $($body)*
+            } else {
+                let $storage = $db
+                    .get_storage_context(::std::iter::empty());
+                $($body)*
+            }
         }
     };
 }

--- a/grovedb/src/visualize.rs
+++ b/grovedb/src/visualize.rs
@@ -195,12 +195,12 @@ impl Visualize for GroveDb {
     }
 }
 
-// impl Visualize for (&GroveDb, &OptimisticTransactionDBTransaction<'_>) {
-//     fn visualize<'a, W: Write>(&self, drawer: Drawer<'a, W>) ->
-// Result<Drawer<'a, W>> {         let (grovedb, transaction) = self;
-//         grovedb.visualize_start(drawer, Some(transaction))
-//     }
-// }
+impl<'db, 'ctx> Visualize for (&'db GroveDb, TransactionArg<'db, 'ctx>) {
+    fn visualize<'a, W: Write>(&self, drawer: Drawer<'a, W>) -> Result<Drawer<'a, W>> {
+        let (grovedb, transaction) = self;
+        grovedb.visualize_start(drawer, *transaction)
+    }
+}
 
 pub fn visualize_stderr<T: Visualize + ?Sized>(value: &T) {
     let mut out = std::io::stderr();

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -176,7 +176,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use storage::rocksdb_storage::RocksDbStorage;
+    use std::iter::empty;
+
+    use storage::{rocksdb_storage::RocksDbStorage, Storage};
     use tempfile::TempDir;
 
     use super::*;
@@ -239,7 +241,7 @@ mod tests {
             let storage = RocksDbStorage::default_rocksdb_with_path(tmp_dir.path())
                 .expect("cannot open rocksdb storage");
 
-            let mut merk = Merk::open(storage.get_prefixed_context(b"".to_vec())).unwrap();
+            let mut merk = Merk::open(storage.get_storage_context(empty())).unwrap();
             let batch = make_batch_seq(1..10);
             merk.apply::<_, Vec<_>>(&batch, &[]).unwrap();
 
@@ -252,7 +254,7 @@ mod tests {
         };
         let storage = RocksDbStorage::default_rocksdb_with_path(tmp_dir.path())
             .expect("cannot open rocksdb storage");
-        let merk = Merk::open(storage.get_prefixed_context(b"".to_vec())).unwrap();
+        let merk = Merk::open(storage.get_storage_context(empty())).unwrap();
         let reopen_chunks = merk.chunks().unwrap().into_iter().map(Result::unwrap);
 
         for (original, checkpoint) in original_chunks.zip(reopen_chunks) {

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -442,9 +442,11 @@ impl Commit for MerkCommitter {
 
 #[cfg(test)]
 mod test {
+    use std::iter::empty;
+
     use storage::{
         rocksdb_storage::{PrefixedRocksDbStorageContext, RocksDbStorage},
-        RawIterator, StorageContext,
+        RawIterator, Storage, StorageContext,
     };
     use tempfile::TempDir;
 
@@ -594,7 +596,7 @@ mod test {
             let storage = RocksDbStorage::default_rocksdb_with_path(tmp_dir.path())
                 .expect("cannot open rocksdb storage");
             let mut merk =
-                Merk::open(storage.get_prefixed_context(b"".to_vec())).expect("cannot open merk");
+                Merk::open(storage.get_storage_context(empty())).expect("cannot open merk");
             let batch = make_batch_seq(1..10_000);
             merk.apply::<_, Vec<_>>(batch.as_slice(), &[]).unwrap();
             let mut tree = merk.tree.take().unwrap();
@@ -607,8 +609,7 @@ mod test {
 
         let storage = RocksDbStorage::default_rocksdb_with_path(tmp_dir.path())
             .expect("cannot open rocksdb storage");
-        let merk =
-            Merk::open(storage.get_prefixed_context(b"".to_vec())).expect("cannot open merk");
+        let merk = Merk::open(storage.get_storage_context(empty())).expect("cannot open merk");
         let mut tree = merk.tree.take().unwrap();
         let walker = RefWalker::new(&mut tree, merk.source());
 
@@ -638,7 +639,7 @@ mod test {
             let storage = RocksDbStorage::default_rocksdb_with_path(tmp_dir.path())
                 .expect("cannot open rocksdb storage");
             let mut merk =
-                Merk::open(storage.get_prefixed_context(b"".to_vec())).expect("cannot open merk");
+                Merk::open(storage.get_storage_context(empty())).expect("cannot open merk");
             let batch = make_batch_seq(1..10_000);
             merk.apply::<_, Vec<_>>(batch.as_slice(), &[]).unwrap();
 
@@ -648,8 +649,7 @@ mod test {
         };
         let storage = RocksDbStorage::default_rocksdb_with_path(tmp_dir.path())
             .expect("cannot open rocksdb storage");
-        let merk =
-            Merk::open(storage.get_prefixed_context(b"".to_vec())).expect("cannot open merk");
+        let merk = Merk::open(storage.get_storage_context(empty())).expect("cannot open merk");
 
         let mut reopen_nodes = vec![];
         collect(&mut merk.storage.raw_iter(), &mut reopen_nodes);

--- a/merk/src/test_utils/crash_merk.rs
+++ b/merk/src/test_utils/crash_merk.rs
@@ -1,7 +1,13 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    iter::empty,
+    ops::{Deref, DerefMut},
+};
 
 use anyhow::Result;
-use storage::rocksdb_storage::{test_utils::TempStorage, PrefixedRocksDbStorageContext};
+use storage::{
+    rocksdb_storage::{test_utils::TempStorage, PrefixedRocksDbStorageContext},
+    Storage,
+};
 
 use crate::Merk;
 
@@ -17,7 +23,7 @@ impl CrashMerk {
     /// does not exist.
     pub fn open() -> Result<CrashMerk> {
         let storage = Box::leak(Box::new(TempStorage::new()));
-        let context = storage.get_prefixed_context(b"".to_vec());
+        let context = storage.get_storage_context(empty());
         let merk = Merk::open(context).unwrap();
         Ok(CrashMerk { merk, storage })
     }

--- a/merk/src/test_utils/temp_merk.rs
+++ b/merk/src/test_utils/temp_merk.rs
@@ -1,6 +1,12 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    iter::empty,
+    ops::{Deref, DerefMut},
+};
 
-use storage::rocksdb_storage::{test_utils::TempStorage, PrefixedRocksDbStorageContext};
+use storage::{
+    rocksdb_storage::{test_utils::TempStorage, PrefixedRocksDbStorageContext},
+    Storage,
+};
 
 use crate::Merk;
 
@@ -15,7 +21,7 @@ impl TempMerk {
     /// does not exist.
     pub fn new() -> Self {
         let storage = Box::leak(Box::new(TempStorage::new()));
-        let context = storage.get_prefixed_context(b"".to_vec());
+        let context = storage.get_storage_context(empty());
         let merk = Merk::open(context).unwrap();
         TempMerk { storage, merk }
     }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -2,7 +2,20 @@
 /// Should be able to hold storage connection and to start transaction when
 /// needed. All query operations will be exposed using [StorageContext].
 pub trait Storage<'db> {
+    /// Storage transaction type
     type Transaction;
+
+    /// Storage context type
+    /// TODO: add `StorageContext<'db, 'ctx, Error = Self::Error>` bound with
+    /// GATs
+    type StorageContext;
+
+    /// Storage context type for transactional data
+    /// TODO: add `StorageContext<'db, 'ctx, Error = Self::Error>` bound with
+    /// GATs
+    type TransactionalStorageContext;
+
+    /// Error type
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Starts a new transaction
@@ -16,6 +29,20 @@ pub trait Storage<'db> {
 
     /// Forces data to be written
     fn flush(&self) -> Result<(), Self::Error>;
+
+    /// Make storage context for a subtree with path
+    fn get_storage_context<'p, P>(&'db self, path: P) -> Self::StorageContext
+    where
+        P: IntoIterator<Item = &'p [u8]>;
+
+    /// Make storage context for a subtree on transactional data
+    fn get_transactional_storage_context<'p, P>(
+        &'db self,
+        path: P,
+        transaction: &'db Self::Transaction,
+    ) -> Self::TransactionalStorageContext
+    where
+        P: IntoIterator<Item = &'p [u8]>;
 }
 
 /// Storage context.


### PR DESCRIPTION
PR to keep progress of storage abstraction task, currently cannot be finished easily without GATs