### PR TITLE
feat: propagate remaining limit and offset after verification

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -5,15 +5,11 @@ mod tests;
 mod util;
 #[cfg(feature = "visualize")]
 mod visualize;
-use std::{
-    collections::{BTreeMap, HashMap},
-    path::Path,
-};
+use std::{collections::BTreeMap, path::Path};
 
 pub use merk::proofs::{query::QueryItem, Query};
 use merk::{self, Merk};
 use rs_merkle::{algorithms::Sha256, MerkleTree};
-use serde::{Deserialize, Serialize};
 pub use storage::{
     rocksdb_storage::{self, RocksDbStorage},
     Storage, StorageContext,
@@ -68,7 +64,7 @@ pub enum Error {
     CorruptedData(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PathQuery {
     // TODO: Make generic over path type
     path: Vec<Vec<u8>>,
@@ -79,7 +75,7 @@ pub struct PathQuery {
 // limit should be applied to the elements returned by the subquery
 // offset should be applied to the first item that will subqueried (first in the
 // case of a range)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SizedQuery {
     query: Query,
     limit: Option<u16>,
@@ -105,14 +101,6 @@ impl PathQuery {
         let query = SizedQuery::new(query, None, None);
         Self { path, query }
     }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct Proof {
-    query_paths: Vec<Vec<Vec<u8>>>,
-    proofs: HashMap<Vec<u8>, Vec<u8>>,
-    root_proof: Vec<u8>,
-    root_leaf_keys: HashMap<Vec<u8>, usize>,
 }
 
 pub struct GroveDb {

--- a/grovedb/src/operations.rs
+++ b/grovedb/src/operations.rs
@@ -3,4 +3,4 @@ pub(crate) mod delete;
 pub(crate) mod get;
 pub(crate) mod insert;
 pub(crate) mod is_empty_tree;
-// pub(crate) mod proof;
+pub(crate) mod proof;

--- a/grovedb/src/operations/proof.rs
+++ b/grovedb/src/operations/proof.rs
@@ -1,261 +1,652 @@
-// use std::collections::HashMap;
-//
-// use merk::proofs::query::Map;
-// use rs_merkle::{algorithms::Sha256, MerkleProof};
-//
-// use crate::{Element, Error, GroveDb, PathQuery, Proof, Query};
-//
-// impl GroveDb {
-//     pub fn proof(&mut self, proof_queries: Vec<PathQuery>) -> Result<Vec<u8>,
-// Error> {         // To prove a path we need to return a proof for each node
-// on the path including         // the root. With multiple paths, nodes can
-// overlap i.e two or more paths can         // share the same nodes. We should
-// only have one proof for each node,         // if a node forks into multiple
-// relevant paths then we should create a         // combined proof for that
-// node with all the relevant keys         let mut query_paths = Vec::new();
-//         let mut intermediate_proof_spec: HashMap<Vec<u8>, Query> =
-// HashMap::new();         let mut root_keys: Vec<Vec<u8>> = Vec::new();
-//         let mut proofs: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
-//
-//         // For each unique node including the root
-//         // determine what keys would need to be included in the proof
-//         for proof_query in proof_queries.iter() {
-//             query_paths.push(
-//                 proof_query
-//                     .path
-//                     .iter()
-//                     .map(|x| x.to_vec())
-//                     .collect::<Vec<_>>(),
-//             );
-//
-//             let mut split_path = proof_query.path.split_last();
-//             while let Some((key, path_slice)) = split_path {
-//                 if path_slice.is_empty() {
-//                     // We have gotten to the root node
-//                     let compressed_path = GroveDb::compress_subtree_key(&[],
-// Some(key));                     root_keys.push(compressed_path);
-//                 } else {
-//                     let compressed_path =
-// GroveDb::compress_subtree_key(path_slice, None);                     if let
-// Some(path_query) = intermediate_proof_spec.get_mut(&compressed_path) {
-//                         path_query.insert_key(key.to_vec());
-//                     } else {
-//                         let mut path_query = Query::new();
-//                         path_query.insert_key(key.to_vec());
-//                         intermediate_proof_spec.insert(compressed_path,
-// path_query);                     }
-//                 }
-//                 split_path = path_slice.split_last();
-//             }
-//         }
-//
-//         // Construct the path proofs
-//         for (path, query) in intermediate_proof_spec {
-//             let proof = self.prove_item(&path, query)?;
-//             proofs.insert(path, proof);
-//         }
-//
-//         // Construct the leaf proofs
-//         for proof_query in proof_queries {
-//             let path = proof_query.path;
-//
-//             // If there is a subquery with a limit it's possible that we only
-// need a reduced             // proof for this leaf.
-//             let reduced_proof_query = proof_query;
-//
-//             // First we must get elements
-//
-//             if let Some(subquery_key) =
-// reduced_proof_query.query.query.subquery_key.clone() {
-// self.get_path_queries_raw(&[&reduced_proof_query], None)?;
-//
-//                 let mut path_vec = path.to_vec();
-//                 path_vec.push(subquery_key.as_slice());
-//                 let compressed_path =
-// GroveDb::compress_subtree_key(path_vec.as_slice(), None);             }
-//
-//             // Now we must insert the final proof for the sub leaves
-//             let compressed_path = GroveDb::compress_subtree_key(path, None);
-//             let proof = self.prove_path_item(&compressed_path,
-// reduced_proof_query)?;             proofs.insert(compressed_path, proof);
-//         }
-//
-//         // Construct the root proof
-//         let mut root_index: Vec<usize> = Vec::new();
-//         for key in root_keys {
-//             let index = self
-//                 .root_leaf_keys
-//                 .get(&key)
-//                 .ok_or(Error::InvalidPath("root key not found"))?;
-//             root_index.push(*index);
-//         }
-//         let root_proof = self.root_tree.proof(&root_index).to_bytes();
-//
-//         let proof = Proof {
-//             query_paths,
-//             proofs,
-//             root_proof,
-//             root_leaf_keys: self.root_leaf_keys.clone(),
-//         };
-//
-//         let serialized_proof = bincode::serialize(&proof)
-//             .map_err(|_| Error::CorruptedData(String::from("unable to
-// serialize proof")))?;
-//
-//         Ok(serialized_proof)
-//     }
-//
-//     fn prove_path_item(
-//         &self,
-//         compressed_path: &[u8],
-//         path_query: PathQuery,
-//     ) -> Result<Vec<u8>, Error> {
-//         let merk = self
-//             .subtrees
-//             .get(compressed_path)
-//             .ok_or(Error::InvalidPath("no subtree found under that path"))?;
-//
-//         let sized_query = path_query.query;
-//
-//         if sized_query.query.subquery.is_none() {
-//             // then limit should be applied directly to the proof here
-//             let proof_result = merk
-//                 .prove(
-//                     sized_query.query,
-//                     sized_query.limit,
-//                     sized_query.offset,
-//                 )
-//                 .expect("should prove both inclusion and absence");
-//             Ok(proof_result)
-//         } else {
-//             let proof_result = merk
-//                 .prove(sized_query.query, None, None)
-//                 .expect("should prove both inclusion and absence");
-//             Ok(proof_result)
-//         }
-//     }
-//
-//     fn prove_item(&self, path: &[u8], query: Query) -> Result<Vec<u8>,
-// Error> {         let merk = self
-//             .subtrees
-//             .get(path)
-//             .ok_or(Error::InvalidPath("no subtree found under that path"))?;
-//
-//         // then limit should be applied directly to the proof here
-//         let proof_result = merk
-//             .prove(query, None, None)
-//             .expect("should prove both inclusion and absence");
-//         Ok(proof_result)
-//     }
-//
-//     pub fn execute_proof(proof: Vec<u8>) -> Result<([u8; 32],
-// HashMap<Vec<u8>, Map>), Error> {         // Deserialize the proof
-//         let proof: Proof = bincode::deserialize(&proof)
-//             .map_err(|_| Error::CorruptedData(String::from("unable to
-// deserialize proof")))?;
-//
-//         // Required to execute the root proof
-//         let mut root_keys_index: Vec<usize> = Vec::new();
-//         let mut root_hashes: Vec<[u8; 32]> = Vec::new();
-//
-//         // Collects the result map for each query
-//         let mut result_map: HashMap<Vec<u8>, Map> = HashMap::new();
-//
-//         for path in proof.query_paths {
-//             let path = path.iter().map(|x| x.as_slice()).collect::<Vec<_>>();
-//             // For each query path, get the result map after execution
-//             // and store hash + index for later root proof execution
-//             let root_key = &path[0];
-//             let (hash, proof_result_map) = GroveDb::execute_path(&path,
-// &proof.proofs)?;             let compressed_root_key_path =
-// GroveDb::compress_subtree_key(&[], Some(root_key));             let
-// compressed_query_path = GroveDb::compress_subtree_key(&path, None);
-//
-//             let index = proof
-//                 .root_leaf_keys
-//                 .get(&compressed_root_key_path)
-//                 .ok_or(Error::InvalidPath("Bad path"))?;
-//             if !root_keys_index.contains(index) {
-//                 root_keys_index.push(*index);
-//                 root_hashes.push(hash);
-//             }
-//
-//             result_map.insert(compressed_query_path, proof_result_map);
-//         }
-//
-//         let root_proof = match
-// MerkleProof::<Sha256>::try_from(proof.root_proof) {             Ok(proof) =>
-// Ok(proof),             Err(_) => Err(Error::InvalidProof("Invalid proof
-// element")),         }?;
-//
-//         let root_hash =
-//             match root_proof.root(&root_keys_index, &root_hashes,
-// proof.root_leaf_keys.len()) {                 Ok(hash) => Ok(hash),
-//                 Err(_) => Err(Error::InvalidProof("Invalid proof element")),
-//             }?;
-//
-//         Ok((root_hash, result_map))
-//     }
-//
-//     // Given a query path and a set of proofs
-//     // execute_path validates that the nodes represented by the paths
-//     // are connected to one another i.e root hash of child node is in parent
-// node     // at the correct key.
-//     // If path is valid, it returns the root hash of topmost merk and result
-// map of     // leaf merk.
-//     fn execute_path(
-//         path: &[&[u8]],
-//         proofs: &HashMap<Vec<u8>, Vec<u8>>,
-//     ) -> Result<([u8; 32], Map), Error> {
-//         let compressed_path = GroveDb::compress_subtree_key(path, None);
-//         let proof = proofs
-//             .get(&compressed_path)
-//             .ok_or(Error::InvalidPath("Bad path"))?;
-//
-//         // Execute the leaf merk proof
-//         let (mut last_root_hash, result_map) = match
-// merk::execute_proof(&proof[..]) {             Ok(result) => Ok(result),
-//             Err(_) => Err(Error::InvalidPath("Invalid proof element")),
-//         }?;
-//
-//         // Validate the path
-//         let mut split_path = path.split_last();
-//         while let Some((key, path_slice)) = split_path {
-//             if !path_slice.is_empty() {
-//                 let compressed_path =
-// GroveDb::compress_subtree_key(path_slice, None);                 let proof =
-// proofs                     .get(&compressed_path)
-//                     .ok_or(Error::InvalidPath("Bad path"))?;
-//
-//                 let proof_result = match merk::execute_proof(&proof[..]) {
-//                     Ok(result) => Ok(result),
-//                     Err(_) => Err(Error::InvalidPath("Invalid proof
-// element")),                 }?;
-//
-//                 let result_map = proof_result.1;
-//                 // TODO: Handle the error better here
-//                 let elem: Element =
-//
-// bincode::deserialize(result_map.get(key).unwrap().unwrap()).unwrap();
-//                 let merk_root_hash = match elem {
-//                     Element::Tree(hash) => Ok(hash),
-//                     _ => Err(Error::InvalidProof(
-//                         "Intermediate proofs should be for trees",
-//                     )),
-//                 }?;
-//
-//                 if merk_root_hash != last_root_hash {
-//                     return Err(Error::InvalidProof("Bad path"));
-//                 }
-//
-//                 last_root_hash = proof_result.0;
-//             } else {
-//                 break;
-//             }
-//
-//             split_path = path_slice.split_last();
-//         }
-//
-//         Ok((last_root_hash, result_map))
-//     }
-// }
+use std::{
+    io::{Read, Write},
+    ptr::write,
+};
+
+use merk::{
+    proofs::query::{ProofVerificationResult, QueryItem},
+    Hash, Merk,
+};
+use rs_merkle::{algorithms::Sha256, MerkleProof};
+use storage::{rocksdb_storage::RocksDbStorage, StorageContext};
+
+use crate::{
+    merk::ProofConstructionResult,
+    subtree::raw_decode,
+    util::{merk_optional_tx, meta_storage_context_optional_tx},
+    Element, Error,
+    Error::{InvalidPath, InvalidProof},
+    GroveDb, PathQuery, Query, SizedQuery,
+};
+
+const EMPTY_TREE_HASH: [u8; 32] = [0; 32];
+
+#[derive(Debug, PartialEq)]
+enum ProofType {
+    MerkProof,
+    SizedMerkProof,
+    RootProof,
+    InvalidProof,
+}
+
+impl From<ProofType> for u8 {
+    fn from(proof_type: ProofType) -> Self {
+        match proof_type {
+            ProofType::MerkProof => 0x01,
+            ProofType::SizedMerkProof => 0x02,
+            ProofType::RootProof => 0x03,
+            ProofType::InvalidProof => 0x10,
+        }
+    }
+}
+
+impl From<u8> for ProofType {
+    fn from(val: u8) -> Self {
+        match val {
+            0x01 => ProofType::MerkProof,
+            0x02 => ProofType::SizedMerkProof,
+            0x03 => ProofType::RootProof,
+            _ => ProofType::InvalidProof,
+        }
+    }
+}
+
+impl GroveDb {
+    pub fn prove(&self, query: PathQuery) -> Result<Vec<u8>, Error> {
+        // TODO: should it be possible to generate proofs for tree items (currently yes)
+        let mut proof_result: Vec<u8> = vec![];
+
+        let path_slices = query.path.iter().map(|x| x.as_slice()).collect::<Vec<_>>();
+
+        if path_slices.len() < 1 {
+            return Err(Error::InvalidPath("can't generate proof for empty path"));
+        }
+
+        self.check_subtree_exists_path_not_found(path_slices.clone(), None, None)?;
+
+        let mut current_limit: Option<u16> = query.query.limit;
+        let mut current_offset: Option<u16> = query.query.offset;
+
+        GroveDb::prove_subqueries(
+            &self,
+            &mut proof_result,
+            path_slices.clone(),
+            query.clone(),
+            &mut current_limit,
+            &mut current_offset,
+        )?;
+
+        // generate a proof to show that the path leads up to the root
+        let mut split_path = path_slices.split_last();
+        while let Some((key, path_slice)) = split_path {
+            if path_slice.is_empty() {
+                // generate root proof
+                meta_storage_context_optional_tx!(self.db, None, meta_storage, {
+                    let root_leaf_keys = Self::get_root_leaf_keys_internal(&meta_storage)?;
+                    let mut index_to_prove: Vec<usize> = vec![];
+                    match root_leaf_keys.get(&key.to_vec()) {
+                        Some(index) => index_to_prove.push(*index),
+                        None => return Err(InvalidPath("invalid root key")),
+                    }
+                    let root_tree = self.get_root_tree(None).expect("should get root tree");
+                    let root_proof = root_tree.proof(&index_to_prove).to_bytes();
+
+                    debug_assert!(root_proof.len() < 256);
+                    write_to_vec(
+                        &mut proof_result,
+                        &vec![ProofType::RootProof.into(), root_proof.len() as u8],
+                    );
+                    write_to_vec(&mut proof_result, &root_proof);
+
+                    // write the number of root leafs
+                    // this makes the assumption that 1 byte is enough to represent the number of
+                    // root leafs i.e max of 255 root leaf keys
+                    // TODO: How do we enforce this? does it make sense to make this variable
+                    // length?
+                    write_to_vec(&mut proof_result, &vec![root_leaf_keys.len() as u8]);
+
+                    // add the index values required to prove the root
+                    let index_to_prove_as_bytes = index_to_prove
+                        .into_iter()
+                        .map(|index| index as u8)
+                        .collect::<Vec<u8>>();
+
+                    write_to_vec(&mut proof_result, &index_to_prove_as_bytes);
+                })
+            } else {
+                // generate proofs for the intermediate paths
+                let path_slices = path_slice.iter().map(|x| *x).collect::<Vec<_>>();
+
+                merk_optional_tx!(self.db, path_slices, None, subtree, {
+                    let mut query = Query::new();
+                    query.insert_key(key.to_vec());
+
+                    generate_and_store_merk_proof(
+                        &subtree,
+                        query,
+                        None,
+                        None,
+                        ProofType::MerkProof,
+                        &mut proof_result,
+                    );
+                });
+            }
+            split_path = path_slice.split_last();
+        }
+
+        Ok(proof_result)
+    }
+
+    pub fn execute_proof(
+        proof: &[u8],
+        query: PathQuery,
+    ) -> Result<([u8; 32], Vec<(Vec<u8>, Vec<u8>)>), Error> {
+        let path_slices = query.path.iter().map(|x| x.as_slice()).collect::<Vec<_>>();
+
+        if path_slices.len() < 1 {
+            return Err(Error::InvalidPath("can't verify proof for empty path"));
+        }
+
+        let mut result_set: Vec<(Vec<u8>, Vec<u8>)> = vec![];
+        let mut proof_reader = ProofReader::new(proof);
+
+        let mut current_limit = query.query.limit;
+        let mut current_offset = query.query.offset;
+
+        let mut expected_root_hash = GroveDb::execute_subquery_proof(
+            &mut proof_reader,
+            &mut result_set,
+            &mut current_limit,
+            &mut current_offset,
+            query.clone(),
+        )?;
+
+        // validate the path elements are connected
+        let mut split_path = path_slices.split_last();
+        while let Some((key, path_slice)) = split_path {
+            if !path_slice.is_empty() {
+                // for every subtree, we should have a corresponding proof for the parent
+                // which should prove that this subtree is a child of the parent tree
+                let parent_merk_proof =
+                    proof_reader.read_proof_of_type(ProofType::MerkProof.into())?;
+
+                let mut parent_query = Query::new();
+                parent_query.insert_key(key.to_vec());
+
+                let proof_result = execute_merk_proof(
+                    &parent_merk_proof,
+                    &parent_query,
+                    None,
+                    None,
+                    query.query.query.left_to_right,
+                )?;
+
+                let result_set = proof_result.1.result_set;
+                if result_set.len() == 0 || result_set[0].0 != key.to_vec() {
+                    return Err(Error::InvalidProof("proof invalid: invalid parent"));
+                }
+
+                let elem = Element::deserialize(result_set[0].1.as_slice())?;
+                let child_hash = match elem {
+                    Element::Tree(hash) => Ok(hash),
+                    _ => Err(Error::InvalidProof(
+                        "intermediate proofs should be for trees",
+                    )),
+                }?;
+
+                if child_hash != expected_root_hash {
+                    return Err(Error::InvalidProof("Bad path"));
+                }
+
+                expected_root_hash = proof_result.0;
+            } else {
+                break;
+            }
+            split_path = path_slice.split_last();
+        }
+
+        // execute the root proof
+        let root_proof_bytes = proof_reader.read_proof_of_type(ProofType::RootProof.into())?;
+
+        // makes the assumption that 1 byte is enough to represent the root leaf count
+        // hence max of 255 root leaf keys
+        let root_leaf_count = proof_reader.read_byte()?;
+
+        let index_to_prove_as_bytes = proof_reader.read_to_end();
+        let index_to_prove_as_usize = index_to_prove_as_bytes
+            .into_iter()
+            .map(|index| index as usize)
+            .collect::<Vec<usize>>();
+
+        let root_proof = match MerkleProof::<Sha256>::try_from(root_proof_bytes) {
+            Ok(proof) => Ok(proof),
+            Err(_) => Err(Error::InvalidProof("invalid proof element")),
+        }?;
+
+        let root_hash = match root_proof.root(
+            &index_to_prove_as_usize,
+            &[expected_root_hash],
+            root_leaf_count[0] as usize,
+        ) {
+            Ok(hash) => Ok(hash),
+            Err(_) => Err(Error::InvalidProof("Invalid proof element")),
+        }?;
+
+        Ok((root_hash, result_set))
+    }
+
+    fn prove_subqueries(
+        db: &GroveDb,
+        proofs: &mut Vec<u8>,
+        path: Vec<&[u8]>,
+        query: PathQuery,
+        current_limit: &mut Option<u16>,
+        current_offset: &mut Option<u16>,
+    ) -> Result<(), Error> {
+        // there is a chance that the subquery key would lead to something that is not a
+        // tree same thing for the subquery itself
+        merk_optional_tx!(db.db, path.clone(), None, subtree, {
+            let mut has_useful_subtree = false;
+            let exhausted_limit = query.query.limit.is_some() && query.query.limit.unwrap() == 0;
+
+            if !exhausted_limit {
+                let subtree_key_values = subtree.get_kv_pairs(query.query.query.left_to_right);
+                for (key, value_bytes) in subtree_key_values.iter() {
+                    let (subquery_key, subquery_value) =
+                        Element::subquery_paths_for_sized_query(&query.query, key);
+
+                    if subquery_key.is_none() && subquery_value.is_none() {
+                        continue;
+                    }
+
+                    let element = raw_decode(value_bytes)?;
+
+                    match element {
+                        // TODO: Look here when dealing with references
+                        Element::Tree(tree_hash) => {
+                            if tree_hash == EMPTY_TREE_HASH {
+                                continue;
+                            }
+
+                            if !has_useful_subtree {
+                                has_useful_subtree = true;
+
+                                let mut all_key_query =
+                                    Query::new_with_direction(query.query.query.left_to_right);
+                                all_key_query.insert_all();
+
+                                generate_and_store_merk_proof(
+                                    &subtree,
+                                    all_key_query,
+                                    None,
+                                    None,
+                                    ProofType::MerkProof,
+                                    proofs,
+                                );
+                            }
+
+                            let mut new_path = path.clone();
+                            new_path.push(key.as_ref());
+
+                            let mut query = subquery_value.clone();
+                            let sub_key = subquery_key.clone();
+
+                            if query.is_some() {
+                                if sub_key.is_some() {
+                                    // intermediate step here, generate a proof that show
+                                    // the existence or absence of the subquery key
+                                    merk_optional_tx!(
+                                        db.db,
+                                        new_path.clone(),
+                                        None,
+                                        inner_subtree,
+                                        {
+                                            let mut key_as_query = Query::new();
+                                            key_as_query.insert_key(sub_key.clone().unwrap());
+
+                                            generate_and_store_merk_proof(
+                                                &inner_subtree,
+                                                key_as_query,
+                                                None,
+                                                None,
+                                                ProofType::MerkProof,
+                                                proofs,
+                                            );
+                                        }
+                                    );
+
+                                    new_path.push(sub_key.as_ref().unwrap());
+
+                                    let subquery_key_path_exists = db
+                                        .check_subtree_exists_path_not_found(
+                                            new_path.clone(),
+                                            None,
+                                            None,
+                                        );
+
+                                    if subquery_key_path_exists.is_err() {
+                                        dbg!("leaving");
+                                        continue;
+                                    }
+                                }
+                            } else {
+                                let mut key_as_query = Query::new();
+                                key_as_query.insert_key(sub_key.unwrap());
+                                query = Some(key_as_query);
+                            }
+
+                            let new_path_owned = new_path.iter().map(|x| x.to_vec()).collect();
+                            let new_path_query =
+                                PathQuery::new_unsized(new_path_owned, query.unwrap());
+
+                            GroveDb::prove_subqueries(
+                                db,
+                                proofs,
+                                new_path,
+                                new_path_query,
+                                current_limit,
+                                current_offset,
+                            )?;
+
+                            // if we hit the limit, we should kill the loop
+                            if current_limit.is_some() && current_limit.unwrap() == 0 {
+                                break;
+                            }
+                        }
+                        _ => {
+                            // Current implementation makes the assumption that all elements of
+                            // a result set are of the same type i.e either all trees, all items
+                            // e.t.c and not mixed types.
+                            // This ensures that invariant is preserved
+                            debug_assert!(has_useful_subtree == false);
+                        }
+                    }
+                }
+            }
+
+            // TODO: Explore the chance that a subquerykey might lead to non tree element
+            if !has_useful_subtree {
+                // if no useful subtree, then we care about the result set of this subtree.
+                // apply the sized query
+                let limit_offset = generate_and_store_merk_proof(
+                    &subtree,
+                    query.query.query,
+                    *current_limit,
+                    *current_offset,
+                    ProofType::SizedMerkProof,
+                    proofs,
+                );
+
+                // update limit and offset values
+                *current_limit = limit_offset.0;
+                *current_offset = limit_offset.1;
+            }
+        });
+
+        Ok(())
+    }
+
+    fn execute_subquery_proof(
+        proof_reader: &mut ProofReader,
+        result_set: &mut Vec<(Vec<u8>, Vec<u8>)>,
+        current_limit: &mut Option<u16>,
+        current_offset: &mut Option<u16>,
+        query: PathQuery,
+    ) -> Result<[u8; 32], Error> {
+        let root_hash: [u8; 32];
+        let (proof_type, proof) = proof_reader.read_proof()?;
+        match proof_type {
+            ProofType::SizedMerkProof => {
+                let verification_result = execute_merk_proof(
+                    &proof,
+                    &query.query.query,
+                    *current_limit,
+                    *current_offset,
+                    query.query.query.left_to_right,
+                )?;
+
+                root_hash = verification_result.0;
+                result_set.extend(verification_result.1.result_set);
+
+                // update limit and offset
+                *current_limit = verification_result.1.limit;
+                *current_offset = verification_result.1.offset;
+            }
+            ProofType::MerkProof => {
+                // for non leaf subtrees, we want to prove that all their keys
+                // have an accompanying proof as long as the limit is non zero
+                // and their child subtree is not empty
+                let mut all_key_query = Query::new_with_direction(query.query.query.left_to_right);
+                all_key_query.insert_all();
+
+                let verification_result = execute_merk_proof(
+                    &proof,
+                    &all_key_query,
+                    None,
+                    None,
+                    all_key_query.left_to_right,
+                )?;
+
+                root_hash = verification_result.0;
+
+                for (key, value_bytes) in verification_result.1.result_set {
+                    let child_element = Element::deserialize(value_bytes.as_slice())?;
+                    match child_element {
+                        Element::Tree(mut expected_root_hash) => {
+                            if expected_root_hash == EMPTY_TREE_HASH {
+                                // child node is empty, move on to next
+                                continue;
+                            }
+
+                            if current_limit == Some(0) {
+                                // we are done verifying the subqueries
+                                break;
+                            }
+
+                            let (subquery_key, subquery_value) =
+                                Element::subquery_paths_for_sized_query(
+                                    &query.query,
+                                    key.as_slice(),
+                                );
+
+                            if subquery_value.is_none() && subquery_key.is_none() {
+                                continue;
+                            }
+
+                            if subquery_key.is_some() {
+                                // prove that the subquery key was used, update the expected hash
+                                // if the proof shows absence, path is no longer useful
+                                // move on to next
+                                let (proof_type, subkey_proof) = proof_reader.read_proof()?;
+                                if proof_type != ProofType::MerkProof {
+                                    return Err(Error::InvalidProof(
+                                        "expected unsized merk proof for subquery key",
+                                    ));
+                                }
+
+                                let mut key_as_query = Query::new();
+                                key_as_query.insert_key(subquery_key.clone().unwrap());
+
+                                let verification_result = execute_merk_proof(
+                                    &subkey_proof,
+                                    &key_as_query,
+                                    None,
+                                    None,
+                                    key_as_query.left_to_right,
+                                )?;
+
+                                let subquery_key_result_set = verification_result.1.result_set;
+                                if subquery_key_result_set.len() == 0 {
+                                    // subquery key does not exist in the subtree
+                                    // proceed to another subtree
+                                    continue;
+                                } else {
+                                    let elem_value = &subquery_key_result_set[0].1;
+                                    let subquery_key_element =
+                                        Element::deserialize(elem_value).unwrap();
+                                    match subquery_key_element {
+                                        Element::Tree(new_exptected_hash) => {
+                                            expected_root_hash = new_exptected_hash;
+                                        }
+                                        _ => {
+                                            // the means that the subquery key pointed to a non tree
+                                            // element
+                                            // what do you do in that case, say it points to an item
+                                            // or reference
+                                            // pointing to a non tree element means we cannot apply
+                                            // TODO: Remove panic
+                                            panic!("figure out what to do in this case");
+                                        }
+                                    }
+                                }
+                            }
+
+                            let new_path_query;
+                            if subquery_value.is_some() {
+                                new_path_query =
+                                    PathQuery::new_unsized(vec![], subquery_value.unwrap());
+                            } else {
+                                let mut key_as_query = Query::new();
+                                key_as_query.insert_key(subquery_key.unwrap());
+                                new_path_query = PathQuery::new_unsized(vec![], key_as_query);
+                            }
+
+                            let child_hash = GroveDb::execute_subquery_proof(
+                                proof_reader,
+                                result_set,
+                                current_limit,
+                                current_offset,
+                                new_path_query,
+                            )?;
+
+                            if child_hash != expected_root_hash {
+                                return Err(Error::InvalidProof(
+                                    "child hash doesn't match the expected hash",
+                                ));
+                            }
+                        }
+                        _ => {
+                            // TODO: why this error??
+                            return Err(Error::InvalidProof("Missing proof for subtree"));
+                        }
+                    }
+                }
+            }
+            _ => {
+                // execute_subquery_proof only expects proofs for merk trees
+                // root proof is handled separately
+                return Err(Error::InvalidProof("wrong proof type"));
+            }
+        }
+        Ok(root_hash)
+    }
+}
+
+// Helpers
+// TODO: Extract into seperate files
+#[derive(Debug)]
+struct ProofReader<'a> {
+    proof_data: &'a [u8],
+}
+
+impl<'a> ProofReader<'a> {
+    fn new(proof_data: &'a [u8]) -> Self {
+        Self { proof_data }
+    }
+
+    // TODO: handle error (e.g. not enough bytes to read)
+    fn read_byte(&mut self) -> Result<[u8; 1], Error> {
+        let mut data = [0; 1];
+        self.proof_data.read(&mut data);
+        Ok(data)
+    }
+
+    fn read_proof(&mut self) -> Result<(ProofType, Vec<u8>), Error> {
+        self.read_proof_with_optional_type(None)
+    }
+
+    fn read_proof_of_type(&mut self, expected_data_type: u8) -> Result<Vec<u8>, Error> {
+        match self.read_proof_with_optional_type(Some(expected_data_type)) {
+            Ok((_, proof)) => Ok(proof),
+            Err(e) => Err(e),
+        }
+    }
+
+    // TODO: handle error (e.g. not enough bytes to read)
+    fn read_proof_with_optional_type(
+        &mut self,
+        expected_data_type_option: Option<u8>,
+    ) -> Result<(ProofType, Vec<u8>), Error> {
+        let mut data_type = [0; 1];
+        self.proof_data.read(&mut data_type);
+
+        if let Some(expected_data_type) = expected_data_type_option {
+            if data_type != [expected_data_type] {
+                return Err(Error::InvalidProof("wrong data_type"));
+            }
+        }
+
+        // TODO: This should not be the invalid proof type
+        let proof_type: ProofType = data_type[0].into();
+
+        let mut length = vec![0; 1];
+        self.proof_data.read(&mut length);
+        let mut proof = vec![0; length[0] as usize];
+        self.proof_data.read(&mut proof);
+
+        Ok((proof_type, proof))
+    }
+
+    fn read_to_end(&mut self) -> Vec<u8> {
+        let mut data = vec![];
+        self.proof_data.read_to_end(&mut data);
+        data
+    }
+}
+
+// TODO: Isn't it possible for this to return some kind of error?
+fn generate_and_store_merk_proof<'a, S: 'a>(
+    subtree: &'a Merk<S>,
+    query: Query,
+    limit: Option<u16>,
+    offset: Option<u16>,
+    proof_type: ProofType,
+    proofs: &mut Vec<u8>,
+) -> (Option<u16>, Option<u16>)
+where
+    S: StorageContext<'a, 'a>,
+{
+    // TODO: How do you handle mixed tree types?
+    let proof_result = subtree
+        .prove(query, limit, offset)
+        .expect("should generate proof");
+
+    // TODO: Switch to variable length encoding
+    debug_assert!(proof_result.proof.len() < 256);
+    write_to_vec(
+        proofs,
+        &vec![proof_type.into(), proof_result.proof.len() as u8],
+    );
+    write_to_vec(proofs, &proof_result.proof);
+
+    (proof_result.limit, proof_result.offset)
+}
+
+fn write_to_vec<W: Write>(dest: &mut W, value: &Vec<u8>) {
+    dest.write_all(value);
+}
+
+fn execute_merk_proof(
+    proof: &Vec<u8>,
+    query: &Query,
+    limit: Option<u16>,
+    offset: Option<u16>,
+    left_to_right: bool,
+) -> Result<(Hash, ProofVerificationResult), Error> {
+    Ok(
+        merk::execute_proof(proof, query, limit, offset, left_to_right).map_err(|e| {
+            eprintln!("{}", e.to_string());
+            Error::InvalidProof("invalid proof verification parameters")
+        })?,
+    )
+}

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -254,7 +254,7 @@ impl Element {
         Ok(())
     }
 
-    fn subquery_paths_for_sized_query(
+    pub fn subquery_paths_for_sized_query(
         sized_query: &SizedQuery,
         key: &[u8],
     ) -> (Option<Vec<u8>>, Option<Query>) {
@@ -268,6 +268,24 @@ impl Element {
                 return (subquery_key, subquery);
             }
         }
+        let subquery_key = sized_query
+            .query
+            .default_subquery_branch
+            .subquery_key
+            .clone();
+        let subquery = sized_query
+            .query
+            .default_subquery_branch
+            .subquery
+            .as_ref()
+            .map(|query| *query.clone());
+        (subquery_key, subquery)
+    }
+
+    // TODO: Remove once you implement conditional subqueries
+    pub fn default_subquery_paths_for_sized_query(
+        sized_query: &SizedQuery,
+    ) -> (Option<Vec<u8>>, Option<Query>) {
         let subquery_key = sized_query
             .query
             .default_subquery_branch

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -11,6 +11,7 @@ use super::*;
 
 pub const TEST_LEAF: &[u8] = b"test_leaf";
 const ANOTHER_TEST_LEAF: &[u8] = b"test_leaf2";
+const DEEP_LEAF: &[u8] = b"deep_leaf";
 
 /// GroveDB wrapper to keep temp directory alive
 pub struct TempGroveDb {
@@ -57,6 +58,260 @@ fn add_test_leafs(db: &mut GroveDb) {
         .expect("successful root tree leaf insert");
     db.insert([], ANOTHER_TEST_LEAF, Element::empty_tree(), None)
         .expect("successful root tree leaf 2 insert");
+}
+
+fn make_deep_tree() -> TempGroveDb {
+    // Tree Structure
+    // root
+    //     test_leaf
+    //         innertree
+    //             k1,v1
+    //             k2,v2
+    //             k3,v3
+    //         innertree4
+    //             k4,v4
+    //             k5,v5
+    //     another_test_leaf
+    //         innertree2
+    //             k3,v3
+    //         innertree3
+    //             k4,v4
+    //     deep_leaf
+    //          deep_node_1
+    //              deeper_node_1
+    //                  k1,v1
+    //                  k2,v2
+    //                  k3,v3
+    //              deeper_node_2
+    //                  k4,v4
+    //                  k5,v5
+    //                  k6,v6
+    //          deep_node_2
+    //              deeper_node_3
+    //                  k7,v7
+    //                  k8,v8
+    //                  k9,v9
+    //              deeper_node_4
+    //                  k10,v10
+    //                  k11,v11
+
+    // Insert elements into grovedb instance
+    let temp_db = make_grovedb();
+
+    // add an extra root leaf
+    temp_db
+        .insert([], DEEP_LEAF, Element::empty_tree(), None)
+        .expect("successful root tree leaf insert");
+
+    // Insert level 1 nodes
+    temp_db
+        .insert([TEST_LEAF], b"innertree", Element::empty_tree(), None)
+        .expect("successful subtree insert");
+    temp_db
+        .insert([TEST_LEAF], b"innertree4", Element::empty_tree(), None)
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [ANOTHER_TEST_LEAF],
+            b"innertree2",
+            Element::empty_tree(),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [ANOTHER_TEST_LEAF],
+            b"innertree3",
+            Element::empty_tree(),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert([DEEP_LEAF], b"deep_node_1", Element::empty_tree(), None)
+        .expect("successful subtree insert");
+    temp_db
+        .insert([DEEP_LEAF], b"deep_node_2", Element::empty_tree(), None)
+        .expect("successful subtree insert");
+    // Insert level 2 nodes
+    temp_db
+        .insert(
+            [TEST_LEAF, b"innertree"],
+            b"key1",
+            Element::Item(b"value1".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [TEST_LEAF, b"innertree"],
+            b"key2",
+            Element::Item(b"value2".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [TEST_LEAF, b"innertree"],
+            b"key3",
+            Element::Item(b"value3".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [TEST_LEAF, b"innertree4"],
+            b"key4",
+            Element::Item(b"value4".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [TEST_LEAF, b"innertree4"],
+            b"key5",
+            Element::Item(b"value5".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [ANOTHER_TEST_LEAF, b"innertree2"],
+            b"key3",
+            Element::Item(b"value3".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [ANOTHER_TEST_LEAF, b"innertree3"],
+            b"key4",
+            Element::Item(b"value4".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_1"],
+            b"deeper_node_1",
+            Element::empty_tree(),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_1"],
+            b"deeper_node_2",
+            Element::empty_tree(),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_2"],
+            b"deeper_node_3",
+            Element::empty_tree(),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_2"],
+            b"deeper_node_4",
+            Element::empty_tree(),
+            None,
+        )
+        .expect("successful subtree insert");
+    // Insert level 3 nodes
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_1", b"deeper_node_1"],
+            b"key1",
+            Element::Item(b"value1".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_1", b"deeper_node_1"],
+            b"key2",
+            Element::Item(b"value2".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_1", b"deeper_node_1"],
+            b"key3",
+            Element::Item(b"value3".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_1", b"deeper_node_2"],
+            b"key4",
+            Element::Item(b"value4".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_1", b"deeper_node_2"],
+            b"key5",
+            Element::Item(b"value5".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_1", b"deeper_node_2"],
+            b"key6",
+            Element::Item(b"value6".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_2", b"deeper_node_3"],
+            b"key7",
+            Element::Item(b"value7".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_2", b"deeper_node_3"],
+            b"key8",
+            Element::Item(b"value8".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_2", b"deeper_node_3"],
+            b"key9",
+            Element::Item(b"value9".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_2", b"deeper_node_4"],
+            b"key10",
+            Element::Item(b"value10".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [DEEP_LEAF, b"deep_node_2", b"deeper_node_4"],
+            b"key11",
+            Element::Item(b"value11".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
 }
 
 #[test]
@@ -253,388 +508,527 @@ fn test_root_tree_leafs_are_noted() {
     assert_eq!(db.get_root_tree(None).unwrap().leaves_len(), 2);
 }
 
-// #[test]
-// fn test_proof_construction() {
-//     // Tree Structure
-//     // root
-//     //     test_leaf
-//     //         innertree
-//     //             k1,v1
-//     //             k2,v2
-//     //     another_test_leaf
-//     //         innertree2
-//     //             k3,v3
-//     //         innertree3
-//     //             k4,v4
-//
-//     // Insert elements into grovedb instance
-//     let mut temp_db = make_grovedb();
-//     // Insert level 1 nodes
-//     temp_db
-//         .insert(
-//             [TEST_LEAF],
-//             b"innertree",
-//             Element::empty_tree(),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     temp_db
-//         .insert(
-//             &[ANOTHER_TEST_LEAF],
-//             b"innertree2",
-//             Element::empty_tree(),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     temp_db
-//         .insert(
-//             &[ANOTHER_TEST_LEAF],
-//             b"innertree3",
-//             Element::empty_tree(),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     // Insert level 2 nodes
-//     temp_db
-//         .insert(
-//             &[TEST_LEAF, b"innertree"],
-//             b"key1",
-//             Element::Item(b"value1"),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     temp_db
-//         .insert(
-//             &[TEST_LEAF, b"innertree"],
-//             b"key2",
-//             Element::Item(b"value2".to_vec()),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     temp_db
-//         .insert(
-//             &[ANOTHER_TEST_LEAF, b"innertree2"],
-//             b"key3",
-//             Element::Item(b"value3".to_vec()),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     temp_db
-//         .insert(
-//             &[ANOTHER_TEST_LEAF, b"innertree3"],
-//             b"key4",
-//             Element::Item(b"value4".to_vec()),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//
-//     // Manually construct HADS bottom up
-//     // Insert level 2 nodes
-//     let mut inner_tree = TempMerk::new();
-//     let value_one = Element::Item(b"value1".to_vec());
-//     value_one
-//         .insert(&mut inner_tree, b"key1", None)
-//         .unwrap();
-//     let value_two = Element::Item(b"value2".to_vec());
-//     value_two
-//         .insert(&mut inner_tree, b"key2", None)
-//         .unwrap();
-//
-//     let mut inner_tree_2 = TempMerk::new();
-//     let value_three = Element::Item(b"value3".to_vec());
-//     value_three
-//         .insert(&mut inner_tree_2, b"key3", None)
-//         .unwrap();
-//
-//     let mut inner_tree_3 = TempMerk::new();
-//     let value_four = Element::Item(b"value4".to_vec());
-//     value_four
-//         .insert(&mut inner_tree_3, b"key4", None)
-//         .unwrap();
-//     // Insert level 1 nodes
-//     let mut test_leaf = TempMerk::new();
-//     let inner_tree_root = Element::Tree(inner_tree.root_hash());
-//     inner_tree_root
-//         .insert(&mut test_leaf, b"innertree", None)
-//         .unwrap();
-//     let mut another_test_leaf = TempMerk::new();
-//     let inner_tree_2_root = Element::Tree(inner_tree_2.root_hash());
-//     inner_tree_2_root
-//         .insert(&mut another_test_leaf, b"innertree2", None)
-//         .unwrap();
-//     let inner_tree_3_root = Element::Tree(inner_tree_3.root_hash());
-//     inner_tree_3_root
-//         .insert(&mut another_test_leaf, b"innertree3", None)
-//         .unwrap();
-//     // Insert root nodes
-//     let leaves = [test_leaf.root_hash(), another_test_leaf.root_hash()];
-//     let root_tree = MerkleTree::<Sha256>::from_leaves(&leaves);
-//
-//     // Proof construction
-//     // Generating a proof for two paths
-//     // root -> test_leaf -> innertree (prove both k1 and k2)
-//     // root -> another_test_leaf -> innertree3 (prove k4)
-//     // root -> another_test_leaf -> innertree2 (prove k3)
-//
-//     // Build reusable query objects
-//     let mut path_one_query = Query::new();
-//     path_one_query.insert_key(b"key1");
-//     path_one_query.insert_key(b"key2");
-//
-//     let mut path_two_query = Query::new();
-//     path_two_query.insert_key(b"key4".to_vec());
-//
-//     let mut path_three_query = Query::new();
-//     path_three_query.insert_key(b"key3");
-//
-//     // Get grovedb proof
-//     let proof = temp_db
-//         .proof(vec![
-//             PathQuery::new_unsized(&[TEST_LEAF, b"innertree"],
-// path_one_query),             PathQuery::new_unsized(&[ANOTHER_TEST_LEAF,
-// b"innertree3"], path_two_query),
-// PathQuery::new_unsized(&[ANOTHER_TEST_LEAF, b"innertree2"],
-// path_three_query),         ])
-//         .unwrap();
-//
-//     // Deserialize the proof
-//     let proof: Proof = bincode::deserialize(&proof).unwrap();
-//
-//     // Perform assertions
-//     assert_eq!(proof.query_paths.len(), 3);
-//     assert_eq!(proof.query_paths[0], &[TEST_LEAF, b"innertree"]);
-//     assert_eq!(proof.query_paths[1], &[ANOTHER_TEST_LEAF, b"innertree3"]);
-//     assert_eq!(proof.query_paths[2], &[ANOTHER_TEST_LEAF, b"innertree2"]);
-//
-//     // For path 1 to path 3, there are 9 nodes
-//     // root is repeated three times and another_test_leaf is repeated twice
-//     // Accounting for duplication, there are 6 unique nodes
-//     // root, test_leaf, another_test_leaf, innertree, innertree2, innertree3
-//     // proof.proofs contains all nodes except the root so we expect 5 sub
-// proofs     assert_eq!(proof.proofs.len(), 5);
-//
-//     // Check that all the subproofs were constructed correctly for each path
-// and     // subpath
-//     let path_one_as_vec = GroveDb::compress_subtree_key(&[TEST_LEAF,
-// b"innertree"], None);     let path_two_as_vec =
-// GroveDb::compress_subtree_key(&[ANOTHER_TEST_LEAF, b"innertree3"], None);
-//     let path_three_as_vec =
-//         GroveDb::compress_subtree_key(&[ANOTHER_TEST_LEAF, b"innertree2"],
-// None);     let test_leaf_path_as_vec =
-// GroveDb::compress_subtree_key([TEST_LEAF], None);
-//     let another_test_leaf_path_as_vec =
-// GroveDb::compress_subtree_key(&[ANOTHER_TEST_LEAF], None);
-//
-//     let proof_for_path_one = proof.proofs.get(&path_one_as_vec).unwrap();
-//     let proof_for_path_two = proof.proofs.get(&path_two_as_vec).unwrap();
-//     let proof_for_path_three = proof.proofs.get(&path_three_as_vec).unwrap();
-//     let proof_for_test_leaf =
-// proof.proofs.get(&test_leaf_path_as_vec).unwrap();
-//     let proof_for_another_test_leaf =
-// proof.proofs.get(&another_test_leaf_path_as_vec).unwrap();
-//
-//     // Assert path 1 proof
-//     let mut proof_query = Query::new();
-//     proof_query.insert_key(b"key1");
-//     proof_query.insert_key(b"key2");
-//     assert_eq!(
-//         *proof_for_path_one,
-//         inner_tree.prove(proof_query, None, None).unwrap()
-//     );
-//
-//     // Assert path 2 proof
-//     let mut proof_query = Query::new();
-//     proof_query.insert_key(b"key4".to_vec());
-//     assert_eq!(
-//         *proof_for_path_two,
-//         inner_tree_3.prove(proof_query, None, None).unwrap()
-//     );
-//
-//     // Assert path 3 proof
-//     let mut proof_query = Query::new();
-//     proof_query.insert_key(b"key3");
-//     assert_eq!(
-//         *proof_for_path_three,
-//         inner_tree_2.prove(proof_query, None, None).unwrap()
-//     );
-//
-//     // Assert test leaf proof
-//     let mut proof_query = Query::new();
-//     proof_query.insert_key(b"innertree".to_vec());
-//     assert_eq!(
-//         *proof_for_test_leaf,
-//         test_leaf.prove(proof_query, None, None).unwrap()
-//     );
-//
-//     // Assert another test leaf proof
-//     // another test leaf appeared in two path,
-//     // hence it should contain proofs for both keys
-//     let mut proof_query = Query::new();
-//     proof_query.insert_key(b"innertree2".to_vec());
-//     proof_query.insert_key(b"innertree3".to_vec());
-//     assert_eq!(
-//         *proof_for_another_test_leaf,
-//         another_test_leaf
-//             .prove(proof_query, None, None)
-//             .unwrap()
-//     );
-//
-//     // Check that the root proof is valid
-//     // Root proof should contain proof for both test_leaf and
-// another_test_leaf     let test_leaf_root_key =
-// GroveDb::compress_subtree_key(&[], Some(TEST_LEAF));
-//     let another_test_leaf_root_key = GroveDb::compress_subtree_key(&[],
-// Some(ANOTHER_TEST_LEAF));     assert_eq!(
-//         proof.root_proof,
-//         root_tree
-//             .proof(&[
-//                 temp_db.root_leaf_keys[&test_leaf_root_key],
-//                 temp_db.root_leaf_keys[&another_test_leaf_root_key],
-//             ])
-//             .to_bytes()
-//     );
-//
-//     // Assert that we got the correct root leaf keys
-//     assert_eq!(proof.root_leaf_keys.len(), 2);
-//     assert_eq!(proof.root_leaf_keys[&test_leaf_root_key], 0);
-//     assert_eq!(proof.root_leaf_keys[&another_test_leaf_root_key], 1);
-// }
+#[test]
+fn test_path_query_proofs_without_subquery() {
+    // Tree Structure
+    // root
+    //     test_leaf
+    //         innertree
+    //             k1,v1
+    //             k2,v2
+    //             k3,v3
+    //     another_test_leaf
+    //         innertree2
+    //             k3,v3
+    //         innertree3
+    //             k4,v4
 
-// #[test]
-// fn test_successful_proof_verification() {
-//     // Build a grovedb database
-//     // Tree Structure
-//     // root
-//     //     test_leaf
-//     //         innertree
-//     //             k1,v1
-//     //             k2,v2
-//     //     another_test_leaf
-//     //         innertree2
-//     //             k3,v3
-//     //         innertree3
-//     //             k4,v4
-//
-//     // Insert elements into grovedb instance
-//     let mut temp_db = make_grovedb();
-//     // Insert level 1 nodes
-//     temp_db
-//         .insert(
-//             [TEST_LEAF],
-//             b"innertree",
-//             Element::empty_tree(),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     temp_db
-//         .insert(
-//             &[ANOTHER_TEST_LEAF],
-//             b"innertree2",
-//             Element::empty_tree(),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     temp_db
-//         .insert(
-//             &[ANOTHER_TEST_LEAF],
-//             b"innertree3",
-//             Element::empty_tree(),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     // Insert level 2 nodes
-//     temp_db
-//         .insert(
-//             &[TEST_LEAF, b"innertree"],
-//             b"key1",
-//             Element::Item(b"value1".to_vec()),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     temp_db
-//         .insert(
-//             &[TEST_LEAF, b"innertree"],
-//             b"key2",
-//             Element::Item(b"value2".to_vec()),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     temp_db
-//         .insert(
-//             &[ANOTHER_TEST_LEAF, b"innertree2"],
-//             b"key3",
-//             Element::Item(b"value3".to_vec()),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//     temp_db
-//         .insert(
-//             &[ANOTHER_TEST_LEAF, b"innertree3"],
-//             b"key4",
-//             Element::Item(b"value4".to_vec()),
-//             None,
-//         )
-//         .expect("successful subtree insert");
-//
-//     // Single query proof verification
-//     let mut path_one_query = Query::new();
-//     path_one_query.insert_key(b"key1");
-//     path_one_query.insert_key(b"key2");
-//
-//     let proof = temp_db
-//         .proof(vec![PathQuery::new_unsized(
-//             &[TEST_LEAF, b"innertree"],
-//             path_one_query,
-//         )])
-//         .unwrap();
-//
-//     // Assert correct root hash
-//     let (root_hash, result_maps) = GroveDb::execute_proof(proof).unwrap();
-//     assert_eq!(temp_db.root_tree.root().unwrap(), root_hash);
-//
-//     // Assert correct result object
-//     // Proof query was for two keys key1 and key2
-//     let path_as_vec = GroveDb::compress_subtree_key(&[TEST_LEAF,
-// b"innertree"], None);     let result_map =
-// result_maps.get(&path_as_vec).unwrap();     let elem_1: Element =
-// bincode::deserialize(result_map.get(b"key1").unwrap().unwrap()).unwrap();
-//     let elem_2: Element =
-// bincode::deserialize(result_map.get(b"key2").unwrap().unwrap()).unwrap();
-//     assert_eq!(elem_1, Element::Item(b"value1".to_vec()));
-//     assert_eq!(elem_2, Element::Item(b"value2".to_vec()));
-//
-//     // Multi query proof verification
-//     let mut path_two_query = Query::new();
-//     path_two_query.insert_key(b"key4".to_vec());
-//
-//     let mut path_three_query = Query::new();
-//     path_three_query.insert_key(b"key3");
-//
-//     // Get grovedb proof
-//     let proof = temp_db
-//         .proof(vec![
-//             PathQuery::new_unsized(&[ANOTHER_TEST_LEAF, b"innertree3"],
-// path_two_query),             PathQuery::new_unsized(&[ANOTHER_TEST_LEAF,
-// b"innertree2"], path_three_query),         ])
-//         .unwrap();
-//
-//     // Assert correct root hash
-//     let (root_hash, result_maps) = GroveDb::execute_proof(proof).unwrap();
-//     assert_eq!(temp_db.root_tree.root().unwrap(), root_hash);
-//
-//     // Assert correct result object
-//     let path_one_as_vec = GroveDb::compress_subtree_key(&[ANOTHER_TEST_LEAF,
-// b"innertree3"], None);     let result_map =
-// result_maps.get(&path_one_as_vec).unwrap();     let elem: Element =
-// bincode::deserialize(result_map.get(b"key4").unwrap().unwrap()).unwrap();
-//     assert_eq!(elem, Element::Item(b"value4".to_vec()));
-//
-//     let path_two_as_vec = GroveDb::compress_subtree_key(&[ANOTHER_TEST_LEAF,
-// b"innertree2"], None);     let result_map =
-// result_maps.get(&path_two_as_vec).unwrap();     let elem: Element =
-// bincode::deserialize(result_map.get(b"key3").unwrap().unwrap()).unwrap();
-//     assert_eq!(elem, Element::Item(b"value3".to_vec()));
-// }
+    // Insert elements into grovedb instance
+    let temp_db = make_grovedb();
+    // Insert level 1 nodes
+    temp_db
+        .insert([TEST_LEAF], b"innertree", Element::empty_tree(), None)
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [ANOTHER_TEST_LEAF],
+            b"innertree2",
+            Element::empty_tree(),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [ANOTHER_TEST_LEAF],
+            b"innertree3",
+            Element::empty_tree(),
+            None,
+        )
+        .expect("successful subtree insert");
+    // Insert level 2 nodes
+    temp_db
+        .insert(
+            [TEST_LEAF, b"innertree"],
+            b"key1",
+            Element::Item(b"value1".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [TEST_LEAF, b"innertree"],
+            b"key2",
+            Element::Item(b"value2".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [TEST_LEAF, b"innertree"],
+            b"key3",
+            Element::Item(b"value3".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [ANOTHER_TEST_LEAF, b"innertree2"],
+            b"key3",
+            Element::Item(b"value3".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+    temp_db
+        .insert(
+            [ANOTHER_TEST_LEAF, b"innertree3"],
+            b"key4",
+            Element::Item(b"value4".to_vec()),
+            None,
+        )
+        .expect("successful subtree insert");
+
+    // Single key query
+    let mut query = Query::new();
+    query.insert_key(b"key1".to_vec());
+
+    let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query);
+
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    let r1 = Element::Item(b"value1".to_vec()).serialize().unwrap();
+    assert_eq!(result_set, vec![(b"key1".to_vec(), r1)]);
+
+    // Range query + limit
+    let mut query = Query::new();
+    query.insert_range_after(b"key1".to_vec()..);
+    let path_query = PathQuery::new(
+        vec![TEST_LEAF.to_vec(), b"innertree".to_vec()],
+        SizedQuery::new(query, Some(1), None),
+    );
+
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    let r1 = Element::Item(b"value2".to_vec()).serialize().unwrap();
+    assert_eq!(result_set, vec![(b"key2".to_vec(), r1)]);
+
+    // Range query + offset + limit
+    let mut query = Query::new();
+    query.insert_range_after(b"key1".to_vec()..);
+    let path_query = PathQuery::new(
+        vec![TEST_LEAF.to_vec(), b"innertree".to_vec()],
+        SizedQuery::new(query, Some(1), Some(1)),
+    );
+
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    let r1 = Element::Item(b"value3".to_vec()).serialize().unwrap();
+    assert_eq!(result_set, vec![(b"key3".to_vec(), r1)]);
+
+    // Range query + direction + limit
+    let mut query = Query::new_with_direction(false);
+    query.insert_all();
+    let path_query = PathQuery::new(
+        vec![TEST_LEAF.to_vec(), b"innertree".to_vec()],
+        SizedQuery::new(query, Some(2), None),
+    );
+
+    let mut proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    let r1 = Element::Item(b"value3".to_vec()).serialize().unwrap();
+    let r2 = Element::Item(b"value2".to_vec()).serialize().unwrap();
+    assert_eq!(
+        result_set,
+        vec![(b"key3".to_vec(), r1), (b"key2".to_vec(), r2)]
+    );
+}
+
+#[test]
+fn test_path_query_proofs_with_default_subquery() {
+    let temp_db = make_deep_tree();
+
+    let mut query = Query::new();
+    query.insert_all();
+
+    let mut subq = Query::new();
+    subq.insert_all();
+    query.set_subquery(subq);
+
+    let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
+
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    assert_eq!(result_set.len(), 5);
+
+    let keys = [
+        b"key1".to_vec(),
+        b"key2".to_vec(),
+        b"key3".to_vec(),
+        b"key4".to_vec(),
+        b"key5".to_vec(),
+    ];
+    let values = [
+        b"value1".to_vec(),
+        b"value2".to_vec(),
+        b"value3".to_vec(),
+        b"value4".to_vec(),
+        b"value5".to_vec(),
+    ];
+    let elements = values.map(|x| Element::Item(x).serialize().unwrap());
+    let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> = keys.into_iter().zip(elements).collect();
+    assert_eq!(result_set, expected_result_set);
+
+    // range subquery
+    let mut query = Query::new();
+    query.insert_all();
+
+    let mut subq = Query::new();
+    subq.insert_range_after_to_inclusive(b"key1".to_vec()..=b"key4".to_vec());
+    query.set_subquery(subq);
+
+    let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
+
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) = GroveDb::execute_proof(proof.as_slice(), path_query).expect(
+        "should
+    execute proof",
+    );
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    assert_eq!(result_set.len(), 3);
+
+    let keys = [b"key2".to_vec(), b"key3".to_vec(), b"key4".to_vec()];
+    let values = [b"value2".to_vec(), b"value3".to_vec(), b"value4".to_vec()];
+    let elements = values.map(|x| Element::Item(x).serialize().unwrap());
+    let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> = keys.into_iter().zip(elements).collect();
+    assert_eq!(result_set, expected_result_set);
+
+    // deep tree test
+    let mut query = Query::new();
+    query.insert_all();
+
+    let mut subq = Query::new();
+    subq.insert_all();
+
+    let mut sub_subquery = Query::new();
+    sub_subquery.insert_all();
+
+    subq.set_subquery(sub_subquery);
+    query.set_subquery(subq);
+
+    let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
+
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    assert_eq!(result_set.len(), 11);
+
+    let keys = [
+        b"key1".to_vec(),
+        b"key2".to_vec(),
+        b"key3".to_vec(),
+        b"key4".to_vec(),
+        b"key5".to_vec(),
+        b"key6".to_vec(),
+        b"key7".to_vec(),
+        b"key8".to_vec(),
+        b"key9".to_vec(),
+        b"key10".to_vec(),
+        b"key11".to_vec(),
+    ];
+    let values = [
+        b"value1".to_vec(),
+        b"value2".to_vec(),
+        b"value3".to_vec(),
+        b"value4".to_vec(),
+        b"value5".to_vec(),
+        b"value6".to_vec(),
+        b"value7".to_vec(),
+        b"value8".to_vec(),
+        b"value9".to_vec(),
+        b"value10".to_vec(),
+        b"value11".to_vec(),
+    ];
+    let elements = values.map(|x| Element::Item(x).serialize().unwrap());
+    let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> = keys.into_iter().zip(elements).collect();
+    assert_eq!(result_set, expected_result_set);
+}
+
+#[test]
+fn test_path_query_proofs_with_subquery_key() {
+    let temp_db = make_deep_tree();
+
+    let mut query = Query::new();
+    query.insert_all();
+
+    let mut subq = Query::new();
+    subq.insert_all();
+
+    query.set_subquery_key(b"deeper_node_1".to_vec());
+    query.set_subquery(subq);
+
+    let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
+
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    assert_eq!(result_set.len(), 3);
+
+    let keys = [b"key1".to_vec(), b"key2".to_vec(), b"key3".to_vec()];
+    let values = [b"value1".to_vec(), b"value2".to_vec(), b"value3".to_vec()];
+    let elements = values.map(|x| Element::Item(x).serialize().unwrap());
+    let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> = keys.into_iter().zip(elements).collect();
+    assert_eq!(result_set, expected_result_set);
+}
+
+#[test]
+fn test_path_query_proofs_with_conditional_subquery() {
+    let temp_db = make_deep_tree();
+
+    let mut query = Query::new();
+    query.insert_all();
+
+    let mut subquery = Query::new();
+    subquery.insert_all();
+
+    let mut final_subquery = Query::new();
+    final_subquery.insert_all();
+
+    subquery.add_conditional_subquery(
+        QueryItem::Key(b"deeper_node_4".to_vec()),
+        None,
+        Some(final_subquery),
+    );
+
+    query.set_subquery(subquery);
+
+    let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+
+    let keys = [
+        b"deeper_node_1".to_vec(),
+        b"deeper_node_2".to_vec(),
+        b"key10".to_vec(),
+        b"key11".to_vec(),
+    ];
+    assert_eq!(result_set.len(), keys.len());
+
+    // TODO: Is this defined behaviour
+    for (index, key) in keys.iter().enumerate() {
+        assert_eq!(&result_set[index].0, key);
+    }
+
+    // Default + Conditional subquery
+    let mut query = Query::new();
+    query.insert_all();
+
+    let mut subquery = Query::new();
+    subquery.insert_all();
+
+    let mut final_conditional_subquery = Query::new();
+    final_conditional_subquery.insert_all();
+
+    let mut final_default_subquery = Query::new();
+    final_default_subquery.insert_range_inclusive(b"key3".to_vec()..=b"key6".to_vec());
+
+    subquery.add_conditional_subquery(
+        QueryItem::Key(b"deeper_node_4".to_vec()),
+        None,
+        Some(final_conditional_subquery),
+    );
+    subquery.set_subquery(final_default_subquery);
+
+    query.set_subquery(subquery);
+
+    let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    assert_eq!(result_set.len(), 6);
+
+    let keys = [
+        b"key3".to_vec(),
+        b"key4".to_vec(),
+        b"key5".to_vec(),
+        b"key6".to_vec(),
+        b"key10".to_vec(),
+        b"key11".to_vec(),
+    ];
+    let values = [
+        b"value3".to_vec(),
+        b"value4".to_vec(),
+        b"value5".to_vec(),
+        b"value6".to_vec(),
+        b"value10".to_vec(),
+        b"value11".to_vec(),
+    ];
+    let elements = values.map(|x| Element::Item(x).serialize().unwrap());
+    let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> = keys.into_iter().zip(elements).collect();
+    assert_eq!(result_set, expected_result_set);
+}
+
+#[test]
+fn test_path_query_proofs_with_sized_query() {
+    let temp_db = make_deep_tree();
+
+    let mut query = Query::new();
+    query.insert_all();
+
+    let mut subquery = Query::new();
+    subquery.insert_all();
+
+    let mut final_conditional_subquery = Query::new();
+    final_conditional_subquery.insert_all();
+
+    let mut final_default_subquery = Query::new();
+    final_default_subquery.insert_range_inclusive(b"key3".to_vec()..=b"key6".to_vec());
+
+    subquery.add_conditional_subquery(
+        QueryItem::Key(b"deeper_node_4".to_vec()),
+        None,
+        Some(final_conditional_subquery),
+    );
+    subquery.set_subquery(final_default_subquery);
+    // subquery.set_subquery_key(b"key3".to_vec());
+
+    query.set_subquery(subquery);
+
+    let path_query = PathQuery::new(
+        vec![DEEP_LEAF.to_vec()],
+        SizedQuery::new(query, Some(3), Some(1)),
+    );
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    assert_eq!(result_set.len(), 3);
+
+    let keys = [b"key4".to_vec(), b"key5".to_vec(), b"key6".to_vec()];
+    let values = [b"value4".to_vec(), b"value5".to_vec(), b"value6".to_vec()];
+    let elements = values.map(|x| Element::Item(x).serialize().unwrap());
+    let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> = keys.into_iter().zip(elements).collect();
+    assert_eq!(result_set, expected_result_set);
+}
+
+#[test]
+fn test_path_query_proofs_with_direction() {
+    let temp_db = make_deep_tree();
+
+    let mut query = Query::new_with_direction(false);
+    query.insert_all();
+
+    let mut subquery = Query::new_with_direction(false);
+    subquery.insert_all();
+
+    let mut final_conditional_subquery = Query::new_with_direction(false);
+    final_conditional_subquery.insert_all();
+
+    let mut final_default_subquery = Query::new_with_direction(false);
+    final_default_subquery.insert_range_inclusive(b"key3".to_vec()..=b"key6".to_vec());
+
+    subquery.add_conditional_subquery(
+        QueryItem::Key(b"deeper_node_4".to_vec()),
+        None,
+        Some(final_conditional_subquery),
+    );
+    subquery.set_subquery(final_default_subquery);
+
+    query.set_subquery(subquery);
+
+    let path_query = PathQuery::new(
+        vec![DEEP_LEAF.to_vec()],
+        SizedQuery::new(query, Some(3), Some(1)),
+    );
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    assert_eq!(result_set.len(), 3);
+
+    let keys = [b"key10".to_vec(), b"key6".to_vec(), b"key5".to_vec()];
+    let values = [b"value10".to_vec(), b"value6".to_vec(), b"value5".to_vec()];
+    let elements = values.map(|x| Element::Item(x).serialize().unwrap());
+    let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> = keys.into_iter().zip(elements).collect();
+    assert_eq!(result_set, expected_result_set);
+
+    // combined directions
+    let mut query = Query::new();
+    query.insert_all();
+
+    let mut subq = Query::new_with_direction(false);
+    subq.insert_all();
+
+    let mut sub_subquery = Query::new();
+    sub_subquery.insert_all();
+
+    subq.set_subquery(sub_subquery);
+    query.set_subquery(subq);
+
+    let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
+
+    let proof = temp_db.prove(path_query.clone()).unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap());
+    assert_eq!(result_set.len(), 11);
+
+    let keys = [
+        b"key4".to_vec(),
+        b"key5".to_vec(),
+        b"key6".to_vec(),
+        b"key1".to_vec(),
+        b"key2".to_vec(),
+        b"key3".to_vec(),
+        b"key10".to_vec(),
+        b"key11".to_vec(),
+        b"key7".to_vec(),
+        b"key8".to_vec(),
+        b"key9".to_vec(),
+    ];
+    let values = [
+        b"value4".to_vec(),
+        b"value5".to_vec(),
+        b"value6".to_vec(),
+        b"value1".to_vec(),
+        b"value2".to_vec(),
+        b"value3".to_vec(),
+        b"value10".to_vec(),
+        b"value11".to_vec(),
+        b"value7".to_vec(),
+        b"value8".to_vec(),
+        b"value9".to_vec(),
+    ];
+    let elements = values.map(|x| Element::Item(x).serialize().unwrap());
+    let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> = keys.into_iter().zip(elements).collect();
+    assert_eq!(result_set, expected_result_set);
+}
 
 // #[test]
 // fn test_checkpoint() {

--- a/merk/src/lib.rs
+++ b/merk/src/lib.rs
@@ -21,4 +21,4 @@ pub use tree::{BatchEntry, Hash, MerkBatch, Op, PanicSource, HASH_LENGTH};
 
 // #[cfg(feature = "full")]
 // // pub use crate::merk::{chunks, restore, Merk};
-pub use crate::merk::Merk;
+pub use crate::merk::{Merk, ProofConstructionResult};

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -13,6 +13,22 @@ use crate::{
 
 const ROOT_KEY_KEY: &[u8] = b"root";
 
+pub struct ProofConstructionResult {
+    pub proof: Vec<u8>,
+    pub limit: Option<u16>,
+    pub offset: Option<u16>,
+}
+
+impl ProofConstructionResult {
+    pub fn new(proof: Vec<u8>, limit: Option<u16>, offset: Option<u16>) -> Self {
+        Self {
+            proof,
+            limit,
+            offset,
+        }
+    }
+}
+
 /// A handle to a Merkle key/value store backed by RocksDB.
 pub struct Merk<S> {
     pub(crate) tree: Cell<Option<Tree>>,
@@ -223,7 +239,7 @@ where
         query: Query,
         limit: Option<u16>,
         offset: Option<u16>,
-    ) -> Result<Vec<u8>> {
+    ) -> Result<ProofConstructionResult> {
         let left_to_right = query.left_to_right;
         self.prove_unchecked(query, limit, offset, left_to_right)
     }
@@ -246,7 +262,7 @@ where
         limit: Option<u16>,
         offset: Option<u16>,
         left_to_right: bool,
-    ) -> Result<Vec<u8>>
+    ) -> Result<ProofConstructionResult>
     where
         Q: Into<QueryItem>,
         I: IntoIterator<Item = Q>,
@@ -257,12 +273,12 @@ where
             let tree = maybe_tree.ok_or(anyhow!("Cannot create proof for empty tree"))?;
 
             let mut ref_walker = RefWalker::new(tree, self.source());
-            let (proof, ..) =
+            let (proof, _, limit, offset, ..) =
                 ref_walker.create_proof(query_vec.as_slice(), limit, offset, left_to_right)?;
 
             let mut bytes = Vec::with_capacity(128);
             encode_into(proof.iter(), &mut bytes);
-            Ok(bytes)
+            Ok(ProofConstructionResult::new(bytes, limit, offset))
         })
     }
 
@@ -334,6 +350,31 @@ where
         iter.seek_to_first();
 
         !iter.valid()
+    }
+
+    // TODO: Convert this to something that returns all the keys in a merk
+    pub fn get_kv_pairs(&self, left_to_right: bool) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let mut result = vec![];
+        let mut iter = self.storage.raw_iter();
+        // might need to use seek for iter, or maybe not
+        // iter.seek_to_first();
+        if left_to_right {
+            iter.seek_to_first();
+        } else {
+            iter.seek_to_last();
+        }
+
+        while iter.valid() {
+            let rs = (iter.key().unwrap().to_vec(), iter.value().unwrap().to_vec());
+            result.push(rs);
+            if left_to_right {
+                iter.next();
+            } else {
+                iter.prev();
+            }
+        }
+
+        result
     }
 
     fn source(&self) -> MerkSource<S> {

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1070,7 +1070,7 @@ pub fn execute_proof(bytes: &[u8]) -> Result<(MerkHash, Map)> {
     Ok((root.hash(), map_builder.build()))
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub struct ProofVerificationResult {
     result_set: Vec<(Vec<u8>, Vec<u8>)>,
     limit: Option<u16>,
@@ -2076,6 +2076,8 @@ mod test {
                 (vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),
             ]
         );
+        assert_eq!(res.limit, None);
+        assert_eq!(res.offset, None);
 
         // skip 1 element
         let mut tree = make_tree_seq(10);
@@ -2107,6 +2109,8 @@ mod test {
             res.result_set,
             vec![(vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60])]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip 2 elements
         let mut tree = make_tree_seq(10);
@@ -2135,6 +2139,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(0));
 
         // skip all elements
         let mut tree = make_tree_seq(10);
@@ -2163,6 +2169,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(198));
 
         // right to left test
         let mut tree = make_tree_seq(10);
@@ -2277,6 +2285,8 @@ mod test {
                 (vec![0, 0, 0, 0, 0, 0, 0, 7], vec![123; 60]),
             ]
         );
+        assert_eq!(res.limit, None);
+        assert_eq!(res.offset, None);
 
         // skip 1 element
         let mut tree = make_tree_seq(10);
@@ -2308,6 +2318,8 @@ mod test {
             res.result_set,
             vec![(vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60])]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip 2 elements
         let mut tree = make_tree_seq(10);
@@ -2339,6 +2351,8 @@ mod test {
             res.result_set,
             vec![(vec![0, 0, 0, 0, 0, 0, 0, 7], vec![123; 60])]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip all elements
         let mut tree = make_tree_seq(10);
@@ -2367,6 +2381,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(197));
 
         // right_to_left proof
         let mut tree = make_tree_seq(10);
@@ -2419,6 +2435,8 @@ mod test {
             res.result_set,
             vec![(vec![0, 0, 0, 0, 0, 0, 0, 5], vec![123; 60])]
         );
+        assert_eq!(res.limit, None);
+        assert_eq!(res.offset, Some(0));
     }
 
     #[test]
@@ -2459,6 +2477,8 @@ mod test {
             res.result_set,
             vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8])]
         );
+        assert_eq!(res.limit, None);
+        assert_eq!(res.offset, None);
 
         // Limit result set to 1 item
         let mut tree = make_6_node_tree();
@@ -2485,6 +2505,8 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
         assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -2518,6 +2540,8 @@ mod test {
             res.result_set,
             vec![(vec![5], vec![5]), (vec![7], vec![7]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -2548,6 +2572,8 @@ mod test {
             res.result_set,
             vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8])]
         );
+        assert_eq!(res.limit, Some(97));
+        assert_eq!(res.offset, None);
 
         // skip 1 element
         let mut tree = make_6_node_tree();
@@ -2574,6 +2600,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![7], vec![7])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -2600,6 +2628,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![8], vec![8])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -2626,6 +2656,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(197));
 
         // right_to_left test
         let mut tree = make_6_node_tree();
@@ -2676,6 +2708,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![7], vec![7]), (vec![5], vec![5])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
     }
 
     #[test]
@@ -2734,6 +2768,8 @@ mod test {
                 (vec![5], vec![5]),
             ]
         );
+        assert_eq!(res.limit, None);
+        assert_eq!(res.offset, None);
 
         // Limit result set to 1 item
         let mut tree = make_6_node_tree();
@@ -2760,6 +2796,8 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
         assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -2789,6 +2827,8 @@ mod test {
             res.result_set,
             vec![(vec![2], vec![2]), (vec![3], vec![3]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -2824,6 +2864,8 @@ mod test {
                 (vec![5], vec![5])
             ]
         );
+        assert_eq!(res.limit, Some(96));
+        assert_eq!(res.offset, None);
 
         // skip 1 element
         let mut tree = make_6_node_tree();
@@ -2850,6 +2892,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![3], vec![3])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -2876,6 +2920,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -2902,6 +2948,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(196));
 
         // right_to_left proof
         let mut tree = make_6_node_tree();
@@ -2953,6 +3001,8 @@ mod test {
             res.result_set,
             vec![(vec![5], vec![5]), (vec![4], vec![4]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
     }
 
     #[test]
@@ -3011,6 +3061,8 @@ mod test {
                 (vec![5], vec![5]),
             ]
         );
+        assert_eq!(res.limit, None);
+        assert_eq!(res.offset, None);
 
         // Limit result set to 1 item
         let mut tree = make_6_node_tree();
@@ -3037,6 +3089,8 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
         assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -3066,6 +3120,8 @@ mod test {
             res.result_set,
             vec![(vec![2], vec![2]), (vec![3], vec![3]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -3101,6 +3157,8 @@ mod test {
                 (vec![5], vec![5])
             ]
         );
+        assert_eq!(res.limit, Some(96));
+        assert_eq!(res.offset, None);
 
         // skip 1 element
         let mut tree = make_6_node_tree();
@@ -3127,6 +3185,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![3], vec![3])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -3153,6 +3213,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -3179,6 +3241,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(196));
 
         // right_to_left proof
         let mut tree = make_6_node_tree();
@@ -3234,6 +3298,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4]),]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
     }
 
     #[test]
@@ -3292,6 +3358,8 @@ mod test {
                 (vec![8], vec![8]),
             ]
         );
+        assert_eq!(res.limit, None);
+        assert_eq!(res.offset, None);
 
         // Limit result set to 1 item
         let mut tree = make_6_node_tree();
@@ -3318,6 +3386,8 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -3347,6 +3417,8 @@ mod test {
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -3382,6 +3454,8 @@ mod test {
                 (vec![8], vec![8])
             ]
         );
+        assert_eq!(res.limit, Some(96));
+        assert_eq!(res.offset, None);
 
         // skip 1 element
         let mut tree = make_6_node_tree();
@@ -3408,6 +3482,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -3434,6 +3510,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![7], vec![7])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -3460,6 +3538,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(196));
 
         // right_to_left proof
         let mut tree = make_6_node_tree();
@@ -3511,6 +3591,8 @@ mod test {
             res.result_set,
             vec![(vec![8], vec![8]), (vec![7], vec![7]), (vec![5], vec![5]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
     }
 
     #[test]
@@ -3579,6 +3661,8 @@ mod test {
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
         );
+        assert_eq!(res.limit, None);
+        assert_eq!(res.offset, None);
 
         // Limit result set to 1 item
         let mut tree = make_6_node_tree();
@@ -3605,6 +3689,8 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -3634,6 +3720,8 @@ mod test {
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -3664,6 +3752,8 @@ mod test {
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
         );
+        assert_eq!(res.limit, Some(98));
+        assert_eq!(res.offset, None);
 
         // skip 1 element
         let mut tree = make_6_node_tree();
@@ -3690,6 +3780,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -3716,6 +3808,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(0));
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -3742,6 +3836,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(198));
 
         // right_to_left
         let mut tree = make_6_node_tree();
@@ -3792,6 +3888,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
+        assert_eq!(res.limit, Some(299));
+        assert_eq!(res.offset, Some(0));
     }
 
     #[test]
@@ -3851,6 +3949,8 @@ mod test {
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]), (vec![7], vec![7])]
         );
