### PR TITLE
feat: conditional subqueries

### DIFF
--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -197,6 +197,34 @@ impl Element {
         Ok(())
     }
 
+    fn subquery_paths_for_sized_query(
+        sized_query: &SizedQuery,
+        key: &[u8],
+    ) -> (Option<Vec<u8>>, Option<Query>) {
+        for (query_item, subquery_branch) in &sized_query.query.conditional_subquery_branches {
+            if query_item.contains(key) {
+                let subquery_key = subquery_branch.subquery_key.clone();
+                let subquery = subquery_branch
+                    .subquery
+                    .as_ref()
+                    .map(|query| *query.clone());
+                return (subquery_key, subquery);
+            }
+        }
+        let subquery_key = sized_query
+            .query
+            .default_subquery_branch
+            .subquery_key
+            .clone();
+        let subquery = sized_query
+            .query
+            .default_subquery_branch
+            .subquery
+            .as_ref()
+            .map(|query| *query.clone());
+        (subquery_key, subquery)
+    }
+
     fn query_item(
         item: &QueryItem,
         results: &mut Vec<Self>,
@@ -216,23 +244,23 @@ impl Element {
                     .borrow_mut(merk_path.iter().copied(), transaction)?
                     .apply(|s| Self::get(s, key))
                 {
-                    Ok(element) => Ok(add_element_function(PathQueryPushArgs {
-                        transaction,
-                        subtrees,
-                        key: Some(key.as_slice()),
-                        element,
-                        path,
-                        subquery_key: sized_query.query.subquery_key.clone(),
-                        subquery: sized_query
-                            .query
-                            .subquery
-                            .as_ref()
-                            .map(|query| *query.clone()),
-                        left_to_right: sized_query.query.left_to_right,
-                        results,
-                        limit,
-                        offset,
-                    })?),
+                    Ok(element) => {
+                        let (subquery_key, subquery) =
+                            Self::subquery_paths_for_sized_query(sized_query, key);
+                        Ok(add_element_function(PathQueryPushArgs {
+                            transaction,
+                            subtrees,
+                            key: Some(key.as_slice()),
+                            element,
+                            path,
+                            subquery_key,
+                            subquery,
+                            left_to_right: sized_query.query.left_to_right,
+                            results,
+                            limit,
+                            offset,
+                        })?)
+                    }
                     Err(e) => match e {
                         Error::PathKeyNotFound(_) => Ok(()),
                         _ => Err(e),
@@ -259,18 +287,16 @@ impl Element {
                 let element =
                     raw_decode(iter.value().expect("if key exists then value should too"))?;
                 let key = iter.key().expect("key should exist");
+                let (subquery_key, subquery) =
+                    Self::subquery_paths_for_sized_query(sized_query, key);
                 add_element_function(PathQueryPushArgs {
                     transaction,
                     subtrees,
                     key: Some(key),
                     element,
                     path,
-                    subquery_key: sized_query.query.subquery_key.clone(),
-                    subquery: sized_query
-                        .query
-                        .subquery
-                        .as_ref()
-                        .map(|query| *query.clone()),
+                    subquery_key,
+                    subquery,
                     left_to_right: sized_query.query.left_to_right,
                     results,
                     limit,

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -1807,7 +1807,7 @@ fn test_get_range_query_with_unique_subquery_ignore_non_unique_null_values() {
 
     query.set_subquery_key(subquery_key);
 
-    let mut subquery = Query::new();
+    let subquery = Query::new();
 
     query.add_conditional_subquery(
         QueryItem::Key(b"".to_vec()),

--- a/merk/Cargo.toml
+++ b/merk/Cargo.toml
@@ -14,6 +14,7 @@ rocksdb = { git = "https://github.com/yiyuanliu/rust-rocksdb", branch = "transac
 anyhow = "1.0.53"
 failure = "0.1.8"
 integer-encoding = "3.0.2"
+indexmap = "1.8.0"
 
 [dependencies.time]
 version = "0.3.7"

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -3,7 +3,7 @@ mod map;
 use std::{
     cmp,
     cmp::{max, min, Ordering},
-    collections::{BTreeSet, HashMap},
+    collections::BTreeSet,
     hash::Hash,
     ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
 };
@@ -30,7 +30,7 @@ pub struct SubqueryBranch {
 pub struct Query {
     items: BTreeSet<QueryItem>,
     pub default_subquery_branch: SubqueryBranch,
-    pub conditional_subquery_branches: HashMap<QueryItem, SubqueryBranch>,
+    pub conditional_subquery_branches: IndexMap<QueryItem, SubqueryBranch>,
     pub left_to_right: bool,
 }
 
@@ -234,7 +234,7 @@ impl<Q: Into<QueryItem>> From<Vec<Q>> for Query {
                 subquery_key: None,
                 subquery: None,
             },
-            conditional_subquery_branches: HashMap::new(),
+            conditional_subquery_branches: IndexMap::new(),
             left_to_right: true,
         }
     }

--- a/node-grove/src/converter.rs
+++ b/node-grove/src/converter.rs
@@ -199,8 +199,8 @@ fn js_object_to_query<'a, C: Context<'a>>(
     let left_to_right = js_value_to_option::<JsBoolean, _>(js_object.get(cx, "leftToRight")?, cx)?
         .map(|x| x.value(cx));
 
-    query.subquery_key = subquery_key;
-    query.subquery = subquery.map(Box::new);
+    query.default_subquery_branch.subquery_key = subquery_key;
+    query.default_subquery_branch.subquery = subquery.map(Box::new);
     query.left_to_right = left_to_right.unwrap_or(true);
 
     Ok(query)


### PR DESCRIPTION
This allows queries to specify subquery branches depending on values of the node.

In RS-Drive, unique values have the value under 0. However null is non unique even in the property should be unique. This means that null values should be treated differently. Instead a tree of values should exist under 0.