### PR TITLE
feat(storage): multi-context batches

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,5 +1,11 @@
+#![deny(missing_docs)]
+
+//! Storage abstraction for GroveDB.
+
 #[cfg(feature = "rocksdb_storage")]
 pub mod rocksdb_storage;
 mod storage;
 
-pub use crate::storage::{Batch, RawIterator, Storage, StorageContext};
+pub use crate::storage::{
+    Batch, BatchOperation, RawIterator, Storage, StorageBatch, StorageContext,
+};

--- a/storage/src/rocksdb_storage.rs
+++ b/storage/src/rocksdb_storage.rs
@@ -7,8 +7,9 @@ mod tests;
 
 pub use rocksdb::Error;
 pub use storage_context::{
-    PrefixedRocksDbBatch, PrefixedRocksDbRawIterator, PrefixedRocksDbStorageContext,
-    PrefixedRocksDbTransactionContext,
+    PrefixedRocksDbBatch, PrefixedRocksDbBatchStorageContext,
+    PrefixedRocksDbBatchTransactionContext, PrefixedRocksDbRawIterator,
+    PrefixedRocksDbStorageContext, PrefixedRocksDbTransactionContext,
 };
 
 pub use self::storage::RocksDbStorage;

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -2,17 +2,23 @@
 use std::path::Path;
 
 use lazy_static::lazy_static;
-use rocksdb::{ColumnFamilyDescriptor, Error, OptimisticTransactionDB, Transaction};
+use rocksdb::{
+    ColumnFamily, ColumnFamilyDescriptor, Error, OptimisticTransactionDB, Transaction,
+    WriteBatchWithTransaction,
+};
 
-use super::{PrefixedRocksDbStorageContext, PrefixedRocksDbTransactionContext};
-use crate::Storage;
+use super::{
+    PrefixedRocksDbBatchStorageContext, PrefixedRocksDbBatchTransactionContext,
+    PrefixedRocksDbStorageContext, PrefixedRocksDbTransactionContext,
+};
+use crate::{BatchOperation, Storage, StorageBatch};
 
 /// Name of column family used to store auxiliary data
-pub(super) const AUX_CF_NAME: &str = "aux";
+pub(crate) const AUX_CF_NAME: &str = "aux";
 /// Name of column family used to store subtrees roots data
-pub(super) const ROOTS_CF_NAME: &str = "roots";
+pub(crate) const ROOTS_CF_NAME: &str = "roots";
 /// Name of column family used to store metadata