+        assert_eq!(res.limit, None);
+        assert_eq!(res.offset, None);
 
         // Limit result set to 1 item
         let mut tree = make_6_node_tree();
@@ -3877,6 +3977,8 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -3906,6 +4008,8 @@ mod test {
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -3936,6 +4040,8 @@ mod test {
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]), (vec![7], vec![7])]
         );
+        assert_eq!(res.limit, Some(97));
+        assert_eq!(res.offset, None);
 
         // skip 1 element
         let mut tree = make_6_node_tree();
@@ -3962,6 +4068,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -3988,6 +4096,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![7], vec![7])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -4014,6 +4124,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(197));
 
         // right_to_left proof
         let mut tree = make_6_node_tree();
@@ -4083,6 +4195,8 @@ mod test {
                 (vec![8], vec![8]),
             ]
         );
+        assert_eq!(res.limit, None);
+        assert_eq!(res.offset, None);
 
         // Limit result set to 1 item
         let mut tree = make_6_node_tree();
@@ -4109,6 +4223,8 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
         assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -4138,6 +4254,8 @@ mod test {
             res.result_set,
             vec![(vec![2], vec![2]), (vec![3], vec![3]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -4175,6 +4293,8 @@ mod test {
                 (vec![8], vec![8])
             ]
         );
+        assert_eq!(res.limit, Some(94));
+        assert_eq!(res.offset, None);
 
         // skip 1 element
         let mut tree = make_6_node_tree();
@@ -4204,6 +4324,8 @@ mod test {
             res.result_set,
             vec![(vec![3], vec![3]), (vec![4], vec![4]), (vec![5], vec![5]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -4233,6 +4355,8 @@ mod test {
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -4259,6 +4383,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
+        assert_eq!(res.limit, Some(1));
+        assert_eq!(res.offset, Some(194));
 
         // right_to_left proof
         let mut tree = make_6_node_tree();
@@ -4319,6 +4445,8 @@ mod test {
             res.result_set,
             vec![(vec![5], vec![5]), (vec![4], vec![4]),]
         );
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
     }
 
     #[test]
@@ -4375,6 +4503,8 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
         assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, None);
     }
 
     #[test]
@@ -4445,6 +4575,8 @@ mod test {
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
+        assert_eq!(res.limit, Some(0));
+        assert_eq!(res.offset, Some(0));
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1070,6 +1070,7 @@ pub fn execute_proof(bytes: &[u8]) -> Result<(MerkHash, Map)> {
     Ok((root.hash(), map_builder.build()))
 }
 
+#[derive(PartialEq)]
 pub struct ProofVerificationResult {
     result_set: Vec<(Vec<u8>, Vec<u8>)>,
     limit: Option<u16>,
@@ -1401,7 +1402,7 @@ mod test {
             .expect("verify failed");
 
         let mut values = std::collections::HashMap::new();
-        for (key, value) in result {
+        for (key, value) in result.result_set {
             assert!(values.insert(key, value).is_none());
         }
 
@@ -1537,7 +1538,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert!(res.is_empty());
+        assert!(res.result_set.is_empty());
     }
 
     #[test]
@@ -1578,7 +1579,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![5], vec![5])]);
+        assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
     }
 
     #[test]
@@ -1619,7 +1620,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![3], vec![3])]);
+        assert_eq!(res.result_set, vec![(vec![3], vec![3])]);
     }
 
     #[test]
