### PR TITLE
fix: simplify `check_subtree_exists`

### DIFF
--- a/grovedb/src/operations/delete.rs
+++ b/grovedb/src/operations/delete.rs
@@ -18,7 +18,7 @@ impl GroveDb {
         <P as IntoIterator>::IntoIter: DoubleEndedIterator + ExactSizeIterator + Clone,
     {
         let mut path_iter = path.into_iter();
-        self.check_subtree_exists_path_not_found(path_iter.clone(), Some(key), transaction)?;
+        self.check_subtree_exists_path_not_found(path_iter.clone(), transaction)?;
         if let Some(stop_path_height) = stop_path_height {
             if stop_path_height == path_iter.clone().len() as u16 {
                 return Ok(0);
@@ -81,7 +81,7 @@ impl GroveDb {
                 "root tree leaves currently cannot be deleted",
             ))
         } else {
-            self.check_subtree_exists_path_not_found(path_iter.clone(), Some(key), transaction)?;
+            self.check_subtree_exists_path_not_found(path_iter.clone(), transaction)?;
             let element = self.get_raw(path_iter.clone(), key.as_ref(), transaction)?;
             let delete_element = || -> Result<(), Error> {
                 merk_optional_tx!(self.db, path_iter.clone(), transaction, mut parent_merk, {

--- a/grovedb/src/operations/get.rs
+++ b/grovedb/src/operations/get.rs
@@ -68,12 +68,13 @@ impl GroveDb {
         <P as IntoIterator>::IntoIter: ExactSizeIterator + DoubleEndedIterator + Clone,
     {
         let path_iter = path.into_iter();
-        self.check_subtree_exists_path_not_found(path_iter.clone(), Some(key), transaction)?;
         if path_iter.len() == 0 {
+            self.check_subtree_exists_path_not_found([key], transaction)?;
             merk_optional_tx!(self.db, [key], transaction, subtree, {
                 Ok(Element::Tree(subtree.root_hash()))
             })
         } else {
+            self.check_subtree_exists_path_not_found(path_iter.clone(), transaction)?;
             merk_optional_tx!(self.db, path_iter, transaction, subtree, {
                 Element::get(&subtree, key)
             })
@@ -160,7 +161,6 @@ impl GroveDb {
     fn check_subtree_exists<'p, P>(
         &self,
         path: P,
-        key: Option<&'p [u8]>,
         transaction: TransactionArg,
         error: Error,
     ) -> Result<(), Error>
@@ -170,13 +170,9 @@ impl GroveDb {
     {
         let mut path_iter = path.into_iter();
         if path_iter.len() == 0 {
-            meta_storage_context_optional_tx!(self.db, transaction, meta_storage, {
-                let root_leaf_keys = Self::get_root_leaf_keys_internal(&meta_storage)?;
-                if !root_leaf_keys.contains_key(key.ok_or(Error::MissingParameter("key"))?) {
-                    return Err(error);
-                }
-            });
-        } else if path_iter.len() == 1 {
+            return Ok(());
+        }
+        if path_iter.len() == 1 {
             meta_storage_context_optional_tx!(self.db, transaction, meta_storage, {
                 let root_leaf_keys = Self::get_root_leaf_keys_internal(&meta_storage)?;
                 if !root_leaf_keys.contains_key(path_iter.next().expect("must contain an item")) {
@@ -187,11 +183,14 @@ impl GroveDb {
             let mut parent_iter = path_iter;
             let parent_key = parent_iter.next_back().expect("path is not empty");
             merk_optional_tx!(self.db, parent_iter, transaction, parent, {
-                if matches!(
-                    Element::get(&parent, parent_key),
-                    Err(Error::PathKeyNotFound(_))
-                ) {
-                    return Err(error);
+                match Element::get(&parent, parent_key) {
+                    Ok(Element::Tree(_)) => {}
+                    Ok(_) | Err(Error::PathKeyNotFound(_)) => {
+                        return Err(error);
+                    }
+                    Err(e) => {
+                        return Err(e);
+                    }
                 }
             });
         }
@@ -201,7 +200,6 @@ impl GroveDb {
     pub fn check_subtree_exists_path_not_found<'p, P>(
         &self,
         path: P,
-        key: Option<&'p [u8]>,
         transaction: TransactionArg,
     ) -> Result<(), Error>
     where
@@ -210,7 +208,6 @@ impl GroveDb {
     {
         self.check_subtree_exists(
             path,
-            key,
             transaction,
             Error::PathNotFound("subtree doesn't exist"),
         )
@@ -219,7 +216,6 @@ impl GroveDb {
     pub fn check_subtree_exists_invalid_path<'p, P>(
         &self,
         path: P,
-        key: Option<&'p [u8]>,
         transaction: TransactionArg,
     ) -> Result<(), Error>
     where
@@ -228,7 +224,6 @@ impl GroveDb {
     {
         self.check_subtree_exists(
             path,
-            key,
             transaction,
             Error::InvalidPath("subtree doesn't exist"),
         )

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -36,7 +36,7 @@ impl GroveDb {
                     ));
                 }
 
-                self.check_subtree_exists_invalid_path(path_iter.clone(), Some(key), transaction)?;
+                self.check_subtree_exists_invalid_path(path_iter.clone(), transaction)?;
                 let referenced_element =
                     self.follow_reference(reference_path.to_owned(), transaction)?;
 
@@ -54,7 +54,7 @@ impl GroveDb {
                         "only subtrees are allowed as root tree's leaves",
                     ));
                 }
-                self.check_subtree_exists_invalid_path(path_iter.clone(), Some(key), transaction)?;
+                self.check_subtree_exists_invalid_path(path_iter.clone(), transaction)?;
                 merk_optional_tx!(self.db, path_iter.clone(), transaction, mut subtree, {
                     element.insert(&mut subtree, key)?;
                 });
@@ -96,7 +96,7 @@ impl GroveDb {
         <P as IntoIterator>::IntoIter: DoubleEndedIterator + ExactSizeIterator + Clone,
     {
         let path_iter = path.into_iter();
-        self.check_subtree_exists_invalid_path(path_iter.clone(), Some(key), transaction)?;
+        self.check_subtree_exists_invalid_path(path_iter.clone(), transaction)?;
         if let Some(tx) = transaction {
             let parent_storage = self
                 .db

--- a/grovedb/src/operations/is_empty_tree.rs
+++ b/grovedb/src/operations/is_empty_tree.rs
@@ -7,7 +7,7 @@ impl GroveDb {
         <P as IntoIterator>::IntoIter: Clone + DoubleEndedIterator + ExactSizeIterator,
     {
         let path_iter = path.into_iter();
-        self.check_subtree_exists_path_not_found(path_iter.clone(), None, transaction)?;
+        self.check_subtree_exists_path_not_found(path_iter.clone(), transaction)?;
         merk_optional_tx!(self.db, path_iter, transaction, subtree, {
             Ok(subtree.is_empty_tree())
         })

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -21,7 +21,7 @@ impl GroveDb {
         if path_slices.len() < 1 {
             return Err(Error::InvalidPath("can't generate proof for empty path"));
         }
-        self.check_subtree_exists_path_not_found(path_slices.clone(), None, None)?;
+        self.check_subtree_exists_path_not_found(path_slices.clone(), None)?;
 
         self.prove_subqueries(
             &mut proof_result,
@@ -116,7 +116,7 @@ impl GroveDb {
                     let new_path_query = PathQuery::new_unsized(new_path_owned, query.unwrap());
 
                     if self
-                        .check_subtree_exists_path_not_found(new_path.clone(), None, None)
+                        .check_subtree_exists_path_not_found(new_path.clone(), None)
                         .is_err()
                     {
                         continue;

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -120,7 +120,6 @@ impl ProofVerifier {
                                 continue;
                             }
 
-
                             if subquery_key.is_some() {
                                 if subquery_value.is_none() {
                                     self.verify_subquery_key(

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -3294,3 +3294,36 @@ fn test_get_non_existing_root_leaf() {
     let db = make_grovedb();
     assert!(matches!(db.get([], b"ayy", None), Err(_)));
 }
+
+#[test]
+fn test_check_subtree_exists_function() {
+    let db = make_grovedb();
+    db.insert(
+        [TEST_LEAF],
+        b"key_scalar",
+        Element::Item(b"ayy".to_vec()),
+        None,
+    )
+    .expect("cannot insert item");
+    db.insert([TEST_LEAF], b"key_subtree", Element::empty_tree(), None)
+        .expect("cannot insert item");
+
+    // Empty tree path means root always exist
+    assert!(db.check_subtree_exists_invalid_path([], None).is_ok());
+
+    // TEST_LEAF should be a tree
+    assert!(db
+        .check_subtree_exists_invalid_path([TEST_LEAF], None)
+        .is_ok());
+
+    // TEST_LEAF.key_subtree should be a tree
+    assert!(db
+        .check_subtree_exists_invalid_path([TEST_LEAF, b"key_subtree"], None)
+        .is_ok());
+
+    // TEST_LEAF.key_scalar should NOT be a tree
+    assert!(matches!(
+        db.check_subtree_exists_invalid_path([TEST_LEAF, b"key_scalar"], None),
+        Err(Error::InvalidPath(_))
+    ));
+}


### PR DESCRIPTION
It wasn't very clear what `key` argument should do so it was removed, also fixed a bug when this function could report no errors if an item under a path exists, but it's not a tree