### PR TITLE
feat: add benchmark for insertion

### DIFF
--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rs_merkle = "1.1.0"
 merk = { path = "../merk", features = ["full"] }
 thiserror = "1.0.30"
-tempdir = "0.3.7"
+tempfile = "3"
 bincode = "1.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
 storage = { path = "../storage", features = ["rocksdb_storage"] }
@@ -16,7 +16,12 @@ itertools = { version = "0.10.3", optional = true }
 
 [dev-dependencies]
 rand = "0.8.4"
+criterion = "0.3"
 
 [features]
 default = ["visualize"]
 visualize = ["itertools"]
+
+[[bench]]
+name = "insertion_benchmark"
+harness = false

--- a/grovedb/benches/insertion_benchmark.rs
+++ b/grovedb/benches/insertion_benchmark.rs
@@ -1,0 +1,151 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use grovedb::{Element, GroveDb};
+use rand::Rng;
+use tempfile::TempDir;
+
+const N_ITEMS: usize = 10_000;
+
+pub fn insertion_benchmark_without_transaction(c: &mut Criterion) {
+    let dir = TempDir::new().unwrap();
+    let db = GroveDb::open(dir.path()).unwrap();
+    let test_leaf: &[u8] = b"leaf1";
+    db.insert([], test_leaf, Element::empty_tree(), None)
+        .unwrap();
+    let keys = std::iter::repeat_with(|| rand::thread_rng().gen::<[u8; 32]>()).take(N_ITEMS);
+
+    c.bench_function("scalars insertion without transaction", |b| {
+        b.iter(|| {
+            for k in keys.clone() {
+                db.insert([test_leaf], &k, Element::Item(k.to_vec()), None)
+                    .unwrap();
+            }
+        })
+    });
+}
+
+pub fn insertion_benchmark_with_transaction(c: &mut Criterion) {
+    let dir = TempDir::new().unwrap();
+    let db = GroveDb::open(dir.path()).unwrap();
+    let test_leaf: &[u8] = b"leaf1";
+    db.insert([], test_leaf, Element::empty_tree(), None)
+        .unwrap();
+    let keys = std::iter::repeat_with(|| rand::thread_rng().gen::<[u8; 32]>()).take(N_ITEMS);
+
+    c.bench_function("scalars insertion with transaction", |b| {
+        b.iter(|| {
+            let tx = db.start_transaction();
+            for k in keys.clone() {
+                db.insert([test_leaf], &k, Element::Item(k.to_vec()), Some(&tx))
+                    .unwrap();
+            }
+            db.commit_transaction(tx).unwrap();
+        })
+    });
+}
+
+pub fn root_leaf_insertion_benchmark_without_transaction(c: &mut Criterion) {
+    let dir = TempDir::new().unwrap();
+    let db = GroveDb::open(dir.path()).unwrap();
+    let keys = std::iter::repeat_with(|| rand::thread_rng().gen::<[u8; 32]>()).take(10);
+
+    c.bench_function("root leafs insertion without transaction", |b| {
+        b.iter(|| {
+            for k in keys.clone() {
+                db.insert([], &k, Element::empty_tree(), None).unwrap();
+            }
+        })
+    });
+}
+
+pub fn root_leaf_insertion_benchmark_with_transaction(c: &mut Criterion) {
+    let dir = TempDir::new().unwrap();
+    let db = GroveDb::open(dir.path()).unwrap();
+    let keys = std::iter::repeat_with(|| rand::thread_rng().gen::<[u8; 32]>()).take(10);
+
+    c.bench_function("root leafs insertion with transaction", |b| {
+        b.iter(|| {
+            let tx = db.start_transaction();
+            for k in keys.clone() {
+                db.insert([], &k, Element::empty_tree(), Some(&tx)).unwrap();
+            }
+            db.commit_transaction(tx).unwrap();
+        })
+    });
+}
+
+pub fn deeply_nested_insertion_benchmark_without_transaction(c: &mut Criterion) {
+    let dir = TempDir::new().unwrap();
+    let db = GroveDb::open(dir.path()).unwrap();
+    let mut nested_subtrees: Vec<[u8; 32]> = Vec::new();
+    for s in std::iter::repeat_with(|| rand::thread_rng().gen::<[u8; 32]>()).take(10) {
+        db.insert(
+            nested_subtrees.iter().map(|x| x.as_slice()),
+            &s,
+            Element::empty_tree(),
+            None,
+        )
+        .unwrap();
+        nested_subtrees.push(s);
+    }
+
+    let keys = std::iter::repeat_with(|| rand::thread_rng().gen::<[u8; 32]>()).take(N_ITEMS);
+
+    c.bench_function("deeply nested scalars insertion without transaction", |b| {
+        b.iter(|| {
+            for k in keys.clone() {
+                db.insert(
+                    nested_subtrees.iter().map(|x| x.as_slice()),
+                    &k,
+                    Element::Item(k.to_vec()),
+                    None,
+                )
+                .unwrap();
+            }
+        })
+    });
+}
+
+pub fn deeply_nested_insertion_benchmark_with_transaction(c: &mut Criterion) {
+    let dir = TempDir::new().unwrap();
+    let db = GroveDb::open(dir.path()).unwrap();
+    let mut nested_subtrees: Vec<[u8; 32]> = Vec::new();
+    for s in std::iter::repeat_with(|| rand::thread_rng().gen::<[u8; 32]>()).take(10) {
+        db.insert(
+            nested_subtrees.iter().map(|x| x.as_slice()),
+            &s,
+            Element::empty_tree(),
+            None,
+        )
+        .unwrap();
+        nested_subtrees.push(s);
+    }
+
+    let keys = std::iter::repeat_with(|| rand::thread_rng().gen::<[u8; 32]>()).take(N_ITEMS);
+
+    c.bench_function("deeply nested scalars insertion with transaction", |b| {
+        b.iter(|| {
+            let tx = db.start_transaction();
+            for k in keys.clone() {
+                db.insert(
+                    nested_subtrees.iter().map(|x| x.as_slice()),
+                    &k,
+                    Element::Item(k.to_vec()),
+                    Some(&tx),
+                )
+                .unwrap();
+            }
+            db.commit_transaction(tx).unwrap();
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    insertion_benchmark_without_transaction,
+    insertion_benchmark_with_transaction,
+    root_leaf_insertion_benchmark_without_transaction,
+    root_leaf_insertion_benchmark_with_transaction,
+    deeply_nested_insertion_benchmark_without_transaction,
+    deeply_nested_insertion_benchmark_with_transaction,
+);
+criterion_main!(benches);

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use rand::Rng;
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 // use test::RunIgnored::No;
 use super::*;
@@ -43,7 +43,7 @@ impl Visualize for TempGroveDb {
 
 /// A helper method to create GroveDB with one leaf for a root tree
 pub fn make_grovedb() -> TempGroveDb {
-    let tmp_dir = TempDir::new("db").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let mut db = GroveDb::open(tmp_dir.path()).unwrap();
     add_test_leafs(&mut db);
     TempGroveDb {
@@ -61,7 +61,7 @@ fn add_test_leafs(db: &mut GroveDb) {
 
 #[test]
 fn test_init() {
-    let tmp_dir = TempDir::new("db").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     GroveDb::open(tmp_dir).expect("empty tree is ok");
 }
 
@@ -203,7 +203,7 @@ fn test_too_many_indirections() {
 
 #[test]
 fn test_tree_structure_is_persistent() {
-    let tmp_dir = TempDir::new("db").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let element = Element::Item(b"ayy".to_vec());
     // Create a scoped GroveDB
     let prev_root_hash = {


### PR DESCRIPTION
Adds some benchmarks for insertion;

Comparing to `master` version, new storage approach works faster for non-transactional insertions (~12% for scalars, ~150% for root leafs, ~70% for nested insertions), and ~20% slower (except root tree bench) in transactions (as there is no temp trees and everything goes to rocksdb directly)