@@ -1654,7 +1655,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![3], vec![3]), (vec![7], vec![7]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![3], vec![3]), (vec![7], vec![7]),]
+        );
     }
 
     #[test]
@@ -1688,7 +1692,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![(vec![3], vec![3]), (vec![5], vec![5]), (vec![7], vec![7]),]
         );
     }
@@ -1740,7 +1744,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
     }
 
     #[test]
@@ -1793,7 +1797,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
     }
 
     #[test]
@@ -1896,7 +1900,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![1], vec![1]),
                 (vec![2], vec![2]),
@@ -2066,7 +2070,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![0, 0, 0, 0, 0, 0, 0, 5], vec![123; 60]),
                 (vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),
@@ -2099,7 +2103,10 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60])]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60])]
+        );
 
         // skip 2 elements
         let mut tree = make_tree_seq(10);
@@ -2127,7 +2134,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // skip all elements
         let mut tree = make_tree_seq(10);
@@ -2155,7 +2162,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // right to left test
         let mut tree = make_tree_seq(10);
@@ -2176,7 +2183,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),
                 (vec![0, 0, 0, 0, 0, 0, 0, 5], vec![123; 60])
@@ -2263,7 +2270,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![0, 0, 0, 0, 0, 0, 0, 5], vec![123; 60]),
                 (vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),