-pub(super) const META_CF_NAME: &str = "meta";
+pub(crate) const META_CF_NAME: &str = "meta";
 
 lazy_static! {
     static ref DEFAULT_OPTS: rocksdb::Options = {
@@ -27,14 +33,21 @@ lazy_static! {
     };
 }
 
+/// Type alias for a database
+pub(crate) type Db = OptimisticTransactionDB;
+
+/// Type alias for a transaction
+pub(crate) type Tx<'db> = Transaction<'db, Db>;
+
 /// Storage which uses RocksDB as its backend.
 pub struct RocksDbStorage {
     db: OptimisticTransactionDB,
 }
 
 impl RocksDbStorage {
+    /// Create RocksDb storage with default parameters using `path`.
     pub fn default_rocksdb_with_path<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let db = rocksdb::OptimisticTransactionDB::open_cf_descriptors(
+        let db = Db::open_cf_descriptors(
             &DEFAULT_OPTS,
             &path,
             [
@@ -72,9 +85,11 @@ impl RocksDbStorage {
 }
 
 impl<'db> Storage<'db> for RocksDbStorage {
+    type BatchStorageContext = PrefixedRocksDbBatchStorageContext<'db>;
+    type BatchTransactionalStorageContext = PrefixedRocksDbBatchTransactionContext<'db>;
     type Error = Error;
     type StorageContext = PrefixedRocksDbStorageContext<'db>;
-    type Transaction = Transaction<'db, OptimisticTransactionDB>;
+    type Transaction = Tx<'db>;
     type TransactionalStorageContext = PrefixedRocksDbTransactionContext<'db>;
 
     fn start_transaction(&'db self) -> Self::Transaction {
@@ -112,6 +127,85 @@ impl<'db> Storage<'db> for RocksDbStorage {
         let prefix = Self::build_prefix(path);
         PrefixedRocksDbTransactionContext::new(&self.db, transaction, prefix)
     }
+
+    fn get_batch_storage_context<'p, P>(
+        &'db self,
+        path: P,
+        batch: &'db StorageBatch,
+    ) -> Self::BatchStorageContext
+    where
+        P: IntoIterator<Item = &'p [u8]>,
+    {
+        let prefix = Self::build_prefix(path);
+        PrefixedRocksDbBatchStorageContext::new(&self.db, prefix, batch)
+    }
+
+    fn get_batch_transactional_storage_context<'p, P>(
+        &'db self,
+        path: P,
+        batch: &'db StorageBatch,
+        transaction: &'db Self::Transaction,
+    ) -> Self::BatchTransactionalStorageContext
+    where
+        P: IntoIterator<Item = &'p [u8]>,
+    {
+        todo!()
+    }
+
+    fn commit_multi_context_batch(&self, batch: StorageBatch) -> Result<(), Self::Error> {
+        let mut db_batch = WriteBatchWithTransaction::<true>::default();
+        for op in batch.into_iter() {
+            match op {
+                BatchOperation::Put { key, value } => {
+                    db_batch.put(key, value);
+                }
+                BatchOperation::PutAux { key, value } => {
+                    db_batch.put_cf(cf_aux(&self.db), key, value);
+                }
+                BatchOperation::PutRoot { key, value } => {
+                    db_batch.put_cf(cf_roots(&self.db), key, value);
+                }
+                BatchOperation::PutMeta { key, value } => {
+                    db_batch.put_cf(cf_meta(&self.db), key, value);
+                }
+                BatchOperation::Delete { key } => {
+                    db_batch.delete(key);
+                }
+                BatchOperation::DeleteAux { key } => {
+                    db_batch.delete_cf(cf_aux(&self.db), key);
+                }
+                BatchOperation::DeleteRoot { key } => {
+                    db_batch.delete_cf(cf_roots(&self.db), key);
+                }
+                BatchOperation::DeleteMeta { key } => {
+                    db_batch.delete_cf(cf_meta(&self.db), key);
+                }
+            }
+        }
+        self.db.write(db_batch)?;
+        Ok(())
+    }
+}
+
+/// Get auxiliary data column family
+fn cf_aux(storage: &Db) -> &ColumnFamily {
+    storage
+        .cf_handle(AUX_CF_NAME)
+        .expect("aux column family must exist")
+}
+
+/// Get trees roots data column family
+fn cf_roots(storage: &Db) -> &ColumnFamily {
+    storage
+        .cf_handle(ROOTS_CF_NAME)
+        .expect("roots column family must exist")
+}
+
+/// Get metadata column family
+fn cf_meta(storage: &Db) -> &ColumnFamily {
+    storage
+        .cf_handle(META_CF_NAME)
+        .expect("meta column family must exist")
 }
 
 #[cfg(test)]

--- a/storage/src/rocksdb_storage/storage_context.rs
+++ b/storage/src/rocksdb_storage/storage_context.rs
@@ -1,20 +1,17 @@
 //! Implementation of prefixed storage context.
 mod batch;
+mod context_batch_no_tx;
+mod context_batch_tx;
 mod context_no_tx;
 mod context_tx;
 mod raw_iterator;
 
 pub use batch::PrefixedRocksDbBatch;
+pub use context_batch_no_tx::PrefixedRocksDbBatchStorageContext;
+pub use context_batch_tx::PrefixedRocksDbBatchTransactionContext;
 pub use context_no_tx::PrefixedRocksDbStorageContext;
 pub use context_tx::PrefixedRocksDbTransactionContext;
 pub use raw_iterator::PrefixedRocksDbRawIterator;
-use rocksdb::{OptimisticTransactionDB, Transaction};
-
-/// Type alias for a database
-type Db = OptimisticTransactionDB;
-
-/// Type alias for a transaction
-type Tx<'db> = Transaction<'db, Db>;
 
 pub fn make_prefixed_key<K: AsRef<[u8]>>(mut prefix: Vec<u8>, key: K) -> Vec<u8> {
     prefix.extend_from_slice(key.as_ref());

--- a/storage/src/rocksdb_storage/storage_context/batch.rs
+++ b/storage/src/rocksdb_storage/storage_context/batch.rs
@@ -4,7 +4,7 @@ use std::convert::Infallible;
 use rocksdb::{ColumnFamily, WriteBatchWithTransaction};
 
 use super::{make_prefixed_key, PrefixedRocksDbTransactionContext};
-use crate::{Batch, BatchOperation, StorageBatch, StorageContext};
+use crate::{Batch, StorageBatch, StorageContext};
 
 /// Wrapper to RocksDB batch
 pub struct PrefixedRocksDbBatch<'db, B> {

--- a/storage/src/rocksdb_storage/storage_context/context_batch_no_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_batch_no_tx.rs
@@ -1,26 +1,31 @@
 use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, Error, WriteBatchWithTransaction};
 
-use super::{make_prefixed_key, PrefixedRocksDbBatch, PrefixedRocksDbRawIterator};
+use super::{batch::PrefixedMultiContextBatchPart, make_prefixed_key, PrefixedRocksDbRawIterator};
 use crate::{
     rocksdb_storage::storage::{Db, AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME},
-    StorageContext,
+    StorageBatch, StorageContext,
 };
 
 /// Storage context with a prefix applied to be used in a subtree to be used
 /// outside of transaction.
-pub struct PrefixedRocksDbStorageContext<'db> {
+pub struct PrefixedRocksDbBatchStorageContext<'db> {
     storage: &'db Db,
     prefix: Vec<u8>,
+    batch: &'db StorageBatch,
 }
 
-impl<'db> PrefixedRocksDbStorageContext<'db> {
+impl<'db> PrefixedRocksDbBatchStorageContext<'db> {
     /// Create a new prefixed storage context instance
-    pub fn new(storage: &'db Db, prefix: Vec<u8>) -> Self {
-        PrefixedRocksDbStorageContext { storage, prefix }
+    pub fn new(storage: &'db Db, prefix: Vec<u8>, batch: &'db StorageBatch) -> Self {
+        PrefixedRocksDbBatchStorageContext {
+            storage,
+            prefix,
+            batch,
+        }
     }
 }
 
-impl<'db> PrefixedRocksDbStorageContext<'db> {
+impl<'db> PrefixedRocksDbBatchStorageContext<'db> {
     /// Get auxiliary data column family
     fn cf_aux(&self) -> &'db ColumnFamily {
         self.storage
@@ -43,58 +48,57 @@ impl<'db> PrefixedRocksDbStorageContext<'db> {
     }
 }
 
-impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbStorageContext<'db> {
-    type Batch = PrefixedRocksDbBatch<'db, WriteBatchWithTransaction<true>>;
+impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbBatchStorageContext<'db> {
+    type Batch = PrefixedMultiContextBatchPart;
     type Error = Error;
     type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, Db>>;
 
     fn put<K: AsRef<[u8]>>(&self, key: K, value: &[u8]) -> Result<(), Self::Error> {
-        self.storage
-            .put(make_prefixed_key(self.prefix.clone(), key), value)
+        self.batch
+            .put(make_prefixed_key(self.prefix.clone(), key), value.to_vec());
+        Ok(())
     }
 
     fn put_aux<K: AsRef<[u8]>>(&self, key: K, value: &[u8]) -> Result<(), Self::Error> {
-        self.storage.put_cf(
-            self.cf_aux(),
-            make_prefixed_key(self.prefix.clone(), key),
-            value,
-        )
+        self.batch
+            .put_aux(make_prefixed_key(self.prefix.clone(), key), value.to_vec());
+        Ok(())
     }
 
     fn put_root<K: AsRef<[u8]>>(&self, key: K, value: &[u8]) -> Result<(), Self::Error> {
-        self.storage.put_cf(
-            self.cf_roots(),
-            make_prefixed_key(self.prefix.clone(), key),
-            value,
-        )
+        self.batch
+            .put_root(make_prefixed_key(self.prefix.clone(), key), value.to_vec());
+        Ok(())
     }
 
     fn put_meta<K: AsRef<[u8]>>(&self, key: K, value: &[u8]) -> Result<(), Self::Error> {
-        self.storage.put_cf(
-            self.cf_meta(),
-            make_prefixed_key(self.prefix.clone(), key),
-            value,
-        )
+        self.batch
+            .put_meta(make_prefixed_key(self.prefix.clone(), key), value.to_vec());
+        Ok(())
     }
 
     fn delete<K: AsRef<[u8]>>(&self, key: K) -> Result<(), Self::Error> {
-        self.storage
-            .delete(make_prefixed_key(self.prefix.clone(), key))
+        self.batch
+            .delete(make_prefixed_key(self.prefix.clone(), key));
+        Ok(())
     }
 
     fn delete_aux<K: AsRef<[u8]>>(&self, key: K) -> Result<(), Self::Error> {
-        self.storage
-            .delete_cf(self.cf_aux(), make_prefixed_key(self.prefix.clone(), key))
+        self.batch
+            .delete_aux(make_prefixed_key(self.prefix.clone(), key));
+        Ok(())
     }
 
     fn delete_root<K: AsRef<[u8]>>(&self, key: K) -> Result<(), Self::Error> {
-        self.storage
-            .delete_cf(self.cf_roots(), make_prefixed_key(self.prefix.clone(), key))
+        self.batch
+            .delete_root(make_prefixed_key(self.prefix.clone(), key));
+        Ok(())
     }
 
     fn delete_meta<K: AsRef<[u8]>>(&self, key: K) -> Result<(), Self::Error> {
-        self.storage
-            .delete_cf(self.cf_meta(), make_prefixed_key(self.prefix.clone(), key))
+        self.batch
+            .delete_meta(make_prefixed_key(self.prefix.clone(), key));
+        Ok(())
     }
 
     fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -118,16 +122,15 @@ impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbStorageContext<'db>
     }
 
     fn new_batch(&self) -> Self::Batch {
-        PrefixedRocksDbBatch {
+        PrefixedMultiContextBatchPart {
             prefix: self.prefix.clone(),
-            batch: WriteBatchWithTransaction::<true>::default(),
-            cf_aux: self.cf_aux(),
-            cf_roots: self.cf_roots(),
+            batch: StorageBatch::new(),
         }
     }
 
     fn commit_batch(&self, batch: Self::Batch) -> Result<(), Self::Error> {
-        self.storage.write(batch.batch)
+        self.batch.merge(batch.batch);
+        Ok(())
     }
 
     fn raw_iter(&self) -> Self::RawIterator {

--- a/storage/src/rocksdb_storage/storage_context/context_batch_no_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_batch_no_tx.rs
@@ -1,4 +1,4 @@
-use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, Error, WriteBatchWithTransaction};
+use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, Error};
 
 use super::{batch::PrefixedMultiContextBatchPart, make_prefixed_key, PrefixedRocksDbRawIterator};
 use crate::{

--- a/storage/src/rocksdb_storage/storage_context/context_batch_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_batch_tx.rs
@@ -136,13 +136,15 @@ where
     }
 
     fn new_batch(&'ctx self) -> Self::Batch {
-        todo!()
-        // self
+        PrefixedMultiContextBatchPart {
+            prefix: self.prefix.clone(),
+            batch: StorageBatch::new(),
+        }
     }
 
-    fn commit_batch(&'ctx self, _batch: Self::Batch) -> Result<(), Self::Error> {
-        todo!()
-        // Ok(())
+    fn commit_batch(&'ctx self, batch: Self::Batch) -> Result<(), Self::Error> {
+        self.batch.merge(batch.batch);
+        Ok(())
     }
 
     fn raw_iter(&self) -> Self::RawIterator {

--- a/storage/src/rocksdb_storage/storage_context/context_batch_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_batch_tx.rs
@@ -1,26 +1,32 @@
+//! Storage context implementation with a transaction.
 use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, Error, WriteBatchWithTransaction};
 
 use super::{make_prefixed_key, PrefixedRocksDbBatch, PrefixedRocksDbRawIterator};
 use crate::{
-    rocksdb_storage::storage::{Db, AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME},
+    rocksdb_storage::storage::{Db, Tx, AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME},
     StorageContext,
 };
 
-/// Storage context with a prefix applied to be used in a subtree to be used
-/// outside of transaction.
-pub struct PrefixedRocksDbStorageContext<'db> {
+/// Storage context with a prefix applied to be used in a subtree to be used in
+/// transaction.
+pub struct PrefixedRocksDbBatchTransactionContext<'db> {
     storage: &'db Db,
+    transaction: &'db Tx<'db>,
     prefix: Vec<u8>,
 }
 
-impl<'db> PrefixedRocksDbStorageContext<'db> {
-    /// Create a new prefixed storage context instance
-    pub fn new(storage: &'db Db, prefix: Vec<u8>) -> Self {
-        PrefixedRocksDbStorageContext { storage, prefix }
+impl<'db> PrefixedRocksDbBatchTransactionContext<'db> {
+    /// Create a new prefixed transaction context instance
+    pub fn new(storage: &'db Db, transaction: &'db Tx<'db>, prefix: Vec<u8>) -> Self {
+        PrefixedRocksDbBatchTransactionContext {
+            storage,
+            transaction,
+            prefix,
+        }
     }
 }
 
-impl<'db> PrefixedRocksDbStorageContext<'db> {
+impl<'db> PrefixedRocksDbBatchTransactionContext<'db> {
     /// Get auxiliary data column family
     fn cf_aux(&self) -> &'db ColumnFamily {
         self.storage
@@ -43,18 +49,22 @@ impl<'db> PrefixedRocksDbStorageContext<'db> {
     }
 }
 
-impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbStorageContext<'db> {
+impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbBatchTransactionContext<'db>
+where
+    'db: 'ctx,
+{
     type Batch = PrefixedRocksDbBatch<'db, WriteBatchWithTransaction<true>>;
+    // &'ctx Self;
     type Error = Error;
-    type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, Db>>;
+    type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, Tx<'db>>>;
 
     fn put<K: AsRef<[u8]>>(&self, key: K, value: &[u8]) -> Result<(), Self::Error> {
-        self.storage
+        self.transaction
             .put(make_prefixed_key(self.prefix.clone(), key), value)
     }
 
     fn put_aux<K: AsRef<[u8]>>(&self, key: K, value: &[u8]) -> Result<(), Self::Error> {
-        self.storage.put_cf(
+        self.transaction.put_cf(
             self.cf_aux(),
             make_prefixed_key(self.prefix.clone(), key),
             value,
@@ -62,7 +72,7 @@ impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbStorageContext<'db>
     }
 
     fn put_root<K: AsRef<[u8]>>(&self, key: K, value: &[u8]) -> Result<(), Self::Error> {
-        self.storage.put_cf(
+        self.transaction.put_cf(
             self.cf_roots(),
             make_prefixed_key(self.prefix.clone(), key),
             value,
@@ -70,7 +80,7 @@ impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbStorageContext<'db>
     }
 
     fn put_meta<K: AsRef<[u8]>>(&self, key: K, value: &[u8]) -> Result<(), Self::Error> {
-        self.storage.put_cf(
+        self.transaction.put_cf(
             self.cf_meta(),
             make_prefixed_key(self.prefix.clone(), key),
             value,
@@ -78,62 +88,59 @@ impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbStorageContext<'db>
     }
 
     fn delete<K: AsRef<[u8]>>(&self, key: K) -> Result<(), Self::Error> {
-        self.storage
+        self.transaction
             .delete(make_prefixed_key(self.prefix.clone(), key))
     }
 
     fn delete_aux<K: AsRef<[u8]>>(&self, key: K) -> Result<(), Self::Error> {
-        self.storage
+        self.transaction
             .delete_cf(self.cf_aux(), make_prefixed_key(self.prefix.clone(), key))
     }
 
     fn delete_root<K: AsRef<[u8]>>(&self, key: K) -> Result<(), Self::Error> {
-        self.storage
+        self.transaction
             .delete_cf(self.cf_roots(), make_prefixed_key(self.prefix.clone(), key))
     }
 
     fn delete_meta<K: AsRef<[u8]>>(&self, key: K) -> Result<(), Self::Error> {
-        self.storage
+        self.transaction
             .delete_cf(self.cf_meta(), make_prefixed_key(self.prefix.clone(), key))
     }
 
     fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.storage
+        self.transaction
             .get(make_prefixed_key(self.prefix.clone(), key))
     }
 
     fn get_aux<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.storage
+        self.transaction
             .get_cf(self.cf_aux(), make_prefixed_key(self.prefix.clone(), key))
     }
 
     fn get_root<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.storage
+        self.transaction
             .get_cf(self.cf_roots(), make_prefixed_key(self.prefix.clone(), key))
     }
 
     fn get_meta<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.storage
+        self.transaction
             .get_cf(self.cf_meta(), make_prefixed_key(self.prefix.clone(), key))
     }
 
-    fn new_batch(&self) -> Self::Batch {
-        PrefixedRocksDbBatch {
-            prefix: self.prefix.clone(),
-            batch: WriteBatchWithTransaction::<true>::default(),
-            cf_aux: self.cf_aux(),
-            cf_roots: self.cf_roots(),
-        }
+    fn new_batch(&'ctx self) -> Self::Batch {
+        todo!()
+        // self
     }
 
-    fn commit_batch(&self, batch: Self::Batch) -> Result<(), Self::Error> {
-        self.storage.write(batch.batch)
+    fn commit_batch(&'ctx self, _batch: Self::Batch) -> Result<(), Self::Error> {
+        todo!()
+        // Ok(())
     }
 
     fn raw_iter(&self) -> Self::RawIterator {
         PrefixedRocksDbRawIterator {
             prefix: self.prefix.clone(),
-            raw_iterator: self.storage.raw_iterator(),
+            raw_iterator: self.transaction.raw_iterator(),
         }
     }
 }

--- a/storage/src/rocksdb_storage/storage_context/context_batch_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_batch_tx.rs
@@ -1,10 +1,7 @@
 //! Storage context implementation with a transaction.
-use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, Error, WriteBatchWithTransaction};
+use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, Error};
 
-use super::{
-    batch::PrefixedMultiContextBatchPart, make_prefixed_key, PrefixedRocksDbBatch,
-    PrefixedRocksDbRawIterator,
-};
+use super::{batch::PrefixedMultiContextBatchPart, make_prefixed_key, PrefixedRocksDbRawIterator};
 use crate::{
     rocksdb_storage::storage::{Db, Tx, AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME},
     StorageBatch, StorageContext,

--- a/storage/src/rocksdb_storage/storage_context/context_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_tx.rs
@@ -1,9 +1,9 @@
 //! Storage context implementation with a transaction.
 use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, Error};
 
-use super::{make_prefixed_key, Db, PrefixedRocksDbRawIterator, Tx};
+use super::{make_prefixed_key, PrefixedRocksDbRawIterator};
 use crate::{
-    rocksdb_storage::storage::{AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME},
+    rocksdb_storage::storage::{Db, Tx, AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME},
     StorageContext,
 };
 

--- a/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
+++ b/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
@@ -3,7 +3,7 @@ use rocksdb::DBRawIteratorWithThreadMode;
 
 use super::make_prefixed_key;
 use crate::{
-    rocksdb_storage::storage_context::{Db, Tx},
+    rocksdb_storage::storage::{Db, Tx},
     RawIterator,
 };
 

--- a/storage/src/rocksdb_storage/test_utils.rs
+++ b/storage/src/rocksdb_storage/test_utils.rs
@@ -1,15 +1,19 @@
+//! Useful utilities for testing.
+
 use std::{cell::Cell, ops::Deref};
 
 use tempfile::TempDir;
 
 use super::*;
 
+/// RocksDb storage with self-cleanup
 pub struct TempStorage {
     dir: Cell<TempDir>,
     storage: RocksDbStorage,
 }
 
 impl TempStorage {
+    /// Create new `TempStorage`
     pub fn new() -> Self {
         let dir = TempDir::new().expect("cannot create tempir");
         let storage = RocksDbStorage::default_rocksdb_with_path(dir.path())
@@ -20,6 +24,7 @@ impl TempStorage {
         }
     }
 
+    /// Simulate storage crash
     pub fn crash(&self) {
         drop(
             self.dir

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -1,3 +1,9 @@
+use std::{
+    borrow::Borrow,
+    cell::{Ref, RefCell},
+    vec::IntoIter,
+};
+
 /// Top-level storage abstraction.
 /// Should be able to hold storage connection and to start transaction when
 /// needed. All query operations will be exposed using [StorageContext].
@@ -15,6 +21,12 @@ pub trait Storage<'db> {
     /// GATs
     type TransactionalStorageContext;
 
+    /// Storage context type for mutli-tree batch operations
+    type BatchStorageContext;
+
+    /// Storage context type for multi-tree batch operations inside transaction
+    type BatchTransactionalStorageContext;
+
     /// Error type
     type Error: std::error::Error + Send + Sync + 'static;
 
@@ -26,6 +38,9 @@ pub trait Storage<'db> {
 
     /// Rollback a transaction
     fn rollback_transaction(&self, transaction: &Self::Transaction) -> Result<(), Self::Error>;
+
+    /// Consumes and applies multi-context batch.
+    fn commit_multi_context_batch(&self, batch: StorageBatch) -> Result<(), Self::Error>;
 
     /// Forces data to be written
     fn flush(&self) -> Result<(), Self::Error>;
@@ -41,6 +56,25 @@ pub trait Storage<'db> {
         path: P,
         transaction: &'db Self::Transaction,
     ) -> Self::TransactionalStorageContext
+    where
+        P: IntoIterator<Item = &'p [u8]>;
+
+    /// Make batch storage context for a subtree with path
+    fn get_batch_storage_context<'p, P>(
+        &'db self,
+        path: P,
+        batch: &'db StorageBatch,
+    ) -> Self::BatchStorageContext
+    where
+        P: IntoIterator<Item = &'p [u8]>;
+
+    /// Make batch storage context for a subtree on transactional data
+    fn get_batch_transactional_storage_context<'p, P>(
+        &'db self,
+        path: P,
+        batch: &'db StorageBatch,
+        transaction: &'db Self::Transaction,
+    ) -> Self::BatchTransactionalStorageContext
     where
         P: IntoIterator<Item = &'p [u8]>;
 }
@@ -105,38 +139,176 @@ pub trait StorageContext<'db, 'ctx> {
     fn raw_iter(&self) -> Self::RawIterator;
 }
 
+/// Database batch (not to be confused with multi-tree operations batch).
 pub trait Batch {
+    /// Error type for failed operations on the batch.
     type Error: std::error::Error + Send + Sync + 'static;
 
+    /// Appends to the database batch a put operation for a data record.
     fn put<K: AsRef<[u8]>>(&mut self, key: K, value: &[u8]) -> Result<(), Self::Error>;
 
+    /// Appends to the database batch a put operation for aux storage.
     fn put_aux<K: AsRef<[u8]>>(&mut self, key: K, value: &[u8]) -> Result<(), Self::Error>;
 
+    /// Appends to the database batch a put operation for subtrees roots
+    /// storage.
     fn put_root<K: AsRef<[u8]>>(&mut self, key: K, value: &[u8]) -> Result<(), Self::Error>;
 
+    /// Appends to the database batch a delete operation for a data record.
     fn delete<K: AsRef<[u8]>>(&mut self, key: K) -> Result<(), Self::Error>;
 
+    /// Appends to the database batch a delete operation for aux storage.
     fn delete_aux<K: AsRef<[u8]>>(&mut self, key: K) -> Result<(), Self::Error>;
 
+    /// Appends to the database batch a delete operation for a record in subtree
+    /// roots storage.
     fn delete_root<K: AsRef<[u8]>>(&mut self, key: K) -> Result<(), Self::Error>;
 }
 
+/// Allows to iterate over database record inside of storage context.
 pub trait RawIterator {
+    /// Move iterator to first valid record.
     fn seek_to_first(&mut self);
 
+    /// Move iterator to last valid record.
     fn seek_to_last(&mut self);
 
+    /// Move iterator forward until `key` is hit.
     fn seek<K: AsRef<[u8]>>(&mut self, key: K);
 
+    /// Move iterator backward until `key` is hit.
     fn seek_for_prev<K: AsRef<[u8]>>(&mut self, key: K);
 
+    /// Move iterator to next record.
     fn next(&mut self);
 
+    /// Move iterator to previous record.
     fn prev(&mut self);
 
+    /// Return value of key-value pair where raw iterator points at.
     fn value(&self) -> Option<&[u8]>;
 
+    /// Return key of key-value pair where raw iterator points at.
     fn key(&self) -> Option<&[u8]>;
 
+    /// Check if raw iterator points into a valid record
     fn valid(&self) -> bool;
+}
+
+/// Structure to hold deferred database operations in "batched" storage
+/// contexts.
+pub struct StorageBatch {
+    operations: RefCell<Vec<BatchOperation>>,
+}
+
+impl StorageBatch {
+    /// Create empty batch.
+    pub fn new() -> Self {
+        StorageBatch {
+            operations: RefCell::new(Vec::new()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.operations.borrow().len()
+    }
+
+    /// Add deferred `put` operation
+    pub fn put(&self, key: Vec<u8>, value: Vec<u8>) {
+        self.operations
+            .borrow_mut()
+            .push(BatchOperation::Put { key, value })
+    }
+
+    /// Add deferred `put` operation for aux storage
+    pub fn put_aux(&self, key: Vec<u8>, value: Vec<u8>) {
+        self.operations
+            .borrow_mut()
+            .push(BatchOperation::PutAux { key, value })
+    }
+
+    /// Add deferred `put` operation for subtree roots storage
+    pub fn put_root(&self, key: Vec<u8>, value: Vec<u8>) {
+        self.operations
+            .borrow_mut()
+            .push(BatchOperation::PutRoot { key, value })
+    }
+
+    /// Add deferred `put` operation for metadata storage
+    pub fn put_meta(&self, key: Vec<u8>, value: Vec<u8>) {
+        self.operations
+            .borrow_mut()
+            .push(BatchOperation::PutMeta { key, value })
+    }
+
+    /// Add deferred `delete` operation
+    pub fn delete(&self, key: Vec<u8>) {
+        self.operations
+            .borrow_mut()
+            .push(BatchOperation::Delete { key })
+    }
+
+    /// Add deferred `delete` operation for aux storage
+    pub fn delete_aux(&self, key: Vec<u8>) {
+        self.operations
+            .borrow_mut()
+            .push(BatchOperation::DeleteAux { key })
+    }
+
+    /// Add deferred `delete` operation for subtree roots storage
+    pub fn delete_root(&self, key: Vec<u8>) {
+        self.operations
+            .borrow_mut()
+            .push(BatchOperation::DeleteRoot { key })
+    }
+
+    /// Add deferred `delete` operation for metadata storage
+    pub fn delete_meta(&self, key: Vec<u8>) {
+        self.operations
+            .borrow_mut()
+            .push(BatchOperation::DeleteMeta { key })
+    }
+
+    /// Return borrowed operations vec
+    pub fn borrow_ops(&self) -> Ref<Vec<BatchOperation>> {
+        self.operations.borrow()
+    }
+
+    /// Consume batch to get an iterator over operations
+    pub fn into_iter(self) -> IntoIter<BatchOperation> {
+        self.operations.into_inner().into_iter()
+    }
+
+    /// Merge batch into this one
+    pub fn merge(&self, other: StorageBatch) {
+        self.operations.borrow_mut().extend(other.into_iter());
+    }
+}
+
+impl Default for StorageBatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Deferred storage operation.
+#[allow(missing_docs)]
+pub enum BatchOperation {
+    /// Deferred put operation
+    Put { key: Vec<u8>, value: Vec<u8> },
+    /// Deferred put operation for aux storage
+    PutAux { key: Vec<u8>, value: Vec<u8> },
+    /// Deferred put operation for roots storage
+    PutRoot { key: Vec<u8>, value: Vec<u8> },
+    /// Deferred put operation for metadata storage
+    PutMeta { key: Vec<u8>, value: Vec<u8> },
+    /// Deferred delete operation
+    Delete { key: Vec<u8> },
+    /// Deferred delete operation for aux storage
+    DeleteAux { key: Vec<u8> },
+    /// Deferred delete operation for roots storage
+    DeleteRoot { key: Vec<u8> },
+    /// Deferred delete operation for metadata storage
+    DeleteMeta { key: Vec<u8> },
 }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Borrow,
     cell::{Ref, RefCell},
     vec::IntoIter,
 };

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -42,6 +42,13 @@ pub trait Storage<'db> {
     /// Consumes and applies multi-context batch.
     fn commit_multi_context_batch(&self, batch: StorageBatch) -> Result<(), Self::Error>;
 
+    /// Consumes and applies multi-context batch on transaction.
+    fn commit_multi_context_batch_with_transaction(
+        &self,
+        batch: StorageBatch,
+        transaction: &'db Self::Transaction,
+    ) -> Result<(), Self::Error>;
+
     /// Forces data to be written
     fn flush(&self) -> Result<(), Self::Error>;
 


### PR DESCRIPTION
This PR adds two storage contexts: one for cross-subtrees batches and another to do it inside transactions.

Note: while this adds a technical ability to apply changes to multiple subtrees in a single pass it's still not integrated with GroveDB