### PR TITLE
feat: return keys on query

### DIFF
--- a/grovedb/src/operations/get.rs
+++ b/grovedb/src/operations/get.rs
@@ -89,7 +89,7 @@ impl GroveDb {
         let elements = self.get_path_queries_raw(path_queries, transaction)?;
         let results = elements
             .into_iter()
-            .map(|element| match element {
+            .map(|(_, element)| match element {
                 Element::Reference(reference_path, _) => {
                     let maybe_item = self.follow_reference(reference_path, transaction)?;
                     if let Element::Item(item, _) = maybe_item {
@@ -110,7 +110,7 @@ impl GroveDb {
         &self,
         path_queries: &[&PathQuery],
         transaction: TransactionArg,
-    ) -> Result<Vec<Element>, Error> {
+    ) -> Result<Vec<(Vec<u8>, Element)>, Error> {
         let mut result = Vec::new();
         for query in path_queries {
             let (query_results, _) = self.get_path_query_raw(query, transaction)?;
@@ -127,7 +127,7 @@ impl GroveDb {
         let (elements, skipped) = self.get_path_query_raw(path_query, transaction)?;
         let results = elements
             .into_iter()
-            .map(|element| match element {
+            .map(|(_, element)| match element {
                 Element::Reference(reference_path, _) => {
                     let maybe_item = self.follow_reference(reference_path, transaction)?;
                     if let Element::Item(item, _) = maybe_item {
@@ -149,7 +149,7 @@ impl GroveDb {
         &self,
         path_query: &PathQuery,
         transaction: TransactionArg,
-    ) -> Result<(Vec<Element>, u16), Error> {
+    ) -> Result<(Vec<(Vec<u8>, Element)>, u16), Error> {
         let path_slices = path_query
             .path
             .iter()
@@ -184,7 +184,7 @@ impl GroveDb {
             let parent_key = parent_iter.next_back().expect("path is not empty");
             merk_optional_tx!(self.db, parent_iter, transaction, parent, {
                 match Element::get(&parent, parent_key) {
-                    Ok(Element::Tree(_)) => {}
+                    Ok(Element::Tree(..)) => {}
                     Ok(_) | Err(Error::PathKeyNotFound(_)) => {
                         return Err(error);
                     }

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -428,9 +428,12 @@ fn test_element_with_flags() {
     );
     assert_eq!(
         flagged_ref_no_follow[0],
-        Element::Reference(
-            vec![TEST_LEAF.to_vec(), b"key1".to_vec(), b"elem2".to_vec()],
-            Some([9].to_vec())
+        (
+            b"elem4".to_vec(),
+            Element::Reference(
+                vec![TEST_LEAF.to_vec(), b"key1".to_vec(), b"elem2".to_vec()],
+                Some([9].to_vec())
+            )
         )
     );
 
@@ -2015,9 +2018,9 @@ fn test_get_full_query() {
         db.get_path_queries_raw(&[&path_query1, &path_query2], None)
             .expect("expected successful get_query"),
         vec![
-            subtree::Element::new_item(b"ayya".to_vec()),
-            subtree::Element::new_item(b"ayyb".to_vec()),
-            subtree::Element::new_item(b"ayyd".to_vec()),
+            (b"key3".to_vec(), Element::new_item(b"ayya".to_vec())),
+            (b"key4".to_vec(), Element::new_item(b"ayyb".to_vec())),
+            (b"key6".to_vec(), Element::new_item(b"ayyd".to_vec())),
         ]
     );
 }
@@ -3430,7 +3433,7 @@ fn test_check_subtree_exists_function() {
     db.insert(
         [TEST_LEAF],
         b"key_scalar",
-        Element::Item(b"ayy".to_vec()),
+        Element::new_item(b"ayy".to_vec()),
         None,
     )
     .expect("cannot insert item");


### PR DESCRIPTION
In some situations returning the keys for a range query are quite important.

Also since we always have them in memory, might as well always return them.