@@ -2297,7 +2304,10 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60])]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60])]
+        );
 
         // skip 2 elements
         let mut tree = make_tree_seq(10);
@@ -2325,7 +2335,10 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![0, 0, 0, 0, 0, 0, 0, 7], vec![123; 60])]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![0, 0, 0, 0, 0, 0, 0, 7], vec![123; 60])]
+        );
 
         // skip all elements
         let mut tree = make_tree_seq(10);
@@ -2353,7 +2366,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // right_to_left proof
         let mut tree = make_tree_seq(10);
@@ -2375,7 +2388,7 @@ mod test {
         let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
 
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![0, 0, 0, 0, 0, 0, 0, 7], vec![123; 60]),
                 (vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),
@@ -2402,7 +2415,10 @@ mod test {
         let res =
             verify_query(bytes.as_slice(), &query, None, Some(2), false, tree.hash()).unwrap();
 
-        assert_eq!(res, vec![(vec![0, 0, 0, 0, 0, 0, 0, 5], vec![123; 60])]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![0, 0, 0, 0, 0, 0, 0, 5], vec![123; 60])]
+        );
     }
 
     #[test]
@@ -2440,7 +2456,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8])]
         );
 
@@ -2468,7 +2484,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![5], vec![5])]);
+        assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -2498,7 +2514,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![5], vec![5]), (vec![7], vec![7]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![5], vec![5]), (vec![7], vec![7]),]
+        );
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -2526,7 +2545,7 @@ mod test {
         let res =
             verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8])]
         );
 
