### PR TITLE
feat: GroveDB batch operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ members = [
     "merk",
     "node-grove",
     "storage",
+    "visualize",
 ]

--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -14,6 +14,7 @@ storage = { path = "../storage", features = ["rocksdb_storage"] }
 hex = "0.4.3"
 itertools = { version = "0.10.3", optional = true }
 integer-encoding = "3.0.3"
+intrusive-collections = "0.9.3"
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -11,6 +11,7 @@ tempfile = "3"
 bincode = "1.3.3"
 serde = { version = "1.0.136", features = ["derive"] }
 storage = { path = "../storage", features = ["rocksdb_storage"] }
+visualize = { path = "../visualize" }
 hex = "0.4.3"
 itertools = { version = "0.10.3", optional = true }
 integer-encoding = "3.0.3"
@@ -19,10 +20,7 @@ intrusive-collections = "0.9.3"
 [dev-dependencies]
 rand = "0.8.4"
 criterion = "0.3"
-
-[features]
-default = ["visualize"]
-visualize = ["itertools"]
+hex = "0.4.3"
 
 [[bench]]
 name = "insertion_benchmark"

--- a/grovedb/benches/insertion_benchmark.rs
+++ b/grovedb/benches/insertion_benchmark.rs
@@ -48,7 +48,7 @@ pub fn root_leaf_insertion_benchmark_without_transaction(c: &mut Criterion) {
     let db = GroveDb::open(dir.path()).unwrap();
     let keys = std::iter::repeat_with(|| rand::thread_rng().gen::<[u8; 32]>()).take(10);
 
-    c.bench_function("root leafs insertion without transaction", |b| {
+    c.bench_function("root leaves insertion without transaction", |b| {
         b.iter(|| {
             for k in keys.clone() {
                 db.insert([], &k, Element::empty_tree(), None).unwrap();
@@ -62,7 +62,7 @@ pub fn root_leaf_insertion_benchmark_with_transaction(c: &mut Criterion) {
     let db = GroveDb::open(dir.path()).unwrap();
     let keys = std::iter::repeat_with(|| rand::thread_rng().gen::<[u8; 32]>()).take(10);
 
-    c.bench_function("root leafs insertion with transaction", |b| {
+    c.bench_function("root leaves insertion with transaction", |b| {
         b.iter(|| {
             let tx = db.start_transaction();
             for k in keys.clone() {

--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -203,13 +203,10 @@ impl GroveDb {
                 } else {
                     // Keep opened Merk instances to accumulate changes before taking final root
                     // hash
-                    if !temp_subtrees.contains_key(&op.path) {
-                        let merk = get_merk_fn(&op.path)?;
-                        temp_subtrees.insert(op.path.clone(), merk);
-                    }
                     let mut merk = temp_subtrees
                         .remove(&op.path)
-                        .expect("subtree was inserted before");
+                        .map(Ok)
+                        .unwrap_or_else(|| get_merk_fn(&op.path))?;
 
                     // On subtree deletion/overwrite we need to do Merk's cleanup
                     match Element::get(&merk, &op.key) {

--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -1,0 +1,336 @@
+//! GroveDB batch operations support
+
+use std::{cmp::Ordering, collections::HashMap};
+
+use intrusive_collections::{intrusive_adapter, KeyAdapter, RBTree, RBTreeLink};
+use merk::Merk;
+use storage::{Storage, StorageBatch, StorageContext};
+
+use crate::{
+    util::storage_context_optional_tx, Element, Error, GroveDb, TransactionArg,
+    ROOT_LEAFS_SERIALIZED_KEY,
+};
+
+#[derive(Debug)]
+enum Op {
+    Insert { element: Element },
+    Delete,
+}
+
+/// Batch operation
+#[derive(Debug)]
+pub struct GroveDbOp {
+    /// Path to a subtree - subject to an operation
+    path: Vec<Vec<u8>>,
+    /// Key of an element in the subtree
+    key: Vec<u8>,
+    /// Operation to perform on the key
+    op: Op,
+    /// Link used in intrusive tree to maintain operations order
+    link: RBTreeLink,
+}
+
+// TODO: keep allocation number small
+intrusive_adapter!(GroveDbOpAdapter = Box<GroveDbOp> : GroveDbOp { link: RBTreeLink });
+
+impl<'a> KeyAdapter<'a> for GroveDbOpAdapter {
+    type Key = &'a [Vec<u8>];
+
+    fn get_key(&self, value: &'a GroveDbOp) -> Self::Key {
+        &value.path
+    }
+}
+
+impl GroveDbOp {
+    pub fn insert(path: Vec<Vec<u8>>, key: Vec<u8>, element: Element) -> Self {
+        Self {
+            path,
+            key,
+            op: Op::Insert { element },
+            link: RBTreeLink::new(),
+        }
+    }
+
+    pub fn delete(path: Vec<Vec<u8>>, key: Vec<u8>) -> Self {
+        Self {
+            path,
+            key,
+            op: Op::Delete,
+            link: RBTreeLink::new(),
+        }
+    }
+}
+
+impl GroveDb {
+    pub fn apply_batch(
+        &self,
+        ops: Vec<GroveDbOp>,
+        transaction: TransactionArg,
+    ) -> Result<(), Error> {
+        if ops.is_empty() {
+            return Ok(());
+        }
+        let storage_batch = StorageBatch::new();
+        let mut tree = RBTree::new(GroveDbOpAdapter::new());
+        let mut temp_root_leafs = self.get_root_leaf_keys(transaction)?;
+
+        // 1. Collect all batch operations into RBTree to keep them sorted
+        for o in ops {
+            tree.insert(Box::new(o));
+        }
+        if let Some(tx) = transaction {
+            let mut temp_subtrees: HashMap<Vec<Vec<u8>>, Merk<_>> = HashMap::new();
+            let mut cursor = tree.back_mut();
+            let mut prev_path = cursor.get().expect("batch is not empty").path.clone();
+
+            loop {
+                // Run propagation if next operation is on different path or no more operations
+                // left
+                if cursor.get().map(|op| op.path != prev_path).unwrap_or(true) {
+                    if let Some((key, path_slice)) = prev_path.split_last() {
+                        let hash = temp_subtrees
+                            .remove(&prev_path)
+                            .expect("subtree was inserted before")
+                            .root_hash();
+
+                        cursor.insert(Box::new(GroveDbOp::insert(
+                            path_slice.to_vec(),
+                            key.to_vec(),
+                            Element::Tree(hash),
+                        )));
+                    }
+                }
+
+                // Execute next available operation
+                cursor = tree.back_mut();
+                if let Some(op) = cursor.remove() {
+                    if op.path.is_empty() {
+                        // Altering root leafs
+                        if temp_root_leafs.get(&op.key).is_none() {
+                            temp_root_leafs.insert(op.key, temp_root_leafs.len());
+                        }
+                    } else {
+                        // Keep opened Merk instances to accumulate changes before taking final root
+                        // hash
+                        if !temp_subtrees.contains_key(&op.path) {
+                            let storage = self.db.get_batch_transactional_storage_context(
+                                op.path.iter().map(|x| x.as_slice()),
+                                &storage_batch,
+                                tx,
+                            );
+                            let merk = Merk::open(storage).map_err(|_| {
+                                Error::CorruptedData("cannot open a subtree".to_owned())
+                            })?;
+                            temp_subtrees.insert(op.path.clone(), merk);
+                        }
+                        let mut merk = temp_subtrees
+                            .get_mut(&op.path)
+                            .expect("subtree was inserted before");
+                        match op.op {
+                            Op::Insert { element } => {
+                                element.insert(&mut merk, op.key)?;
+                            }
+                            Op::Delete => {
+                                Element::delete(&mut merk, op.key)?;
+                            }
+                        }
+                    }
+                    prev_path = op.path;
+                } else {
+                    break;
+                }
+            }
+            let meta_storage = self.db.get_batch_transactional_storage_context(
+                std::iter::empty(),
+                &storage_batch,
+                tx,
+            );
+            let root_leafs_serialized = bincode::serialize(&temp_root_leafs).map_err(|_| {
+                Error::CorruptedData(String::from("unable to serialize root leaves data"))
+            })?;
+            meta_storage.put_meta(ROOT_LEAFS_SERIALIZED_KEY, &root_leafs_serialized)?;
+        }
+
+        dbg!(tree);
+        dbg!(storage_batch);
+        todo!()
+    }
+
+    // pub fn apply_batch(
+    //     &self,
+    //     batch: &[GroveDbOp],
+    //     transaction: TransactionArg,
+    // ) -> Result<(), Error> {
+    //     // TODO: validate chains
+    //     let mut storage_batch = StorageBatch::new();
+    //     if let Some(tx) = transaction {
+    //         // Temp subtrees are required to accumulate changes, to compute root
+    // hashes and         // to do propagation --- all of these with no `get`
+    // queries to the database         let mut temp_subtrees = HashMap::new();
+    //         for op in batch {
+    //             match op {
+    //                 GroveDbOp::Insert { path, key, element } => {
+    //                     let storage =
+    // self.db.get_batch_transactional_storage_context(
+    // path.iter().map(|x| *x),                         &storage_batch,
+    //                         tx,
+    //                     );
+    //                     let merk = Merk::open(storage).map_err(|_| {
+    //                         crate::Error::CorruptedData("cannot open a
+    // subtree".to_owned())                     })?;
+    //                     temp_subtrees.insert(path, merk);
+    //                 }
+    //                 _ => todo!(),
+    //             }
+    //         }
+    //     } else {
+    //         // Temp subtrees are required to accumulate changes, to compute root
+    //         // hashes and to do propagation --- all of these with no
+    //         // `get` queries to the database let mut temp_subtrees =
+    //         // HashMap::new();
+    //     }
+
+    //     todo!()
+    // }
+    //
+    // pub fn apply_batch(
+    //     &self,
+    //     mut ops: Vec<GroveDbOp>,
+    //     transaction: TransactionArg,
+    // ) -> Result<(), Error> {
+    //     if ops.is_empty() {
+    //         return Ok(());
+    //     }
+
+    //     // TODO: validate chains
+    //     let mut storage_batch = StorageBatch::new();
+
+    //     // Opearations need to be sorted and applied using a stack structure:
+    //     // 1. First we apply deepmost operations grouped by path
+    //     // 2. If there are no operations for a subtree left, we put onto stack a
+    //     //    propagation operation: insert to an upper tree its root hash
+    //     // 3. Repeat until the stack is empty
+
+    //     // We'll use vector as a stack, so operations will be run from its tail,
+    // thus     // deletions go before insertions and operations on children
+    // will go after ones     // on parent because of reverse order
+    //     ops.sort_by(|a, b| match (a, b) {
+    //         // Delete is always before insert (remember reverse order of
+    // execution)         (GroveDbOp::Delete { .. }, GroveDbOp::Insert { .. })
+    // => Ordering::Less,         (GroveDbOp::Insert { .. }, GroveDbOp::Delete {
+    // .. }) => Ordering::Greater,         // For operations of the same kind we
+    // put shorter paths first         (GroveDbOp::Delete { path: left, .. },
+    // GroveDbOp::Delete { path: right, .. }) => {             left.cmp(right)
+    //         }
+    //         (GroveDbOp::Insert { path: left, .. }, GroveDbOp::Insert { path:
+    // right, .. }) => {             left.cmp(right)
+    //         }
+    //     });
+
+    //     if let Some(tx) = transaction {
+    //         let mut prev_path: Option<&[&[u8]]> = None;
+    //         let mut merk: Option<Merk<_>> = None;
+
+    //         while let Some(op) = ops.last() {
+    //             let current_path = match op {
+    //                 GroveDbOp::Insert { path, .. } => path,
+    //                 GroveDbOp::Delete { path, .. } => path,
+    //             };
+    //             // 1. Initially or because we're moving to next subtree
+    //         }
+
+    //         // while let Some(op) = ops.pop() {
+    //         //     let current_path = match op {
+    //         //         GroveDbOp::Insert { path, .. } => path,
+    //         //         GroveDbOp::Delete { path, .. } => path,
+    //         //     };
+
+    //         //     if Some(current_path) != prev_path {
+    //         //         if let Some(pp) = prev_path {
+    //         //             // Finished with a deeper subtree, need to propagate
+    // its root hash to parent         //             ops.push(GroveDbOp::Insert
+    // {         //                 path: current_path,
+    //         //                 key: todo!(),
+    //         //                 element: Element::Tree(merk.expect("Merk must
+    // exist").root_hash()),         //             });
+    //         //         }
+    //         //         let storage =
+    // self.db.get_batch_transactional_storage_context(         //
+    // current_path.iter().map(|x| *x),         //             &storage_batch,
+    //         //             tx,
+    //         //         );
+    //         //         prev_path = Some(current_path);
+    //         //         merk =
+    //         //             Some(Merk::open(storage).map_err(|_| {
+    //         //                 Error::CorruptedData("cannot open a
+    // subtree".to_owned())         //             })?);
+    //         //     }
+    //         // }
+    //     } else {
+    //     }
+
+    //     // if let Some(tx) = transaction {
+    //     //     // Temp subtrees are required to accumulate changes, to compute
+    // root hashes and     //     // to do propagation --- all of these with no
+    // `get` queries to the database     //     let mut temp_subtrees =
+    // HashMap::new();     //     for op in batch {
+    //     //         match op {
+    //     //             GroveDbOp::Insert { path, key, element } => {
+    //     //                 let storage =
+    // self.db.get_batch_transactional_storage_context(     //
+    // path.iter().map(|x| *x),     //                     &storage_batch,
+    //     //                     tx,
+    //     //                 );
+    //     //                 let merk = Merk::open(storage).map_err(|_| {
+    //     //                     crate::Error::CorruptedData("cannot open a
+    // subtree".to_owned())     //                 })?;
+    //     //                 temp_subtrees.insert(path, merk);
+    //     //             }
+    //     //             _ => todo!(),
+    //     //         }
+    //     //     }
+    //     // } else {
+    //     //     // Temp subtrees are required to accumulate changes, to compute
+    // root     //     // hashes and to do propagation --- all of these with no
+    //     //     // `get` queries to the database let mut temp_subtrees =
+    //     //     // HashMap::new();
+    //     // }
+
+    //     todo!()
+    // }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::make_grovedb;
+
+    #[test]
+    fn test_something() {
+        let ops = vec![
+            GroveDbOp::insert(
+                vec![b"ass".to_vec(), b"we".to_vec(), b"can".to_vec()],
+                b"key".to_vec(),
+                Element::empty_tree(),
+            ),
+            GroveDbOp::insert(
+                vec![
+                    b"ass".to_vec(),
+                    b"we".to_vec(),
+                    b"can".to_vec(),
+                    b"ayy".to_vec(),
+                ],
+                b"key".to_vec(),
+                Element::empty_tree(),
+            ),
+            GroveDbOp::insert(
+                vec![b"ass".to_vec(), b"can".to_vec()],
+                b"key".to_vec(),
+                Element::empty_tree(),
+            ),
+        ];
+        let db = make_grovedb();
+        let tx = db.start_transaction();
+        db.apply_batch(ops, Some(&tx));
+    }
+}

--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -62,6 +62,68 @@ impl GroveDbOp {
 }
 
 impl GroveDb {
+    fn apply_body<'db, 'ctx, S: StorageContext<'db, 'ctx> + 'ctx>(
+        &self,
+        tree: &mut RBTree<GroveDbOpAdapter>,
+        get_merk_fn: impl Fn(&[Vec<u8>]) -> Result<Merk<S>, Error>,
+    ) -> Result<(), Error> {
+        let mut temp_subtrees: HashMap<Vec<Vec<u8>>, Merk<_>> = HashMap::new();
+        let mut cursor = tree.back_mut();
+        let mut prev_path = cursor.get().expect("batch is not empty").path.clone();
+
+        loop {
+            // Run propagation if next operation is on different path or no more operations
+            // left
+            if cursor.get().map(|op| op.path != prev_path).unwrap_or(true) {
+                if let Some((key, path_slice)) = prev_path.split_last() {
+                    let hash = temp_subtrees
+                        .remove(&prev_path)
+                        .expect("subtree was inserted before")
+                        .root_hash();
+
+                    cursor.insert(Box::new(GroveDbOp::insert(
+                        path_slice.to_vec(),
+                        key.to_vec(),
+                        Element::Tree(hash),
+                    )));
+                }
+            }
+
+            // Execute next available operation
+            cursor = tree.back_mut();
+            if let Some(op) = cursor.remove() {
+                if op.path.is_empty() {
+                    // Altering root leafs
+                    // if temp_root_leafs.get(&op.key).is_none() {
+                    //     temp_root_leafs.insert(op.key,
+                    // temp_root_leafs.len()); }
+                } else {
+                    // Keep opened Merk instances to accumulate changes before taking final root
+                    // hash
+                    if !temp_subtrees.contains_key(&op.path) {
+                        let merk = get_merk_fn(&op.path)?;
+                        temp_subtrees.insert(op.path.clone(), merk);
+                    }
+                    let mut merk = temp_subtrees
+                        .get_mut(&op.path)
+                        .expect("subtree was inserted before");
+                    match op.op {
+                        Op::Insert { element } => {
+                            element.insert(&mut merk, op.key)?;
+                        }
+                        Op::Delete => {
+                            Element::delete(&mut merk, op.key)?;
+                        }
+                    }
+                }
+                prev_path = op.path;
+            } else {
+                break;
+            }
+        }
+        Ok(())
+    }
+
     pub fn apply_batch(
         &self,
         ops: Vec<GroveDbOp>,
@@ -149,155 +211,12 @@ impl GroveDb {
                 Error::CorruptedData(String::from("unable to serialize root leaves data"))
             })?;
             meta_storage.put_meta(ROOT_LEAFS_SERIALIZED_KEY, &root_leafs_serialized)?;
+            self.db
+                .commit_multi_context_batch_with_transaction(storage_batch, tx)?;
         }
 
-        dbg!(tree);
-        dbg!(storage_batch);
         todo!()
     }
-
-    // pub fn apply_batch(
-    //     &self,
-    //     batch: &[GroveDbOp],
-    //     transaction: TransactionArg,
-    // ) -> Result<(), Error> {
-    //     // TODO: validate chains
-    //     let mut storage_batch = StorageBatch::new();
-    //     if let Some(tx) = transaction {
-    //         // Temp subtrees are required to accumulate changes, to compute root
-    // hashes and         // to do propagation --- all of these with no `get`
-    // queries to the database         let mut temp_subtrees = HashMap::new();
-    //         for op in batch {
-    //             match op {
-    //                 GroveDbOp::Insert { path, key, element } => {
-    //                     let storage =
-    // self.db.get_batch_transactional_storage_context(
-    // path.iter().map(|x| *x),                         &storage_batch,
-    //                         tx,
-    //                     );
-    //                     let merk = Merk::open(storage).map_err(|_| {
-    //                         crate::Error::CorruptedData("cannot open a
-    // subtree".to_owned())                     })?;
-    //                     temp_subtrees.insert(path, merk);
-    //                 }
-    //                 _ => todo!(),
-    //             }
-    //         }
-    //     } else {
-    //         // Temp subtrees are required to accumulate changes, to compute root
-    //         // hashes and to do propagation --- all of these with no
-    //         // `get` queries to the database let mut temp_subtrees =
-    //         // HashMap::new();
-    //     }
-
-    //     todo!()
-    // }
-    //
-    // pub fn apply_batch(
-    //     &self,
-    //     mut ops: Vec<GroveDbOp>,
-    //     transaction: TransactionArg,
-    // ) -> Result<(), Error> {
-    //     if ops.is_empty() {
-    //         return Ok(());
-    //     }
-
-    //     // TODO: validate chains
-    //     let mut storage_batch = StorageBatch::new();
-
-    //     // Opearations need to be sorted and applied using a stack structure:
-    //     // 1. First we apply deepmost operations grouped by path
-    //     // 2. If there are no operations for a subtree left, we put onto stack a
-    //     //    propagation operation: insert to an upper tree its root hash
-    //     // 3. Repeat until the stack is empty
-
-    //     // We'll use vector as a stack, so operations will be run from its tail,
-    // thus     // deletions go before insertions and operations on children
-    // will go after ones     // on parent because of reverse order
-    //     ops.sort_by(|a, b| match (a, b) {
-    //         // Delete is always before insert (remember reverse order of
-    // execution)         (GroveDbOp::Delete { .. }, GroveDbOp::Insert { .. })
-    // => Ordering::Less,         (GroveDbOp::Insert { .. }, GroveDbOp::Delete {
-    // .. }) => Ordering::Greater,         // For operations of the same kind we
-    // put shorter paths first         (GroveDbOp::Delete { path: left, .. },
-    // GroveDbOp::Delete { path: right, .. }) => {             left.cmp(right)
-    //         }
-    //         (GroveDbOp::Insert { path: left, .. }, GroveDbOp::Insert { path:
-    // right, .. }) => {             left.cmp(right)
-    //         }
-    //     });
-
-    //     if let Some(tx) = transaction {
-    //         let mut prev_path: Option<&[&[u8]]> = None;
-    //         let mut merk: Option<Merk<_>> = None;
-
-    //         while let Some(op) = ops.last() {
-    //             let current_path = match op {
-    //                 GroveDbOp::Insert { path, .. } => path,
-    //                 GroveDbOp::Delete { path, .. } => path,
-    //             };
-    //             // 1. Initially or because we're moving to next subtree
-    //         }
-
-    //         // while let Some(op) = ops.pop() {
-    //         //     let current_path = match op {
-    //         //         GroveDbOp::Insert { path, .. } => path,
-    //         //         GroveDbOp::Delete { path, .. } => path,
-    //         //     };
-
-    //         //     if Some(current_path) != prev_path {
-    //         //         if let Some(pp) = prev_path {
-    //         //             // Finished with a deeper subtree, need to propagate
-    // its root hash to parent         //             ops.push(GroveDbOp::Insert
-    // {         //                 path: current_path,
-    //         //                 key: todo!(),
-    //         //                 element: Element::Tree(merk.expect("Merk must
-    // exist").root_hash()),         //             });
-    //         //         }
-    //         //         let storage =
-    // self.db.get_batch_transactional_storage_context(         //
-    // current_path.iter().map(|x| *x),         //             &storage_batch,
-    //         //             tx,
-    //         //         );
-    //         //         prev_path = Some(current_path);
-    //         //         merk =
-    //         //             Some(Merk::open(storage).map_err(|_| {
-    //         //                 Error::CorruptedData("cannot open a
-    // subtree".to_owned())         //             })?);
-    //         //     }
-    //         // }
-    //     } else {
-    //     }
-
-    //     // if let Some(tx) = transaction {
-    //     //     // Temp subtrees are required to accumulate changes, to compute
-    // root hashes and     //     // to do propagation --- all of these with no
-    // `get` queries to the database     //     let mut temp_subtrees =
-    // HashMap::new();     //     for op in batch {
-    //     //         match op {
-    //     //             GroveDbOp::Insert { path, key, element } => {
-    //     //                 let storage =
-    // self.db.get_batch_transactional_storage_context(     //
-    // path.iter().map(|x| *x),     //                     &storage_batch,
-    //     //                     tx,
-    //     //                 );
-    //     //                 let merk = Merk::open(storage).map_err(|_| {
-    //     //                     crate::Error::CorruptedData("cannot open a
-    // subtree".to_owned())     //                 })?;
-    //     //                 temp_subtrees.insert(path, merk);
-    //     //             }
-    //     //             _ => todo!(),
-    //     //         }
-    //     //     }
-    //     // } else {
-    //     //     // Temp subtrees are required to accumulate changes, to compute
-    // root     //     // hashes and to do propagation --- all of these with no
-    //     //     // `get` queries to the database let mut temp_subtrees =
-    //     //     // HashMap::new();
-    //     // }
-
-    //     todo!()
-    // }
 }
 
 #[cfg(test)]
@@ -305,32 +224,32 @@ mod tests {
     use super::*;
     use crate::tests::make_grovedb;
 
-    #[test]
-    fn test_something() {
-        let ops = vec![
-            GroveDbOp::insert(
-                vec![b"ass".to_vec(), b"we".to_vec(), b"can".to_vec()],
-                b"key".to_vec(),
-                Element::empty_tree(),
-            ),
-            GroveDbOp::insert(
-                vec![
-                    b"ass".to_vec(),
-                    b"we".to_vec(),
-                    b"can".to_vec(),
-                    b"ayy".to_vec(),
-                ],
-                b"key".to_vec(),
-                Element::empty_tree(),
-            ),
-            GroveDbOp::insert(
-                vec![b"ass".to_vec(), b"can".to_vec()],
-                b"key".to_vec(),
-                Element::empty_tree(),
-            ),
-        ];
-        let db = make_grovedb();
-        let tx = db.start_transaction();
-        db.apply_batch(ops, Some(&tx));
-    }
+    // #[test]
+    // fn test_something() {
+    //     let ops = vec![
+    //         GroveDbOp::insert(
+    //             vec![b"ass".to_vec(), b"we".to_vec(), b"can".to_vec()],
+    //             b"key".to_vec(),
+    //             Element::empty_tree(),
+    //         ),
+    //         GroveDbOp::insert(
+    //             vec![
+    //                 b"ass".to_vec(),
+    //                 b"we".to_vec(),
+    //                 b"can".to_vec(),
+    //                 b"ayy".to_vec(),
+    //             ],
+    //             b"key".to_vec(),
+    //             Element::empty_tree(),
+    //         ),
+    //         GroveDbOp::insert(
+    //             vec![b"ass".to_vec(), b"can".to_vec()],
+    //             b"key".to_vec(),
+    //             Element::empty_tree(),
+    //         ),
+    //     ];
+    //     let db = make_grovedb();
+    //     let tx = db.start_transaction();
+    //     db.apply_batch(ops, Some(&tx));
+    // }
 }

--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -59,7 +59,7 @@ impl GroveDbOp {
 }
 
 impl GroveDb {
-    fn apply_body<'db, 'ctx, S: StorageContext<'db, 'ctx> + 'ctx>(
+    fn apply_body<'db, S: StorageContext<'db>>(
         &self,
         sorted_operations: &mut RBTree<GroveDbOpAdapter>,
         temp_root_leaves: &mut BTreeMap<Vec<u8>, usize>,
@@ -135,8 +135,8 @@ impl GroveDb {
             temp_root_leaves: &BTreeMap<Vec<u8>, usize>,
         ) -> Result<(), Error>
         where
-            S: StorageContext<'db, 'ctx>,
-            Error: From<<S as storage::StorageContext<'db, 'ctx>>::Error>,
+            S: StorageContext<'db>,
+            Error: From<<S as storage::StorageContext<'db>>::Error>,
         {
             let root_leaves_serialized = bincode::serialize(&temp_root_leaves).map_err(|_| {
                 Error::CorruptedData(String::from("unable to serialize root leaves data"))

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -146,12 +146,12 @@ impl GroveDb {
         Ok(Self::get_root_tree_internal(&self.db, transaction)?.root())
     }
 
-    fn get_root_leaf_keys_internal<'db, 'ctx, S>(
+    fn get_root_leaf_keys_internal<'db, S>(
         meta_storage: &S,
     ) -> Result<BTreeMap<Vec<u8>, usize>, Error>
     where
-        S: StorageContext<'db, 'ctx>,
-        Error: From<<S as StorageContext<'db, 'ctx>>::Error>,
+        S: StorageContext<'db>,
+        Error: From<<S as StorageContext<'db>>::Error>,
     {
         let root_leaf_keys: BTreeMap<Vec<u8>, usize> = if let Some(root_leaf_keys_serialized) =
             meta_storage.get_meta(ROOT_LEAFS_SERIALIZED_KEY)?

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -28,7 +28,7 @@ use crate::util::{merk_optional_tx, meta_storage_context_optional_tx};
 
 /// A key to store serialized data about subtree prefixes to restore HADS
 /// structure
-/// A key to store serialized data about root tree leafs keys and order
+/// A key to store serialized data about root tree leaves keys and order
 const ROOT_LEAFS_SERIALIZED_KEY: &[u8] = b"rootLeafsSerialized";
 
 #[derive(Debug, thiserror::Error)]
@@ -157,7 +157,7 @@ impl GroveDb {
             meta_storage.get_meta(ROOT_LEAFS_SERIALIZED_KEY)?
         {
             bincode::deserialize(&root_leaf_keys_serialized).map_err(|_| {
-                Error::CorruptedData(String::from("unable to deserialize root leafs"))
+                Error::CorruptedData(String::from("unable to deserialize root leaves"))
             })?
         } else {
             BTreeMap::new()

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -4,7 +4,6 @@ mod subtree;
 #[cfg(test)]
 mod tests;
 mod util;
-#[cfg(feature = "visualize")]
 mod visualize;
 
 use std::{
@@ -21,8 +20,6 @@ pub use storage::{
     Storage, StorageContext,
 };
 pub use subtree::Element;
-#[cfg(feature = "visualize")]
-pub use visualize::{visualize_stderr, visualize_stdout, Drawer, Visualize};
 
 use crate::util::{merk_optional_tx, meta_storage_context_optional_tx};
 

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -1,3 +1,4 @@
+mod batch;
 mod operations;
 mod subtree;
 #[cfg(test)]
@@ -5,6 +6,7 @@ mod tests;
 mod util;
 #[cfg(feature = "visualize")]
 mod visualize;
+
 use std::{
     collections::{BTreeMap, HashMap},
     path::Path,

--- a/grovedb/src/operations/delete.rs
+++ b/grovedb/src/operations/delete.rs
@@ -92,8 +92,7 @@ impl GroveDb {
 
             if let Element::Tree(_) = element {
                 let subtree_merk_path = path_iter.clone().chain(std::iter::once(key));
-                let subtrees_paths =
-                    self.find_subtrees(subtree_merk_path.clone(), transaction, true)?;
+                let subtrees_paths = self.find_subtrees(subtree_merk_path.clone(), transaction)?;
                 let is_empty =
                     merk_optional_tx!(self.db, subtree_merk_path, transaction, subtree, {
                         subtree.is_empty_tree()
@@ -137,7 +136,6 @@ impl GroveDb {
         &self,
         path: P,
         transaction: TransactionArg,
-        include_parent: bool,
     ) -> Result<Vec<Vec<Vec<u8>>>, Error>
     where
         P: IntoIterator<Item = &'p [u8]>,
@@ -152,11 +150,7 @@ impl GroveDb {
 
         let mut queue: Vec<Vec<Vec<u8>>> =
             vec![path.into_iter().map(|x| x.as_ref().to_vec()).collect()];
-        let mut result: Vec<Vec<Vec<u8>>> = if include_parent {
-            queue.clone()
-        } else {
-            Vec::new()
-        };
+        let mut result: Vec<Vec<Vec<u8>>> = queue.clone();
 
         while let Some(q) = queue.pop() {
             // Get the correct subtree with q_ref as path

--- a/grovedb/src/operations/delete.rs
+++ b/grovedb/src/operations/delete.rs
@@ -78,7 +78,7 @@ impl GroveDb {
         if path_iter.len() == 0 {
             // Attempt to delete a root tree leaf
             Err(Error::InvalidPath(
-                "root tree leafs currently cannot be deleted",
+                "root tree leaves currently cannot be deleted",
             ))
         } else {
             self.check_subtree_exists_path_not_found(path_iter.clone(), Some(key), transaction)?;

--- a/grovedb/src/operations/delete.rs
+++ b/grovedb/src/operations/delete.rs
@@ -92,7 +92,8 @@ impl GroveDb {
 
             if let Element::Tree(_) = element {
                 let subtree_merk_path = path_iter.clone().chain(std::iter::once(key));
-                let subtrees_paths = self.find_subtrees(subtree_merk_path.clone(), transaction)?;
+                let subtrees_paths =
+                    self.find_subtrees(subtree_merk_path.clone(), transaction, true)?;
                 let is_empty =
                     merk_optional_tx!(self.db, subtree_merk_path, transaction, subtree, {
                         subtree.is_empty_tree()
@@ -136,6 +137,7 @@ impl GroveDb {
         &self,
         path: P,
         transaction: TransactionArg,
+        include_parent: bool,
     ) -> Result<Vec<Vec<Vec<u8>>>, Error>
     where
         P: IntoIterator<Item = &'p [u8]>,
@@ -150,7 +152,11 @@ impl GroveDb {
 
         let mut queue: Vec<Vec<Vec<u8>>> =
             vec![path.into_iter().map(|x| x.as_ref().to_vec()).collect()];
-        let mut result: Vec<Vec<Vec<u8>>> = queue.clone();
+        let mut result: Vec<Vec<Vec<u8>>> = if include_parent {
+            queue.clone()
+        } else {
+            Vec::new()
+        };
 
         while let Some(q) = queue.pop() {
             // Get the correct subtree with q_ref as path

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -34,7 +34,7 @@ impl GroveDb {
                 // but trees
                 if path_iter.len() == 0 {
                     return Err(Error::InvalidPath(
-                        "only subtrees are allowed as root tree's leafs",
+                        "only subtrees are allowed as root tree's leaves",
                     ));
                 }
                 self.check_subtree_exists_invalid_path(path_iter.clone(), Some(key), transaction)?;

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -24,7 +24,8 @@ impl GroveDb {
                 if path_iter.len() == 0 {
                     self.add_root_leaf(key, transaction)?;
                 } else {
-                    self.add_non_root_subtree(path_iter, key, transaction)?;
+                    self.add_non_root_subtree(path_iter.clone(), key, transaction)?;
+                    self.propagate_changes(path_iter, transaction)?;
                 }
             }
             _ => {
@@ -105,7 +106,6 @@ impl GroveDb {
             let element = Element::Tree(child_subtree.root_hash());
             element.insert(&mut parent_subtree, key)?;
         }
-        self.propagate_changes(path_iter, transaction)?;
         Ok(())
     }
 

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -105,7 +105,7 @@ impl Element {
 
     /// Delete an element from Merk under a key
     pub fn delete<'db, 'ctx, K: AsRef<[u8]>, S: StorageContext<'db, 'ctx> + 'ctx>(
-        merk: &'ctx mut Merk<S>,
+        merk: &mut Merk<S>,
         key: K,
     ) -> Result<(), Error> {
         // TODO: delete references on this element
@@ -468,9 +468,9 @@ impl Element {
     /// If transaction is not passed, the batch will be written immediately.
     /// If transaction is passed, the operation will be committed on the
     /// transaction commit.
-    pub fn insert<'db, 'ctx, K: AsRef<[u8]>, S: StorageContext<'db, 'ctx>>(
+    pub fn insert<'db, 'ctx, K: AsRef<[u8]>, S: StorageContext<'db, 'ctx> + 'ctx>(
         &self,
-        merk: &'ctx mut Merk<S>,
+        merk: &mut Merk<S>,
         key: K,
     ) -> Result<(), Error> {
         let batch_operations = [(key, Op::Put(self.serialize()?))];

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -20,7 +20,7 @@ use crate::{
 /// Variants of GroveDB stored entities
 /// ONLY APPEND TO THIS LIST!!! Because
 /// of how serialization works.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Element {
     /// An ordinary value
     Item(Vec<u8>),

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -20,7 +20,7 @@ use crate::{
 /// Variants of GroveDB stored entities
 /// ONLY APPEND TO THIS LIST!!! Because
 /// of how serialization works.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Element {
     /// An ordinary value
     Item(Vec<u8>),

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -104,7 +104,7 @@ impl Element {
     }
 
     /// Delete an element from Merk under a key
-    pub fn delete<'db, 'ctx, K: AsRef<[u8]>, S: StorageContext<'db, 'ctx> + 'ctx>(
+    pub fn delete<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
         merk: &mut Merk<S>,
         key: K,
     ) -> Result<(), Error> {
@@ -116,7 +116,7 @@ impl Element {
 
     /// Get an element from Merk under a key; path should be resolved and proper
     /// Merk should be loaded by this moment
-    pub fn get<'db, 'ctx, K: AsRef<[u8]>, S: StorageContext<'db, 'ctx> + 'ctx>(
+    pub fn get<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
         merk: &Merk<S>,
         key: K,
     ) -> Result<Element, Error> {
@@ -468,7 +468,7 @@ impl Element {
     /// If transaction is not passed, the batch will be written immediately.
     /// If transaction is passed, the operation will be committed on the
     /// transaction commit.
-    pub fn insert<'db, 'ctx, K: AsRef<[u8]>, S: StorageContext<'db, 'ctx> + 'ctx>(
+    pub fn insert<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
         &self,
         merk: &mut Merk<S>,
         key: K,

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -7,7 +7,6 @@ use ::visualize::{Drawer, Visualize};
 use rand::Rng;
 use tempfile::TempDir;
 
-// use test::RunIgnored::No;
 use super::*;
 
 pub const TEST_LEAF: &[u8] = b"test_leaf";
@@ -972,8 +971,6 @@ fn test_find_subtrees() {
         ],
         subtrees
     );
-
-    dbg!(db.find_subtrees(vec![b"AOOO".as_ref()], None, false));
 }
 
 #[test]

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -3,6 +3,7 @@ use std::{
     option::Option::None,
 };
 
+use ::visualize::{Drawer, Visualize};
 use rand::Rng;
 use tempfile::TempDir;
 
@@ -33,10 +34,7 @@ impl Deref for TempGroveDb {
 }
 
 impl Visualize for TempGroveDb {
-    fn visualize<'a, W: std::io::Write>(
-        &self,
-        drawer: Drawer<'a, W>,
-    ) -> std::io::Result<Drawer<'a, W>> {
+    fn visualize<W: std::io::Write>(&self, drawer: Drawer<W>) -> std::io::Result<Drawer<W>> {
         self.db.visualize(drawer)
     }
 }

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -960,7 +960,7 @@ fn test_find_subtrees() {
     db.insert([TEST_LEAF], b"key4", Element::empty_tree(), None)
         .expect("successful subtree 3 insert");
     let subtrees = db
-        .find_subtrees(vec![TEST_LEAF], None, true)
+        .find_subtrees(vec![TEST_LEAF], None)
         .expect("cannot get subtrees");
     assert_eq!(
         vec![

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 use super::*;
 
 pub const TEST_LEAF: &[u8] = b"test_leaf";
-const ANOTHER_TEST_LEAF: &[u8] = b"test_leaf2";
+pub const ANOTHER_TEST_LEAF: &[u8] = b"test_leaf2";
 
 /// GroveDB wrapper to keep temp directory alive
 pub struct TempGroveDb {

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -963,7 +963,7 @@ fn test_find_subtrees() {
     db.insert([TEST_LEAF], b"key4", Element::empty_tree(), None)
         .expect("successful subtree 3 insert");
     let subtrees = db
-        .find_subtrees(vec![TEST_LEAF], None)
+        .find_subtrees(vec![TEST_LEAF], None, true)
         .expect("cannot get subtrees");
     assert_eq!(
         vec![
@@ -974,6 +974,8 @@ fn test_find_subtrees() {
         ],
         subtrees
     );
+
+    dbg!(db.find_subtrees(vec![b"AOOO".as_ref()], None, false));
 }
 
 #[test]

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -45,14 +45,14 @@ impl Visualize for TempGroveDb {
 pub fn make_grovedb() -> TempGroveDb {
     let tmp_dir = TempDir::new().unwrap();
     let mut db = GroveDb::open(tmp_dir.path()).unwrap();
-    add_test_leafs(&mut db);
+    add_test_leaves(&mut db);
     TempGroveDb {
         _tmp_dir: tmp_dir,
         db,
     }
 }
 
-fn add_test_leafs(db: &mut GroveDb) {
+fn add_test_leaves(db: &mut GroveDb) {
     db.insert([], TEST_LEAF, Element::empty_tree(), None)
         .expect("successful root tree leaf insert");
     db.insert([], ANOTHER_TEST_LEAF, Element::empty_tree(), None)
@@ -208,7 +208,7 @@ fn test_tree_structure_is_persistent() {
     // Create a scoped GroveDB
     let prev_root_hash = {
         let mut db = GroveDb::open(tmp_dir.path()).unwrap();
-        add_test_leafs(&mut db);
+        add_test_leaves(&mut db);
 
         // Insert some nested subtrees
         db.insert([TEST_LEAF], b"key1", Element::empty_tree(), None)
@@ -244,7 +244,7 @@ fn test_tree_structure_is_persistent() {
 }
 
 #[test]
-fn test_root_tree_leafs_are_noted() {
+fn test_root_tree_leaves_are_noted() {
     let db = make_grovedb();
     let mut hm = BTreeMap::new();
     hm.insert(TEST_LEAF.to_vec(), 0);

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -140,7 +140,7 @@ where
     /// ];
     /// store.apply::<_, Vec<_>>(batch, &[]).unwrap();
     /// ```
-    pub fn apply<KB, KA>(&'ctx mut self, batch: &MerkBatch<KB>, aux: &MerkBatch<KA>) -> Result<()>
+    pub fn apply<KB, KA>(&mut self, batch: &MerkBatch<KB>, aux: &MerkBatch<KA>) -> Result<()>
     where
         KB: AsRef<[u8]>,
         KA: AsRef<[u8]>,
@@ -183,7 +183,7 @@ where
     /// unsafe { store.apply_unchecked::<_, Vec<_>>(batch, &[]).unwrap() };
     /// ```
     pub unsafe fn apply_unchecked<KB, KA>(
-        &'ctx mut self,
+        &mut self,
         batch: &MerkBatch<KB>,
         aux: &MerkBatch<KA>,
     ) -> Result<()>
@@ -266,11 +266,7 @@ where
         })
     }
 
-    pub fn commit<K>(
-        &'ctx mut self,
-        deleted_keys: LinkedList<Vec<u8>>,
-        aux: &MerkBatch<K>,
-    ) -> Result<()>
+    pub fn commit<K>(&mut self, deleted_keys: LinkedList<Vec<u8>>, aux: &MerkBatch<K>) -> Result<()>
     where
         K: AsRef<[u8]>,
     {

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -27,10 +27,10 @@ impl<S> fmt::Debug for Merk<S> {
 
 pub type UseTreeMutResult = Result<Vec<(Vec<u8>, Option<Vec<u8>>)>>;
 
-impl<'db, 'ctx, S> Merk<S>
+impl<'db, S> Merk<S>
 where
-    S: StorageContext<'db, 'ctx> + 'ctx,
-    <S as StorageContext<'db, 'ctx>>::Error: std::error::Error,
+    S: StorageContext<'db>,
+    <S as StorageContext<'db>>::Error: std::error::Error,
 {
     pub fn open(storage: S) -> Result<Self> {
         let mut merk = Self {
@@ -43,7 +43,7 @@ where
     }
 
     /// Deletes tree data
-    pub fn clear(&'ctx mut self) -> Result<()> {
+    pub fn clear(&mut self) -> Result<()> {
         let mut iter = self.storage.raw_iter();
         iter.seek_to_first();
         let mut to_delete = self.storage.new_batch();
@@ -218,12 +218,7 @@ where
     /// check adds some overhead, so if you are sure your batch is sorted and
     /// unique you can use the unsafe `prove_unchecked` for a small performance
     /// gain.
-    pub fn prove(
-        &'ctx self,
-        query: Query,
-        limit: Option<u16>,
-        offset: Option<u16>,
-    ) -> Result<Vec<u8>> {
+    pub fn prove(&self, query: Query, limit: Option<u16>, offset: Option<u16>) -> Result<Vec<u8>> {
         let left_to_right = query.left_to_right;
         self.prove_unchecked(query, limit, offset, left_to_right)
     }
@@ -241,7 +236,7 @@ where
     /// of this method which checks to ensure the batch is sorted and
     /// unique, see `prove`.
     pub fn prove_unchecked<Q, I>(
-        &'ctx self,
+        &self,
         query: I,
         limit: Option<u16>,
         offset: Option<u16>,
@@ -396,9 +391,9 @@ impl<'s, S> Clone for MerkSource<'s, S> {
     }
 }
 
-impl<'s, 'db, 'ctx, S> Fetch for MerkSource<'s, S>
+impl<'s, 'db, S> Fetch for MerkSource<'s, S>
 where
-    S: StorageContext<'db, 'ctx>,
+    S: StorageContext<'db>,
 {
     fn fetch(&self, link: &Link) -> Result<Tree> {
         Tree::get(self.storage, link.key())?.ok_or(anyhow!("Key not found"))
@@ -616,7 +611,7 @@ mod test {
     }
 
     type PrefixedStorageIter<'db, 'ctx> =
-        &'ctx mut <PrefixedRocksDbStorageContext<'db> as StorageContext<'db, 'ctx>>::RawIterator;
+        &'ctx mut <PrefixedRocksDbStorageContext<'db> as StorageContext<'db>>::RawIterator;
 
     #[test]
     fn reopen_iter() {

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -9,9 +9,9 @@ impl Tree {
         Decode::decode(bytes).map_err(|e| anyhow!("failed to decode a Tree structure ({})", e))
     }
 
-    pub(crate) fn get<'db, 'ctx, S, K>(storage: &S, key: K) -> Result<Option<Self>, Error>
+    pub(crate) fn get<'db, S, K>(storage: &S, key: K) -> Result<Option<Self>, Error>
     where
-        S: StorageContext<'db, 'ctx>,
+        S: StorageContext<'db>,
         K: AsRef<[u8]>,
         Error: From<S::Error>,
     {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -8,6 +8,8 @@ lazy_static = { version = "1.4.0", optional = true }
 num_cpus = { version = "1.13.1", optional = true }
 tempfile = { version = "3.3.0", optional = true }
 blake3 = { version = "1.3.1", optional = true }
+visualize = { path = "../visualize" }
+strum = { version = "0.24.0", features = ["derive"] }
 
 [dependencies.rocksdb]
 git = "https://github.com/yiyuanliu/rust-rocksdb"

--- a/storage/src/rocksdb_storage/storage_context/batch.rs
+++ b/storage/src/rocksdb_storage/storage_context/batch.rs
@@ -133,8 +133,8 @@ impl<'db> Batch for PrefixedRocksDbBatch<'db, WriteBatchWithTransaction<true>> {
 
 /// Implementation of a batch inside a transaction.
 /// Basically just proxies all calls to the underlying transaction.
-impl<'db, 'ctx> Batch for &'ctx PrefixedRocksDbTransactionContext<'db> {
-    type Error = <PrefixedRocksDbTransactionContext<'db> as StorageContext<'db, 'ctx>>::Error;
+impl<'ctx, 'db> Batch for &'ctx PrefixedRocksDbTransactionContext<'db> {
+    type Error = <PrefixedRocksDbTransactionContext<'db> as StorageContext<'db>>::Error;
 
     fn put<K: AsRef<[u8]>>(&mut self, key: K, value: &[u8]) -> Result<(), Self::Error> {
         StorageContext::put(*self, key, value)

--- a/storage/src/rocksdb_storage/storage_context/context_batch_no_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_batch_no_tx.rs
@@ -48,7 +48,7 @@ impl<'db> PrefixedRocksDbBatchStorageContext<'db> {
     }
 }
 
-impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbBatchStorageContext<'db> {
+impl<'db> StorageContext<'db> for PrefixedRocksDbBatchStorageContext<'db> {
     type Batch = PrefixedMultiContextBatchPart;
     type Error = Error;
     type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, Db>>;

--- a/storage/src/rocksdb_storage/storage_context/context_batch_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_batch_tx.rs
@@ -56,10 +56,7 @@ impl<'db> PrefixedRocksDbBatchTransactionContext<'db> {
     }
 }
 
-impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbBatchTransactionContext<'db>
-where
-    'db: 'ctx,
-{
+impl<'db> StorageContext<'db> for PrefixedRocksDbBatchTransactionContext<'db> {
     type Batch = PrefixedMultiContextBatchPart;
     type Error = Error;
     type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, Tx<'db>>>;

--- a/storage/src/rocksdb_storage/storage_context/context_batch_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_batch_tx.rs
@@ -132,14 +132,14 @@ where
             .get_cf(self.cf_meta(), make_prefixed_key(self.prefix.clone(), key))
     }
 
-    fn new_batch(&'ctx self) -> Self::Batch {
+    fn new_batch(&self) -> Self::Batch {
         PrefixedMultiContextBatchPart {
             prefix: self.prefix.clone(),
             batch: StorageBatch::new(),
         }
     }
 
-    fn commit_batch(&'ctx self, batch: Self::Batch) -> Result<(), Self::Error> {
+    fn commit_batch(&self, batch: Self::Batch) -> Result<(), Self::Error> {
         self.batch.merge(batch.batch);
         Ok(())
     }

--- a/storage/src/rocksdb_storage/storage_context/context_no_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_no_tx.rs
@@ -43,7 +43,7 @@ impl<'db> PrefixedRocksDbStorageContext<'db> {
     }
 }
 
-impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbStorageContext<'db> {
+impl<'db> StorageContext<'db> for PrefixedRocksDbStorageContext<'db> {
     type Batch = PrefixedRocksDbBatch<'db, WriteBatchWithTransaction<true>>;
     type Error = Error;
     type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, Db>>;

--- a/storage/src/rocksdb_storage/storage_context/context_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_tx.rs
@@ -1,10 +1,10 @@
 //! Storage context implementation with a transaction.
 use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, Error};
 
-use super::{make_prefixed_key, PrefixedRocksDbRawIterator};
+use super::{batch::DummyBatch, make_prefixed_key, PrefixedRocksDbRawIterator};
 use crate::{
     rocksdb_storage::storage::{Db, Tx, AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME},
-    StorageContext,
+    BatchOperation, StorageContext,
 };
 
 /// Storage context with a prefix applied to be used in a subtree to be used in
@@ -53,7 +53,7 @@ impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbTransactionContext<
 where
     'db: 'ctx,
 {
-    type Batch = &'ctx Self;
+    type Batch = DummyBatch;
     type Error = Error;
     type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, Tx<'db>>>;
 
@@ -126,11 +126,39 @@ where
             .get_cf(self.cf_meta(), make_prefixed_key(self.prefix.clone(), key))
     }
 
-    fn new_batch(&'ctx self) -> Self::Batch {
-        self
+    fn new_batch(&self) -> Self::Batch {
+        DummyBatch::default()
     }
 
-    fn commit_batch(&'ctx self, _batch: Self::Batch) -> Result<(), Self::Error> {
+    fn commit_batch(&self, batch: Self::Batch) -> Result<(), Self::Error> {
+        for op in batch.operations {
+            match op {
+                BatchOperation::Put { key, value } => {
+                    self.put(key, &value)?;
+                }
+                BatchOperation::PutAux { key, value } => {
+                    self.put_aux(key, &value)?;
+                }
+                BatchOperation::PutRoot { key, value } => {
+                    self.put_root(key, &value)?;
+                }
+                BatchOperation::PutMeta { key, value } => {
+                    self.put_meta(key, &value)?;
+                }
+                BatchOperation::Delete { key } => {
+                    self.delete(key)?;
+                }
+                BatchOperation::DeleteAux { key } => {
+                    self.delete_aux(key)?;
+                }
+                BatchOperation::DeleteRoot { key } => {
+                    self.delete_root(key)?;
+                }
+                BatchOperation::DeleteMeta { key } => {
+                    self.delete_meta(key)?;
+                }
+            }
+        }
         Ok(())
     }
 

--- a/storage/src/rocksdb_storage/storage_context/context_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_tx.rs
@@ -49,10 +49,7 @@ impl<'db> PrefixedRocksDbTransactionContext<'db> {
     }
 }
 
-impl<'db, 'ctx> StorageContext<'db, 'ctx> for PrefixedRocksDbTransactionContext<'db>
-where
-    'db: 'ctx,
-{
+impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
     type Batch = DummyBatch;
     type Error = Error;
     type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, Tx<'db>>>;

--- a/storage/src/rocksdb_storage/tests.rs
+++ b/storage/src/rocksdb_storage/tests.rs
@@ -1,4 +1,5 @@
 use super::test_utils::TempStorage;
+use crate::Batch;
 
 fn to_path(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
     std::iter::once(bytes)
@@ -615,13 +616,23 @@ mod transaction {
             .expect("cannot get from storage")
             .is_none());
 
-        let batch = context_ayya.new_batch();
+        let mut batch = context_ayya.new_batch();
         batch.delete(b"key1").expect("infallible");
         batch.put(b"key3", b"ayyavalue3").expect("infallible");
+
+        assert!(context_ayya
+            .get(b"key1")
+            .expect("cannot get from storage")
+            .is_some());
 
         context_ayya
             .commit_batch(batch)
             .expect("cannot commit a batch");
+
+        assert!(context_ayya
+            .get(b"key1")
+            .expect("cannot get from storage")
+            .is_none());
 
         storage
             .commit_transaction(tx)

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -11,14 +11,10 @@ pub trait Storage<'db> {
     type Transaction;
 
     /// Storage context type
-    /// TODO: add `StorageContext<'db, Error = Self::Error>` bound with
-    /// GATs
-    type StorageContext;
+    type StorageContext: StorageContext<'db, Error = Self::Error>;
 
     /// Storage context type for transactional data
-    /// TODO: add `StorageContext<'db, Error = Self::Error>` bound with
-    /// GATs
-    type TransactionalStorageContext;
+    type TransactionalStorageContext: StorageContext<'db, Error = Self::Error>;
 
     /// Storage context type for mutli-tree batch operations
     type BatchStorageContext;

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -11,12 +11,12 @@ pub trait Storage<'db> {
     type Transaction;
 
     /// Storage context type
-    /// TODO: add `StorageContext<'db, 'ctx, Error = Self::Error>` bound with
+    /// TODO: add `StorageContext<'db, Error = Self::Error>` bound with
     /// GATs
     type StorageContext;
 
     /// Storage context type for transactional data
-    /// TODO: add `StorageContext<'db, 'ctx, Error = Self::Error>` bound with
+    /// TODO: add `StorageContext<'db, Error = Self::Error>` bound with
     /// GATs
     type TransactionalStorageContext;
 
@@ -88,7 +88,7 @@ pub trait Storage<'db> {
 /// Storage context.
 /// Provides operations expected from a database abstracting details such as
 /// whether it is a transaction or not.
-pub trait StorageContext<'db, 'ctx> {
+pub trait StorageContext<'db> {
     /// Storage error type
     type Error: std::error::Error + Send + Sync + 'static;
 

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -136,10 +136,10 @@ pub trait StorageContext<'db, 'ctx> {
     fn get_meta<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Initialize a new batch
-    fn new_batch(&'ctx self) -> Self::Batch;
+    fn new_batch(&self) -> Self::Batch;
 
     /// Commits changes from batch into storage
-    fn commit_batch(&'ctx self, batch: Self::Batch) -> Result<(), Self::Error>;
+    fn commit_batch(&self, batch: Self::Batch) -> Result<(), Self::Error>;
 
     /// Get raw iterator over storage
     fn raw_iter(&self) -> Self::RawIterator;
@@ -282,14 +282,18 @@ impl StorageBatch {
         self.operations.borrow()
     }
 
-    /// Consume batch to get an iterator over operations
-    pub fn into_iter(self) -> IntoIter<BatchOperation> {
-        self.operations.into_inner().into_iter()
-    }
-
     /// Merge batch into this one
     pub fn merge(&self, other: StorageBatch) {
         self.operations.borrow_mut().extend(other.into_iter());
+    }
+}
+
+impl IntoIterator for StorageBatch {
+    type IntoIter = IntoIter<BatchOperation>;
+    type Item = BatchOperation;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.operations.into_inner().into_iter()
     }
 }
 

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -203,6 +203,7 @@ pub trait RawIterator {
 
 /// Structure to hold deferred database operations in "batched" storage
 /// contexts.
+#[derive(Debug)]
 pub struct StorageBatch {
     operations: RefCell<Vec<BatchOperation>>,
 }
@@ -300,6 +301,7 @@ impl Default for StorageBatch {
 
 /// Deferred storage operation.
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub enum BatchOperation {
     /// Deferred put operation
     Put { key: Vec<u8>, value: Vec<u8> },

--- a/visualize/Cargo.toml
+++ b/visualize/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "visualize"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+hex = "0.4.3"
+itertools = "0.10.3"

--- a/visualize/src/lib.rs
+++ b/visualize/src/lib.rs
@@ -1,0 +1,105 @@
+use std::io::{Result, Write};
+
+use itertools::Itertools;
+
+static HEX_LEN: usize = 8;
+static STR_LEN: usize = 32;
+static INDENT_SPACES: usize = 4;
+
+/// Pretty visualization of GroveDB components.
+pub trait Visualize {
+    fn visualize<'a, W: Write>(&self, drawer: Drawer<W>) -> Result<Drawer<W>>;
+}
+
+/// A `io::Write` proxy to prepend padding and symbols to draw trees
+pub struct Drawer<W: Write> {
+    level: usize,
+    write: W,
+}
+
+impl<'a, W: Write> Drawer<W> {
+    pub fn new(write: W) -> Self {
+        Drawer { level: 0, write }
+    }
+
+    pub fn down(&mut self) {
+        self.level += 1;
+    }
+
+    pub fn up(&mut self) {
+        self.level -= 1;
+    }
+
+    pub fn write(&mut self, buf: &[u8]) -> Result<()> {
+        let lines_iter = buf.split(|c| *c == b'\n');
+        let sep = if self.level > 0 {
+            let mut result = " ".repeat(INDENT_SPACES * self.level - 1);
+            result.insert(0, '\n');
+            result
+        } else {
+            String::new()
+        };
+        let interspersed_lines_iter = Itertools::intersperse(lines_iter, sep.as_bytes());
+        for line in interspersed_lines_iter {
+            self.write.write_all(line)?;
+        }
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        self.write.write_all(b"\n")?;
+        self.write.flush()?;
+        Ok(())
+    }
+}
+
+pub fn to_hex(bytes: &[u8]) -> String {
+    let mut result = hex::encode(bytes);
+    result.truncate(HEX_LEN);
+    result
+}
+
+impl Visualize for [u8] {
+    fn visualize<'a, W: Write>(&self, mut drawer: Drawer<W>) -> Result<Drawer<W>> {
+        let hex_repr = to_hex(self);
+        let str_repr = String::from_utf8(self.to_vec());
+        drawer.write(format!("[hex: {hex_repr}").as_bytes())?;
+        if let Ok(str_repr) = str_repr {
+            let str_part = if str_repr.len() > STR_LEN {
+                &str_repr[..=STR_LEN]
+            } else {
+                &str_repr
+            };
+            drawer.write(format!(", str: {str_part}").as_bytes())?;
+        }
+        drawer.write(b"]")?;
+        Ok(drawer)
+    }
+}
+
+/// `visulize` shortcut to write straight into stderr offhand
+pub fn visualize_stderr<T: Visualize + ?Sized>(value: &T) {
+    let mut out = std::io::stderr();
+    let drawer = Drawer::new(&mut out);
+    value
+        .visualize(drawer)
+        .expect("IO error when trying to `visualize`");
+}
+
+/// `visulize` shortcut to write straight into stdout offhand
+pub fn visualize_stdout<T: Visualize + ?Sized>(value: &T) {
+    let mut out = std::io::stdout();
+    let drawer = Drawer::new(&mut out);
+    value
+        .visualize(drawer)
+        .expect("IO error when trying to `visualize`");
+}
+
+/// `visulize` shortcut to write into provided buffer, should be a `Vec` not a
+/// slice because slices won't grow if needed.
+pub fn visualize_to_vec<T: Visualize + ?Sized>(v: &mut Vec<u8>, value: &T) {
+    let drawer = Drawer::new(v);
+    value
+        .visualize(drawer)
+        .expect("error while writing into slice");
+}


### PR DESCRIPTION
This PR improves GroveDB API to support batched updates.

Batches could be used to perform multiple operations on GroveDB and as a result to have exactly one database (RocksDB in our case) batch, moreover, this implies atomicity and invalid operations will fail the whole batch with no partially applied state with no need of transaction (transactions are supported as well for multiple batches if needed).

This is achieved in a number of steps:
1. GroveDB batch should pass validation, this requires to perform some `get` requests to GroveDB to ensure that insertions are done to existing subtrees if there is no way to check that they will be inserted within the same batch, also tree deletions and overwrites must be deleted recursively, that requires to do even more `get`s, but still no writes;
2. on passed validations expanded (meaning additional deletions added to handle recursion) batch is applied sequentially from right to left (deepest operations first), this is required for propagation: when there are no more operations for a subtree, then hash update operations are put into the batch to do it when it comes to the parent operations execution
3. Merk code is unaware of how storage works and acts as usual plus all batch operations are run sequentially, but `StorageContext` implementation for batches done previously makes all these writes deferred and prepares a big RocksDB batch which eventually will be run; that's why all `get`s should be done only on pre-batch state and other assumptions goes from batch input -- there is no intermediate state.

In addition to the feature, minor improvements were done:

- Improved `visualize` library, better debug output for Storage structs
- Fixed an issue with batches (RocksDB batches) inside transaction, when they just proxified all calls to the transaction
- Removed unnecessary `'ctx` lifetime from `StorageContext` trait