@@ -2554,7 +2573,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![7], vec![7])]);
+        assert_eq!(res.result_set, vec![(vec![7], vec![7])]);
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -2580,7 +2599,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![8], vec![8])]);
+        assert_eq!(res.result_set, vec![(vec![8], vec![8])]);
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -2606,7 +2625,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // right_to_left test
         let mut tree = make_6_node_tree();
@@ -2627,7 +2646,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![(vec![8], vec![8]), (vec![7], vec![7]), (vec![5], vec![5])]
         );
 
@@ -2656,7 +2675,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![7], vec![7]), (vec![5], vec![5])]);
+        assert_eq!(res.result_set, vec![(vec![7], vec![7]), (vec![5], vec![5])]);
     }
 
     #[test]
@@ -2707,7 +2726,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![2], vec![2]),
                 (vec![3], vec![3]),
@@ -2740,7 +2759,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![2], vec![2])]);
+        assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -2766,7 +2785,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![2], vec![2]), (vec![3], vec![3]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![2], vec![2]), (vec![3], vec![3]),]
+        );
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -2794,7 +2816,7 @@ mod test {
         let res =
             verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![2], vec![2]),
                 (vec![3], vec![3]),
@@ -2827,7 +2849,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![3], vec![3])]);
+        assert_eq!(res.result_set, vec![(vec![3], vec![3])]);
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -2853,7 +2875,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4])]);
+        assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -2879,7 +2901,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // right_to_left proof
         let mut tree = make_6_node_tree();
@@ -2900,7 +2922,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![5], vec![5]),
                 (vec![4], vec![4]),
@@ -2927,7 +2949,10 @@ mod test {
         }
         let res =
             verify_query(bytes.as_slice(), &query, Some(2), None, false, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![5], vec![5]), (vec![4], vec![4]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![5], vec![5]), (vec![4], vec![4]),]
+        );
     }
 
     #[test]
@@ -2978,7 +3003,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![2], vec![2]),
                 (vec![3], vec![3]),
@@ -3011,7 +3036,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![2], vec![2])]);
+        assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -3037,7 +3062,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![2], vec![2]), (vec![3], vec![3]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![2], vec![2]), (vec![3], vec![3]),]
+        );
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -3065,7 +3093,7 @@ mod test {
         let res =
             verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![2], vec![2]),
                 (vec![3], vec![3]),
@@ -3098,7 +3126,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![3], vec![3])]);
+        assert_eq!(res.result_set, vec![(vec![3], vec![3])]);
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -3124,7 +3152,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4])]);
+        assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -3150,7 +3178,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // right_to_left proof
         let mut tree = make_6_node_tree();
@@ -3171,7 +3199,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![5], vec![5]),
                 (vec![4], vec![4]),
@@ -3205,7 +3233,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4]),]);
+        assert_eq!(res.result_set, vec![(vec![4], vec![4]),]);
     }
 
     #[test]
@@ -3256,7 +3284,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![4], vec![4]),
                 (vec![5], vec![5]),
@@ -3289,7 +3317,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4])]);
+        assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -3315,7 +3343,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4]), (vec![5], vec![5]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![4], vec![4]), (vec![5], vec![5]),]
+        );
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -3343,7 +3374,7 @@ mod test {
         let res =
             verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![4], vec![4]),
                 (vec![5], vec![5]),
@@ -3376,7 +3407,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![5], vec![5])]);
+        assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -3402,7 +3433,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![7], vec![7])]);
+        assert_eq!(res.result_set, vec![(vec![7], vec![7])]);
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -3428,7 +3459,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // right_to_left proof
         let mut tree = make_6_node_tree();
@@ -3449,7 +3480,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![8], vec![8]),
                 (vec![7], vec![7]),
@@ -3477,7 +3508,7 @@ mod test {
         let res =
             verify_query(bytes.as_slice(), &query, Some(3), None, false, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![(vec![8], vec![8]), (vec![7], vec![7]), (vec![5], vec![5]),]
         );
     }
@@ -3544,7 +3575,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4]), (vec![5], vec![5]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![4], vec![4]), (vec![5], vec![5]),]
+        );
 
         // Limit result set to 1 item
         let mut tree = make_6_node_tree();
@@ -3570,7 +3604,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4])]);
+        assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -3596,7 +3630,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4]), (vec![5], vec![5]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![4], vec![4]), (vec![5], vec![5]),]
+        );
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -3623,7 +3660,10 @@ mod test {
         }
         let res =
             verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4]), (vec![5], vec![5]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![4], vec![4]), (vec![5], vec![5]),]
+        );
 
         // skip 1 element
         let mut tree = make_6_node_tree();
@@ -3649,7 +3689,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![5], vec![5])]);
+        assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -3675,7 +3715,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -3701,7 +3741,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // right_to_left
         let mut tree = make_6_node_tree();
@@ -3721,7 +3761,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![5], vec![5]), (vec![4], vec![4]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![5], vec![5]), (vec![4], vec![4]),]
+        );
 
         let mut tree = make_6_node_tree();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
@@ -3748,7 +3791,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4])]);
+        assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
     }
 
     #[test]
@@ -3805,7 +3848,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]), (vec![7], vec![7])]
         );
 
@@ -3833,7 +3876,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4])]);
+        assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -3859,7 +3902,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4]), (vec![5], vec![5]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![4], vec![4]), (vec![5], vec![5]),]
+        );
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -3887,7 +3933,7 @@ mod test {
         let res =
             verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]), (vec![7], vec![7])]
         );
 
@@ -3915,7 +3961,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![5], vec![5])]);
+        assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
 
         // skip 2 elements
         let mut tree = make_6_node_tree();
@@ -3941,7 +3987,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![7], vec![7])]);
+        assert_eq!(res.result_set, vec![(vec![7], vec![7])]);
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -3967,7 +4013,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // right_to_left proof
         let mut tree = make_6_node_tree();
@@ -3988,7 +4034,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![(vec![7], vec![7]), (vec![5], vec![5]), (vec![4], vec![4])]
         );
     }
@@ -4027,7 +4073,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![2], vec![2]),
                 (vec![3], vec![3]),
@@ -4062,7 +4108,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![2], vec![2])]);
+        assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
 
         // Limit result set to 2 items
         let mut tree = make_6_node_tree();
@@ -4088,7 +4134,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![2], vec![2]), (vec![3], vec![3]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![2], vec![2]), (vec![3], vec![3]),]
+        );
 
         // Limit result set to 100 items
         let mut tree = make_6_node_tree();
@@ -4116,7 +4165,7 @@ mod test {
         let res =
             verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![2], vec![2]),
                 (vec![3], vec![3]),
@@ -4152,7 +4201,7 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![(vec![3], vec![3]), (vec![4], vec![4]), (vec![5], vec![5]),]
         );
 
@@ -4180,7 +4229,10 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4]), (vec![5], vec![5]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![4], vec![4]), (vec![5], vec![5]),]
+        );
 
         // skip all elements
         let mut tree = make_6_node_tree();
@@ -4206,7 +4258,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![]);
+        assert_eq!(res.result_set, vec![]);
 
         // right_to_left proof
         let mut tree = make_6_node_tree();
@@ -4227,7 +4279,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![8], vec![8]),
                 (vec![7], vec![7]),
@@ -4263,7 +4315,10 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![5], vec![5]), (vec![4], vec![4]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![5], vec![5]), (vec![4], vec![4]),]
+        );
     }
 
     #[test]
@@ -4319,7 +4374,7 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![2], vec![2])]);
+        assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
     }
 
     #[test]
@@ -4389,7 +4444,7 @@ mod test {
             tree.hash(),
         )
         .unwrap();
-        assert_eq!(res, vec![(vec![4], vec![4])]);
+        assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
     }
 
     #[test]
@@ -4447,7 +4502,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![8], vec![8]),
                 (vec![7], vec![7]),
@@ -4540,7 +4595,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
         assert_eq!(
-            res,
+            res.result_set,
             vec![
                 (vec![0, 0, 0, 0, 0, 0, 0, 5], vec![123; 60]),
                 (vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),
@@ -4633,7 +4688,10 @@ mod test {
             query.insert_item(item);
         }
         let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
-        assert_eq!(res, vec![(vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),]);
+        assert_eq!(
+            res.result_set,
+            vec![(vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),]
+        );
     }
 
     #[test]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1070,6 +1070,12 @@ pub fn execute_proof(bytes: &[u8]) -> Result<(MerkHash, Map)> {
     Ok((root.hash(), map_builder.build()))
 }
 
+pub struct ProofVerificationResult {
+    result_set: Vec<(Vec<u8>, Vec<u8>)>,
+    limit: Option<u16>,
+    offset: Option<u16>,
+}
+
 /// Verifies the encoded proof with the given query and expected hash.
 ///
 /// Every key in `keys` is checked to either have a key/value pair in the proof,
@@ -1088,7 +1094,7 @@ pub fn verify_query(
     offset: Option<u16>,
     left_to_right: bool,
     expected_hash: MerkHash,
-) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+) -> Result<ProofVerificationResult> {
     pub fn get_query_iter(
         query: &Query,
         left_to_right: bool,
@@ -1310,7 +1316,11 @@ pub fn verify_query(
         );
     }
 
-    Ok(output)
+    Ok(ProofVerificationResult {
+        result_set: output,
+        limit: current_limit,
+        offset: current_offset,
+    })
 }
 
 #[allow(deprecated)]

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -34,7 +34,7 @@ pub struct Query {
     pub left_to_right: bool,
 }
 
-type ProofOffsetLimit = (LinkedList<Op>, (bool, bool), Option<u16>, Option<u16>);
+type ProofAbsenceLimitOffset = (LinkedList<Op>, (bool, bool), Option<u16>, Option<u16>);
 
 impl Query {
     /// Creates a new query which contains no items.
@@ -808,10 +808,8 @@ where
         limit: Option<u16>,
         offset: Option<u16>,
         left_to_right: bool,
-    ) -> Result<(LinkedList<Op>, (bool, bool))> {
-        let (linked_list, (left, right), ..) =
-            self.create_proof(query, limit, offset, left_to_right)?;
-        Ok((linked_list, (left, right)))
+    ) -> Result<ProofAbsenceLimitOffset> {
+        self.create_proof(query, limit, offset, left_to_right)
     }
 
     /// Generates a proof for the list of queried keys. Returns a tuple
@@ -827,7 +825,7 @@ where
         limit: Option<u16>,
         offset: Option<u16>,
         left_to_right: bool,
-    ) -> Result<ProofOffsetLimit> {
+    ) -> Result<ProofAbsenceLimitOffset> {
         // TODO: don't copy into vec, support comparing QI to byte slice
         let node_key = QueryItem::Key(self.tree().key().to_vec());
         let mut search = query.binary_search_by(|key| key.cmp(&node_key));
@@ -1023,7 +1021,7 @@ where
         limit: Option<u16>,
         offset: Option<u16>,
         left_to_right: bool,
-    ) -> Result<ProofOffsetLimit> {
+    ) -> Result<ProofAbsenceLimitOffset> {
         Ok(if !query.is_empty() {
             if let Some(mut child) = self.walk(left)? {
                 child.create_proof(query, limit, offset, left_to_right)?
@@ -1303,9 +1301,9 @@ pub fn execute_proof(
 
 #[derive(PartialEq, Debug)]
 pub struct ProofVerificationResult {
-    result_set: Vec<(Vec<u8>, Vec<u8>)>,
-    limit: Option<u16>,
-    offset: Option<u16>,
+    pub result_set: Vec<(Vec<u8>, Vec<u8>)>,
+    pub limit: Option<u16>,
+    pub offset: Option<u16>,
 }
 
 /// Verifies the encoded proof with the given query and expected hash
@@ -1380,7 +1378,7 @@ mod test {
         let mut tree = make_3_node_tree();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(
                 keys.clone()
                     .into_iter()
@@ -1503,7 +1501,7 @@ mod test {
         let mut tree = make_3_node_tree();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(vec![].as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -1554,7 +1552,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![5])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -1595,7 +1593,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![3])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -1636,7 +1634,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![3]), QueryItem::Key(vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -1678,7 +1676,7 @@ mod test {
             QueryItem::Key(vec![5]),
             QueryItem::Key(vec![7]),
         ];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -1710,7 +1708,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![8])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -1760,7 +1758,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -1855,7 +1853,7 @@ mod test {
             QueryItem::Key(vec![3]),
             QueryItem::Key(vec![4]),
         ];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2003,7 +2001,7 @@ mod test {
         let queryitems = vec![QueryItem::Range(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2093,7 +2091,7 @@ mod test {
         let queryitems = vec![QueryItem::Range(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(1), true)
             .expect("create_proof errored");
 
@@ -2126,7 +2124,7 @@ mod test {
         let queryitems = vec![QueryItem::Range(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(2), true)
             .expect("create_proof errored");
 
@@ -2156,7 +2154,7 @@ mod test {
         let queryitems = vec![QueryItem::Range(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(200), true)
             .expect("create_proof errored");
 
@@ -2186,7 +2184,7 @@ mod test {
         let queryitems = vec![QueryItem::Range(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, false)
             .expect("create_proof errored");
 
@@ -2214,7 +2212,7 @@ mod test {
         let queryitems = vec![QueryItem::RangeInclusive(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..=vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2302,7 +2300,7 @@ mod test {
         let queryitems = vec![QueryItem::RangeInclusive(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..=vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(1), true)
             .expect("create_proof errored");
 
@@ -2335,7 +2333,7 @@ mod test {
         let queryitems = vec![QueryItem::RangeInclusive(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..=vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(2), true)
             .expect("create_proof errored");
 
@@ -2368,7 +2366,7 @@ mod test {
         let queryitems = vec![QueryItem::RangeInclusive(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..=vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(200), true)
             .expect("create_proof errored");
 
@@ -2398,7 +2396,7 @@ mod test {
         let queryitems = vec![QueryItem::RangeInclusive(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..=vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, false)
             .expect("create_proof errored");
 
@@ -2425,7 +2423,7 @@ mod test {
         let queryitems = vec![QueryItem::RangeInclusive(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..=vec![0, 0, 0, 0, 0, 0, 0, 7],
         )];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, Some(2), false)
             .expect("create_proof errored");
 
@@ -2452,7 +2450,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2492,12 +2490,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::Key(vec![5])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2520,7 +2518,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), None, true)
             .expect("create_proof errored");
 
@@ -2529,7 +2527,7 @@ mod test {
             QueryItem::Key(vec![6]),
             QueryItem::Key(vec![7]),
         ];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2555,12 +2553,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(100), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2587,7 +2585,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(1), true)
             .expect("create_proof errored");
 
@@ -2615,7 +2613,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(2), true)
             .expect("create_proof errored");
 
@@ -2643,7 +2641,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(200), true)
             .expect("create_proof errored");
 
@@ -2671,7 +2669,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, false)
             .expect("create_proof errored");
 
@@ -2693,7 +2691,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![5]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), Some(1), false)
             .expect("create_proof errored");
 
@@ -2725,7 +2723,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeTo(..vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2783,12 +2781,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeTo(..vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeToInclusive(..=vec![2])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2811,12 +2809,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeTo(..vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeToInclusive(..=vec![3])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2842,12 +2840,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeTo(..vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(100), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeTo(..vec![6])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -2879,7 +2877,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeTo(..vec![6])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(1), true)
             .expect("create_proof errored");
 
@@ -2907,7 +2905,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeTo(..vec![6])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(2), true)
             .expect("create_proof errored");
 
@@ -2935,7 +2933,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeTo(..vec![6])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(200), true)
             .expect("create_proof errored");
 
@@ -2963,7 +2961,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeTo(..vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, false)
             .expect("create_proof errored");
 
@@ -2990,7 +2988,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeTo(..vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), None, false)
             .expect("create_proof errored");
 
@@ -3018,7 +3016,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3076,12 +3074,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeToInclusive(..=vec![2])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3104,12 +3102,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeToInclusive(..=vec![3])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3135,12 +3133,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(100), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3172,7 +3170,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(1), true)
             .expect("create_proof errored");
 
@@ -3200,7 +3198,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(2), true)
             .expect("create_proof errored");
 
@@ -3228,7 +3226,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(200), true)
             .expect("create_proof errored");
 
@@ -3256,7 +3254,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, false)
             .expect("create_proof errored");
 
@@ -3283,7 +3281,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeToInclusive(..=vec![6])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(1), false)
             .expect("create_proof errored");
 
@@ -3315,7 +3313,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![RangeAfter(vec![3]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3373,12 +3371,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfter(vec![3]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![4])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3401,12 +3399,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfter(vec![3]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![5])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3432,12 +3430,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfter(vec![3]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(100), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeAfter(vec![3]..)];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3469,7 +3467,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfter(vec![3]..)];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(1), true)
             .expect("create_proof errored");
 
@@ -3497,7 +3495,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfter(vec![3]..)];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(2), true)
             .expect("create_proof errored");
 
@@ -3525,7 +3523,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfter(vec![3]..)];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(200), true)
             .expect("create_proof errored");
 
@@ -3553,7 +3551,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![RangeAfter(vec![3]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, false)
             .expect("create_proof errored");
 
@@ -3580,7 +3578,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![RangeAfter(vec![3]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(3), None, false)
             .expect("create_proof errored");
 
@@ -3608,7 +3606,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3676,12 +3674,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![4])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3704,12 +3702,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![5])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3735,12 +3733,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(100), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3767,7 +3765,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(1), true)
             .expect("create_proof errored");
 
@@ -3795,7 +3793,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(2), true)
             .expect("create_proof errored");
 
@@ -3823,7 +3821,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(200), true)
             .expect("create_proof errored");
 
@@ -3851,7 +3849,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, false)
             .expect("create_proof errored");
 
@@ -3873,7 +3871,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterTo(vec![3]..vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(300), Some(1), false)
             .expect("create_proof errored");
 
@@ -3905,7 +3903,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3964,12 +3962,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![4])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -3992,12 +3990,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![5])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -4023,12 +4021,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(100), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![7])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -4055,7 +4053,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![7])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(1), true)
             .expect("create_proof errored");
 
@@ -4083,7 +4081,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![7])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(2), true)
             .expect("create_proof errored");
 
@@ -4111,7 +4109,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![7])];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(200), true)
             .expect("create_proof errored");
 
@@ -4139,7 +4137,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeAfterToInclusive(vec![3]..=vec![7])];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, false)
             .expect("create_proof errored");
 
@@ -4164,7 +4162,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFull(..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -4210,12 +4208,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFull(..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeToInclusive(..=vec![2])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -4238,12 +4236,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFull(..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeToInclusive(..=vec![3])];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -4269,12 +4267,12 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFull(..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(100), None, true)
             .expect("create_proof errored");
 
         let equivalent_queryitems = vec![QueryItem::RangeFull(..)];
-        let (equivalent_proof, equivalent_absence) = walker
+        let (equivalent_proof, equivalent_absence, ..) = walker
             .create_full_proof(equivalent_queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -4308,7 +4306,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFull(..)];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(3), Some(1), true)
             .expect("create_proof errored");
 
@@ -4339,7 +4337,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFull(..)];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), Some(2), true)
             .expect("create_proof errored");
 
@@ -4370,7 +4368,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFull(..)];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(200), true)
             .expect("create_proof errored");
 
@@ -4398,7 +4396,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFull(..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, false)
             .expect("create_proof errored");
 
@@ -4427,7 +4425,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFull(..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(2), Some(2), false)
             .expect("create_proof errored");
 
@@ -4462,9 +4460,13 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![2]..)];
-        let (proof, _) = walker
+        let (proof, _, limit, offset) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), None, true)
             .expect("create_proof errored");
+
+        // TODO: Add this test for other range types
+        assert_eq!(limit, Some(0));
+        assert_eq!(offset, None);
 
         let mut iter = proof.iter();
         assert_eq!(iter.next(), Some(&Op::Push(Node::KV(vec![2], vec![2]))));
@@ -4520,7 +4522,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![2]..)];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(queryitems.as_slice(), Some(1), Some(2), true)
             .expect("create_proof errored");
 
@@ -4592,7 +4594,7 @@ mod test {
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeFrom(vec![3]..)];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, false)
             .expect("create_proof errored");
 
@@ -4660,7 +4662,7 @@ mod test {
         let queryitems = vec![QueryItem::Range(
             vec![0, 0, 0, 0, 0, 0, 0, 5]..vec![0, 0, 0, 0, 0, 0, 0, 6, 5],
         )];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -4751,7 +4753,7 @@ mod test {
             // 7 is not inclusive
             QueryItem::Range(vec![0, 0, 0, 0, 0, 0, 0, 5, 5]..vec![0, 0, 0, 0, 0, 0, 0, 7]),
         ];
-        let (proof, absence) = walker
+        let (proof, absence, ..) = walker
             .create_full_proof(queryitems.as_slice(), None, None, true)
             .expect("create_proof errored");
 
@@ -4884,7 +4886,7 @@ mod test {
         let root_hash = tree.hash();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(vec![QueryItem::Key(vec![5])].as_slice(), None, None, true)
             .expect("failed to create proof");
         let mut bytes = vec![];
@@ -4906,7 +4908,7 @@ mod test {
 
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(vec![QueryItem::Key(vec![5])].as_slice(), None, None, true)
             .expect("failed to create proof");
         let mut bytes = vec![];
@@ -4922,7 +4924,7 @@ mod test {
         let mut tree = make_3_node_tree();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
         let keys = vec![vec![5], vec![7]];
-        let (proof, _) = walker
+        let (proof, ..) = walker
             .create_full_proof(
                 keys.clone()
                     .into_iter()

--- a/merk/src/tree/kv.rs
+++ b/merk/src/tree/kv.rs
@@ -125,6 +125,8 @@ impl Decode for KV {
         self.value.clear();
         input.read_to_end(self.value.as_mut())?;
 
+        self.value_hash = value_hash(self.value());
+
         Ok(())
     }
 }

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -108,7 +108,7 @@ impl Tree {
         self.inner.kv.hash()
     }
 
-    /// Returns the hash of the node's value
+    /// Returns the hash of the node's valu
     #[inline]
     pub const fn value_hash(&self) -> &Hash {
         self.inner.kv.value_hash()


### PR DESCRIPTION
The verify_query function must be called with the same limit and offset values
that was used during proof construction. (anything different and verification
fails).

Grovedb proof_construction chains multiple merk proofs.
To verify a chain, we need to know the output of the previous
verification i.e (remaining limit and offset values)

This pr allows the verification function to return the net limit and offset value