### PR TITLE
feat: costs for Merk operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "fees",
+    "costs",
     "grovedb",
     "merk",
     "node-grove",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "fees",
     "grovedb",
     "merk",
     "node-grove",

--- a/costs/Cargo.toml
+++ b/costs/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "costs"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]

--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -193,12 +193,12 @@ macro_rules! cost_return_on_error {
 }
 
 /// Macro to achieve a kind of what `?` operator does, but with `CostContext` on
-/// top. The difference between this macro and `cost_return_on_error` is to use it on
-/// `Result` rather than `CostContext<Result<..>>`, so no costs will be added except previously
-/// accumulated.
+/// top. The difference between this macro and `cost_return_on_error` is to use
+/// it on `Result` rather than `CostContext<Result<..>>`, so no costs will be
+/// added except previously accumulated.
 #[macro_export]
 macro_rules! cost_return_on_error_no_add {
-    ( &mut $cost:ident, $($body:tt)+ ) => {
+    ( &$cost:ident, $($body:tt)+ ) => {
         {
             use $crate::CostsExt;
             let result = { $($body)+ };

--- a/fees/Cargo.toml
+++ b/fees/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "fees"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/fees/Cargo.toml
+++ b/fees/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fees"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/fees/src/lib.rs
+++ b/fees/src/lib.rs
@@ -1,0 +1,424 @@
+#![deny(missing_docs)]
+//! Interface crate to unify how operations' costs are passed and retrieved.
+
+use std::ops::{Add, AddAssign};
+
+/// Piece of data representing affected computer resources (approximately).
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct OperationCost {
+    /// How many storage seeks were done.
+    pub seek_count: usize,
+    /// How many bytes were written on hard drive.
+    pub storage_written_bytes: usize,
+    /// How many bytes were loaded from hard drive.
+    pub storage_loaded_bytes: usize,
+    /// How many bytes were loaded into memory (usually keys and values).
+    pub loaded_bytes: usize,
+    /// How many times hash was called for bytes (paths, keys, values).
+    pub hash_byte_calls: usize,
+    /// How many times node hashing was done (for merkelized tree).
+    pub hash_node_calls: usize,
+}
+
+impl Add for OperationCost {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        OperationCost {
+            seek_count: self.seek_count + rhs.seek_count,
+            storage_written_bytes: self.storage_written_bytes + rhs.storage_written_bytes,
+            storage_loaded_bytes: self.storage_loaded_bytes + rhs.storage_loaded_bytes,
+            loaded_bytes: self.loaded_bytes + rhs.loaded_bytes,
+            hash_byte_calls: self.hash_byte_calls + rhs.hash_byte_calls,
+            hash_node_calls: self.hash_node_calls + rhs.hash_node_calls,
+        }
+    }
+}
+
+impl AddAssign for OperationCost {
+    fn add_assign(&mut self, rhs: Self) {
+        self.seek_count += rhs.seek_count;
+        self.storage_written_bytes += rhs.storage_written_bytes;
+        self.storage_loaded_bytes += rhs.storage_loaded_bytes;
+        self.loaded_bytes += rhs.loaded_bytes;
+        self.hash_byte_calls += rhs.hash_byte_calls;
+        self.hash_node_calls += rhs.hash_node_calls;
+    }
+}
+
+/// Wrapped operation result with associated cost.
+#[derive(Debug, Eq, PartialEq)]
+pub struct FeesContext<T> {
+    /// Wrapped operation's return value.
+    value: T,
+    /// Cost of the operation.
+    cost: OperationCost,
+}
+
+/// General combinators for `FeesContext`.
+impl<T> FeesContext<T> {
+    /// Take wrapped value out adding its cost to provided accumulator.
+    pub fn unwrap_add_cost(self, acc_cost: &mut OperationCost) -> T {
+        *acc_cost += self.cost;
+        self.value
+    }
+
+    /// Take wrapped value out dropping cost data.
+    pub fn unwrap(self) -> T {
+        self.value
+    }
+
+    /// Borrow costs data.
+    pub fn cost(&self) -> &OperationCost {
+        &self.cost
+    }
+
+    /// Borrow wrapped data.
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    /// Applies function to wrapped value keeping cost the same as before.
+    pub fn map<B>(self, f: impl FnOnce(T) -> B) -> FeesContext<B> {
+        let cost = self.cost;
+        let value = f(self.value);
+        FeesContext { value, cost }
+    }
+
+    /// Applies function to wrapped value adding costs.
+    pub fn flat_map<B>(self, f: impl FnOnce(T) -> FeesContext<B>) -> FeesContext<B> {
+        let mut cost = self.cost;
+        let value = f(self.value).unwrap_add_cost(&mut cost);
+        FeesContext { value, cost }
+    }
+}
+
+/// Combinators to use with `Result` wrapped in `FeesContext`.
+impl<T, E> FeesContext<Result<T, E>> {
+    /// Applies function to wrapped value in case of `Ok` keeping cost the same
+    /// as before.
+    pub fn map_ok<B>(self, f: impl FnOnce(T) -> B) -> FeesContext<Result<B, E>> {
+        self.map(|result| result.map(f))
+    }
+
+    /// Applies function to wrapped result in case of `Ok` adding costs.
+    pub fn flat_map_ok<B>(
+        self,
+        f: impl FnOnce(T) -> FeesContext<Result<B, E>>,
+    ) -> FeesContext<Result<B, E>> {
+        let mut cost = self.cost;
+        let result = match self.value {
+            Ok(x) => f(x).unwrap_add_cost(&mut cost),
+            Err(e) => Err(e),
+        };
+        FeesContext {
+            value: result,
+            cost,
+        }
+    }
+}
+
+impl<T, E> FeesContext<Result<Result<T, E>, E>> {
+    /// Flattens nested errors inside `FeesContext`
+    pub fn flatten(self) -> FeesContext<Result<T, E>> {
+        self.map(|value| match value {
+            Err(e) => Err(e),
+            Ok(Err(e)) => Err(e),
+            Ok(Ok(v)) => Ok(v),
+        })
+    }
+}
+
+/// Extension trait to add costs context to values.
+pub trait FeesExt {
+    /// Wraps any value into a `FeesContext` object with provided costs.
+    fn wrap_with_cost(self, cost: OperationCost) -> FeesContext<Self>
+    where
+        Self: Sized,
+    {
+        FeesContext { value: self, cost }
+    }
+
+    /// Wraps any value into `FeesContext` object with costs computed using the
+    /// value getting wrapped.
+    fn wrap_fn_cost(self, f: impl FnOnce(&Self) -> OperationCost) -> FeesContext<Self>
+    where
+        Self: Sized,
+    {
+        FeesContext {
+            cost: f(&self),
+            value: self,
+        }
+    }
+}
+
+impl<T> FeesExt for T {}
+
+/// General way to get full occupied space by an object.
+pub trait FullSize {
+    /// Get full size of an object (approximately, no alignment taken into
+    /// account).
+    fn full_size(&self) -> usize;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map() {
+        let initial = FeesContext {
+            value: 75,
+            cost: OperationCost {
+                loaded_bytes: 3,
+                ..Default::default()
+            },
+        };
+
+        let mapped = initial.map(|x| x + 25);
+        assert_eq!(
+            mapped,
+            FeesContext {
+                value: 100,
+                cost: OperationCost {
+                    loaded_bytes: 3,
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_flat_map() {
+        let initial = FeesContext {
+            value: 75,
+            cost: OperationCost {
+                loaded_bytes: 3,
+                ..Default::default()
+            },
+        };
+
+        let mapped = initial.flat_map(|x| FeesContext {
+            value: x + 25,
+            cost: OperationCost {
+                loaded_bytes: 7,
+                ..Default::default()
+            },
+        });
+        assert_eq!(
+            mapped,
+            FeesContext {
+                value: 100,
+                cost: OperationCost {
+                    loaded_bytes: 10,
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_map_ok() {
+        let initial: FeesContext<Result<usize, ()>> = FeesContext {
+            value: Ok(75),
+            cost: OperationCost {
+                loaded_bytes: 3,
+                ..Default::default()
+            },
+        };
+
+        let mapped = initial.map_ok(|x| x + 25);
+        assert_eq!(
+            mapped,
+            FeesContext {
+                value: Ok(100),
+                cost: OperationCost {
+                    loaded_bytes: 3,
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_map_ok_err() {
+        let initial: FeesContext<Result<usize, ()>> = FeesContext {
+            value: Err(()),
+            cost: OperationCost {
+                loaded_bytes: 3,
+                ..Default::default()
+            },
+        };
+
+        let mapped = initial.map_ok(|x| x + 25);
+        assert_eq!(
+            mapped,
+            FeesContext {
+                value: Err(()),
+                cost: OperationCost {
+                    loaded_bytes: 3,
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_flat_map_ok() {
+        let initial: FeesContext<Result<usize, ()>> = FeesContext {
+            value: Ok(75),
+            cost: OperationCost {
+                loaded_bytes: 3,
+                ..Default::default()
+            },
+        };
+
+        let mapped = initial.flat_map_ok(|x| FeesContext {
+            value: Ok(x + 25),
+            cost: OperationCost {
+                loaded_bytes: 7,
+                ..Default::default()
+            },
+        });
+        assert_eq!(
+            mapped,
+            FeesContext {
+                value: Ok(100),
+                cost: OperationCost {
+                    loaded_bytes: 10,
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_flat_map_err_first() {
+        let initial: FeesContext<Result<usize, ()>> = FeesContext {
+            value: Err(()),
+            cost: OperationCost {
+                loaded_bytes: 3,
+                ..Default::default()
+            },
+        };
+        let mut executed = false;
+        let mapped = initial.flat_map_ok(|x| {
+            executed = true;
+            FeesContext {
+                value: Ok(x + 25),
+                cost: OperationCost {
+                    loaded_bytes: 7,
+                    ..Default::default()
+                },
+            }
+        });
+
+        // Second function won't be executed and thus no costs added.
+        assert!(!executed);
+        assert_eq!(
+            mapped,
+            FeesContext {
+                value: Err(()),
+                cost: OperationCost {
+                    loaded_bytes: 3,
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_flat_map_err_second() {
+        let initial: FeesContext<Result<usize, ()>> = FeesContext {
+            value: Ok(75),
+            cost: OperationCost {
+                loaded_bytes: 3,
+                ..Default::default()
+            },
+        };
+        let mut executed = false;
+        let mapped: FeesContext<Result<usize, ()>> = initial.flat_map_ok(|_| {
+            executed = true;
+            FeesContext {
+                value: Err(()),
+                cost: OperationCost {
+                    loaded_bytes: 7,
+                    ..Default::default()
+                },
+            }
+        });
+
+        // Second function should be executed and costs should increase. Result is error
+        // though.
+        assert!(executed);
+        assert_eq!(
+            mapped,
+            FeesContext {
+                value: Err(()),
+                cost: OperationCost {
+                    loaded_bytes: 10,
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_flatten_nested_errors() {
+        let initial: FeesContext<Result<usize, &str>> = FeesContext {
+            value: Ok(75),
+            cost: OperationCost {
+                loaded_bytes: 3,
+                ..Default::default()
+            },
+        };
+        // We use function that has nothing to do with fees but returns a result, we're
+        // trying to flatten nested errors inside FeesContext.
+        let ok = initial.map_ok(|x| Ok(x + 25));
+        assert_eq!(ok.flatten().unwrap(), Ok(100));
+
+        let initial: FeesContext<Result<usize, &str>> = FeesContext {
+            value: Ok(75),
+            cost: OperationCost {
+                loaded_bytes: 3,
+                ..Default::default()
+            },
+        };
+        let error_inner: FeesContext<Result<Result<usize, &str>, &str>> =
+            initial.map_ok(|_| Err("latter"));
+        assert_eq!(error_inner.flatten().unwrap(), Err("latter"));
+
+        let initial: FeesContext<Result<usize, &str>> = FeesContext {
+            value: Err("inner"),
+            cost: OperationCost {
+                loaded_bytes: 3,
+                ..Default::default()
+            },
+        };
+        let error_inner: FeesContext<Result<Result<usize, &str>, &str>> =
+            initial.map_ok(|x| Ok(x + 25));
+        assert_eq!(error_inner.flatten().unwrap(), Err("inner"));
+    }
+
+    #[test]
+    fn test_wrap_fn_cost() {
+        // Imagine this one is loaded from storage.
+        let loaded_value = b"ayylmao";
+        let fees_ctx = loaded_value.wrap_fn_cost(|x| OperationCost {
+            seek_count: 1,
+            loaded_bytes: x.len(),
+            ..Default::default()
+        });
+        assert_eq!(
+            fees_ctx,
+            FeesContext {
+                value: loaded_value,
+                cost: OperationCost {
+                    seek_count: 1,
+                    loaded_bytes: 7,
+                    ..Default::default()
+                }
+            }
+        )
+    }
+}

--- a/fees/src/lib.rs
+++ b/fees/src/lib.rs
@@ -154,13 +154,6 @@ pub trait FeesExt {
 
 impl<T> FeesExt for T {}
 
-/// General way to get full occupied space by an object.
-pub trait FullSize {
-    /// Get full size of an object (approximately, no alignment taken into
-    /// account).
-    fn full_size(&self) -> usize;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -180,7 +180,8 @@ impl GroveDb {
                     let hash = temp_subtrees
                         .remove(&prev_path)
                         .expect("subtree was inserted before")
-                        .root_hash();
+                        .root_hash()
+                        .unwrap(); // TODO implement costs
 
                     cursor.insert(Box::new(GroveDbOp::insert(
                         path_slice.to_vec(),
@@ -436,7 +437,7 @@ impl GroveDb {
                     &storage_batch,
                     tx,
                 );
-                Merk::open(storage)
+                Merk::open(storage).unwrap() // TODO implement costs
                     .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))
             })?;
 
@@ -453,7 +454,7 @@ impl GroveDb {
                 let storage = self
                     .db
                     .get_batch_storage_context(path.iter().map(|x| x.as_slice()), &storage_batch);
-                Merk::open(storage)
+                Merk::open(storage).unwrap() // TODO implement costs
                     .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))
             })?;
 

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -172,7 +172,7 @@ impl GroveDb {
         let mut leaf_hashes: Vec<[u8; 32]> = vec![[0; 32]; root_leaf_keys.len()];
         for (subtree_path, root_leaf_idx) in root_leaf_keys {
             merk_optional_tx!(db, [subtree_path.as_slice()], transaction, subtree, {
-                leaf_hashes[root_leaf_idx] = subtree.root_hash();
+                leaf_hashes[root_leaf_idx] = subtree.root_hash().unwrap(); // TODO implement costs
             });
         }
         Ok(MerkleTree::<Sha256>::from_leaves(&leaf_hashes))
@@ -196,24 +196,32 @@ impl GroveDb {
                 let subtree_storage = self
                     .db
                     .get_transactional_storage_context(path_iter.clone(), tx);
-                let subtree = Merk::open(subtree_storage)
+                let subtree = Merk::open(subtree_storage).unwrap() // TODO implement costs
                     .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))?;
                 let key = path_iter.next_back().expect("next element is `Some`");
                 let parent_storage = self
                     .db
                     .get_transactional_storage_context(path_iter.clone(), tx);
-                let mut parent_tree = Merk::open(parent_storage)
+                let mut parent_tree = Merk::open(parent_storage).unwrap() // TODO implement costs
                     .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))?;
-                Self::update_tree_item_preserve_flag(&mut parent_tree, key, subtree.root_hash())?;
+                Self::update_tree_item_preserve_flag(
+                    &mut parent_tree,
+                    key,
+                    subtree.root_hash().unwrap(), // TODO implement costs
+                )?;
             } else {
                 let subtree_storage = self.db.get_storage_context(path_iter.clone());
-                let subtree = Merk::open(subtree_storage)
+                let subtree = Merk::open(subtree_storage).unwrap() // TODO implement costs
                     .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))?;
                 let key = path_iter.next_back().expect("next element is `Some`");
                 let parent_storage = self.db.get_storage_context(path_iter.clone());
-                let mut parent_tree = Merk::open(parent_storage)
+                let mut parent_tree = Merk::open(parent_storage).unwrap() // TODO implement costs
                     .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))?;
-                Self::update_tree_item_preserve_flag(&mut parent_tree, key, subtree.root_hash())?;
+                Self::update_tree_item_preserve_flag(
+                    &mut parent_tree,
+                    key,
+                    subtree.root_hash().unwrap(), // TODO implement costs
+                )?;
             }
         }
 
@@ -239,7 +247,7 @@ impl GroveDb {
         key: K,
     ) -> Result<Element, Error> {
         let element_bytes = subtree
-            .get(key.as_ref())
+            .get(key.as_ref()).unwrap() // TODO implement costs
             .map_err(|_| Error::InvalidPath("can't find subtree in parent during propagation"))?
             .ok_or(Error::InvalidPath(
                 "can't find subtree in parent during propagation",

--- a/grovedb/src/operations/get.rs
+++ b/grovedb/src/operations/get.rs
@@ -71,7 +71,9 @@ impl GroveDb {
         if path_iter.len() == 0 {
             self.check_subtree_exists_path_not_found([key], transaction)?;
             merk_optional_tx!(self.db, [key], transaction, subtree, {
-                Ok(Element::new_tree(subtree.root_hash()))
+                Ok(Element::new_tree(
+                    subtree.root_hash().unwrap(), // TODO implement costs
+                ))
             })
         } else {
             self.check_subtree_exists_path_not_found(path_iter.clone(), transaction)?;

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -106,26 +106,32 @@ impl GroveDb {
             let parent_storage = self
                 .db
                 .get_transactional_storage_context(path_iter.clone(), tx);
-            let mut parent_subtree = Merk::open(parent_storage)
+            let mut parent_subtree = Merk::open(parent_storage).unwrap() // TODO implement costs
                 .map_err(|_| crate::Error::CorruptedData("cannot open a subtree".to_owned()))?;
             let child_storage = self.db.get_transactional_storage_context(
                 path_iter.clone().chain(std::iter::once(key)),
                 tx,
             );
-            let child_subtree = Merk::open(child_storage)
+            let child_subtree = Merk::open(child_storage).unwrap() // TODO implement costs
                 .map_err(|_| crate::Error::CorruptedData("cannot open a subtree".to_owned()))?;
-            let element = Element::new_tree_with_flag(child_subtree.root_hash(), element_flag);
+            let element = Element::new_tree_with_flag(
+                child_subtree.root_hash().unwrap(), // TODO implement costs
+                element_flag,
+            );
             element.insert(&mut parent_subtree, key)?;
         } else {
             let parent_storage = self.db.get_storage_context(path_iter.clone());
-            let mut parent_subtree = Merk::open(parent_storage)
+            let mut parent_subtree = Merk::open(parent_storage).unwrap() // TODO implement costs
                 .map_err(|_| crate::Error::CorruptedData("cannot open a subtree".to_owned()))?;
             let child_storage = self
                 .db
                 .get_storage_context(path_iter.clone().chain(std::iter::once(key)));
-            let child_subtree = Merk::open(child_storage)
+            let child_subtree = Merk::open(child_storage).unwrap() // TODO implement costs
                 .map_err(|_| crate::Error::CorruptedData("cannot open a subtree".to_owned()))?;
-            let element = Element::new_tree_with_flag(child_subtree.root_hash(), element_flag);
+            let element = Element::new_tree_with_flag(
+                child_subtree.root_hash().unwrap(), // TODO implement costs
+                element_flag,
+            );
             element.insert(&mut parent_subtree, key)?;
         }
         Ok(())

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -247,7 +247,7 @@ impl GroveDb {
     {
         // TODO: How do you handle mixed tree types?
         let mut proof_result = subtree
-            .prove_without_encoding(query.clone(), limit, offset)
+            .prove_without_encoding(query.clone(), limit, offset).unwrap() // TODO implement costs
             .expect("should generate proof");
 
         self.replace_references(&mut proof_result)?;
@@ -296,7 +296,7 @@ impl GroveDb {
         path: &Vec<&[u8]>,
     ) -> Result<Merk<PrefixedRocksDbStorageContext>, Error> {
         let storage = self.db.get_storage_context(path.clone());
-        let subtree = Merk::open(storage)
+        let subtree = Merk::open(storage).unwrap() // TODO implement costs
             .map_err(|_| Error::CorruptedData("cannot open a subtree".to_owned()))?;
         Ok(subtree)
     }

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -359,7 +359,13 @@ impl ProofVerifier {
             offset = self.offset;
         }
 
-        let (hash, result) = merk::execute_proof(proof, query, limit, offset, left_to_right)
+        let (hash, result) = merk::execute_proof(
+            proof,
+            query,
+            limit,
+            offset,
+            left_to_right
+        ).unwrap() // TODO implement costs
             .map_err(|e| {
                 eprintln!("{}", e.to_string());
                 Error::InvalidProof("invalid proof verification parameters")

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -179,7 +179,7 @@ impl Element {
     ) -> Result<(), Error> {
         // TODO: delete references on this element
         let batch = [(key, Op::Delete)];
-        merk.apply::<_, Vec<u8>>(&batch, &[])
+        merk.apply::<_, Vec<u8>>(&batch, &[]).unwrap() // TODO implement costs
             .map_err(|e| Error::CorruptedData(e.to_string()))
     }
 
@@ -190,7 +190,7 @@ impl Element {
         key: K,
     ) -> Result<Element, Error> {
         let element = Self::deserialize(
-            merk.get(key.as_ref())
+            merk.get(key.as_ref()).unwrap() // TODO implement costs
                 .map_err(|e| Error::CorruptedData(e.to_string()))?
                 .ok_or_else(|| {
                     Error::PathKeyNotFound(format!("key not found in Merk: {}", hex::encode(key)))
@@ -543,7 +543,7 @@ impl Element {
         key: K,
     ) -> Result<(), Error> {
         let batch_operations = [(key, Op::Put(self.serialize()?))];
-        merk.apply::<_, Vec<u8>>(&batch_operations, &[])
+        merk.apply::<_, Vec<u8>>(&batch_operations, &[]).unwrap() // TODO implement costs
             .map_err(|e| Error::CorruptedData(e.to_string()))
     }
 
@@ -559,7 +559,7 @@ impl Element {
         referenced_value: Vec<u8>,
     ) -> Result<(), Error> {
         let batch_operations = [(key, Op::PutReference(self.serialize()?, referenced_value))];
-        merk.apply::<_, Vec<u8>>(&batch_operations, &[])
+        merk.apply::<_, Vec<u8>>(&batch_operations, &[]).unwrap() // TODO implement costs
             .map_err(|e| Error::CorruptedData(e.to_string()))
     }
 
@@ -708,7 +708,9 @@ mod tests {
 
         let storage = &db.db;
         let storage_context = storage.get_storage_context([TEST_LEAF]);
-        let mut merk = Merk::open(storage_context).expect("cannot open Merk");
+        let mut merk = Merk::open(storage_context)
+            .unwrap()
+            .expect("cannot open Merk"); // TODO implement costs
 
         Element::new_item(b"ayyd".to_vec())
             .insert(&mut merk, b"d")
@@ -786,7 +788,9 @@ mod tests {
 
         let storage = &db.db;
         let storage_context = storage.get_storage_context([TEST_LEAF]);
-        let mut merk = Merk::open(storage_context).expect("cannot open Merk");
+        let mut merk = Merk::open(storage_context)
+            .unwrap()
+            .expect("cannot open Merk"); // TODO implement costs
 
         Element::new_item(b"ayyd".to_vec())
             .insert(&mut merk, b"d")
@@ -842,7 +846,9 @@ mod tests {
 
         let storage = &db.db;
         let storage_context = storage.get_storage_context([TEST_LEAF]);
-        let mut merk = Merk::open(storage_context).expect("cannot open Merk");
+        let mut merk = Merk::open(storage_context)
+            .unwrap()
+            .expect("cannot open Merk"); // TODO implement costs
 
         Element::new_item(b"ayyd".to_vec())
             .insert(&mut merk, b"d")
@@ -910,7 +916,9 @@ mod tests {
 
         let storage = &db.db;
         let storage_context = storage.get_storage_context([TEST_LEAF]);
-        let mut merk = Merk::open(storage_context).expect("cannot open Merk");
+        let mut merk = Merk::open(storage_context)
+            .unwrap()
+            .expect("cannot open Merk"); // TODO implement costs
 
         Element::new_item(b"ayyd".to_vec())
             .insert(&mut merk, b"d")

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -2314,7 +2314,6 @@ fn compare_result_sets(elements: &Vec<Vec<u8>>, result_set: &Vec<(Vec<u8>, Vec<u
 }
 
 fn deserialize_and_extract_item_bytes(raw_bytes: &[u8]) -> Result<Vec<u8>, Error> {
-    dbg!(raw_bytes);
     let elem = Element::deserialize(raw_bytes)?;
     return match elem {
         Element::Item(item, _) => Ok(item),

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -542,10 +542,14 @@ fn test_references() {
     .expect("successful subtree insert");
 
     let subtree_storage = db.db.db.get_storage_context([TEST_LEAF, b"merk_1"]);
-    let subtree = Merk::open(subtree_storage).expect("cannot open merk");
+    let subtree = Merk::open(subtree_storage)
+        .unwrap()
+        .expect("cannot open merk"); // TODO implement costs
 
     let subtree_storage = db.db.db.get_storage_context([TEST_LEAF, b"merk_2"]);
-    let subtree = Merk::open(subtree_storage).expect("cannot open merk");
+    let subtree = Merk::open(subtree_storage)
+        .unwrap()
+        .expect("cannot open merk"); // TODO implement costs
 }
 
 #[test]
@@ -1730,7 +1734,9 @@ fn test_get_subtree() {
     // Check if it returns the same instance that was inserted
     {
         let subtree_storage = db.db.db.get_storage_context([TEST_LEAF, b"key1", b"key2"]);
-        let subtree = Merk::open(subtree_storage).expect("cannot open merk");
+        let subtree = Merk::open(subtree_storage)
+            .unwrap()
+            .expect("cannot open merk"); // TODO implement costs
         let result_element = Element::get(&subtree, b"key3").unwrap();
         assert_eq!(result_element, Element::new_item(b"ayy".to_vec()));
     }
@@ -1758,13 +1764,17 @@ fn test_get_subtree() {
         .db
         .db
         .get_transactional_storage_context([TEST_LEAF, b"key1", b"innertree"], &transaction);
-    let subtree = Merk::open(subtree_storage).expect("cannot open merk");
+    let subtree = Merk::open(subtree_storage)
+        .unwrap()
+        .expect("cannot open merk"); // TODO implement costs
     let result_element = Element::get(&subtree, b"key4").unwrap();
     assert_eq!(result_element, Element::new_item(b"ayy".to_vec()));
 
     // Should be able to retrieve instances created before transaction
     let subtree_storage = db.db.db.get_storage_context([TEST_LEAF, b"key1", b"key2"]);
-    let subtree = Merk::open(subtree_storage).expect("cannot open merk");
+    let subtree = Merk::open(subtree_storage)
+        .unwrap()
+        .expect("cannot open merk"); // TODO implement costs
     let result_element = Element::get(&subtree, b"key3").unwrap();
     assert_eq!(result_element, Element::new_item(b"ayy".to_vec()));
 }

--- a/grovedb/src/util.rs
+++ b/grovedb/src/util.rs
@@ -42,7 +42,7 @@ macro_rules! merk_optional_tx {
         {
             use crate::util::storage_context_optional_tx;
             storage_context_optional_tx!($db, $path, $transaction, storage, {
-                let mut $subtree = ::merk::Merk::open(storage)
+                let mut $subtree = ::merk::Merk::open(storage).unwrap() // TODO implement costs
                     .map_err(|_| crate::Error::CorruptedData("cannot open a subtree".to_owned()))?;
                 $($body)*
             })
@@ -53,7 +53,7 @@ macro_rules! merk_optional_tx {
         {
             use crate::util::storage_context_optional_tx;
             storage_context_optional_tx!($db, $path, $transaction, storage, {
-                let $subtree = ::merk::Merk::open(storage)
+                let $subtree = ::merk::Merk::open(storage).unwrap() // TODO implement costs
                     .map_err(|_| crate::Error::CorruptedData("cannot open a subtree".to_owned()))?;
                 $($body)*
             })

--- a/merk/Cargo.toml
+++ b/merk/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.53"
 failure = "0.1.8"
 integer-encoding = "3.0.2"
 indexmap = "1.8.0"
+fees = { version = "0.1.0", path = "../fees" }
 
 [dependencies.time]
 version = "0.3.7"

--- a/merk/Cargo.toml
+++ b/merk/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0.53"
 failure = "0.1.8"
 integer-encoding = "3.0.2"
 indexmap = "1.8.0"
-fees = { version = "0.1.0", path = "../fees" }
+costs = { path = "../costs" }
 
 [dependencies.time]
 version = "0.3.7"

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -241,7 +241,9 @@ mod tests {
             let storage = RocksDbStorage::default_rocksdb_with_path(tmp_dir.path())
                 .expect("cannot open rocksdb storage");
 
-            let mut merk = Merk::open(storage.get_storage_context(empty())).unwrap();
+            let mut merk = Merk::open(storage.get_storage_context(empty()))
+                .unwrap()
+                .unwrap();
             let batch = make_batch_seq(1..10);
             merk.apply::<_, Vec<_>>(&batch, &[]).unwrap();
 
@@ -254,7 +256,9 @@ mod tests {
         };
         let storage = RocksDbStorage::default_rocksdb_with_path(tmp_dir.path())
             .expect("cannot open rocksdb storage");
-        let merk = Merk::open(storage.get_storage_context(empty())).unwrap();
+        let merk = Merk::open(storage.get_storage_context(empty()))
+            .unwrap()
+            .unwrap();
         let reopen_chunks = merk.chunks().unwrap().into_iter().map(Result::unwrap);
 
         for (original, checkpoint) in original_chunks.zip(reopen_chunks) {

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -2,7 +2,7 @@
 //! a Merk.
 use std::error::Error;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use costs::{cost_return_on_error, CostContext, CostsExt, OperationCost};
 use ed::Encode;
 use storage::{RawIterator, StorageContext};
@@ -251,7 +251,7 @@ mod tests {
 
         for (chunk, node) in chunks.zip(trunk.layer(height / 2)) {
             let ops = Decoder::new(chunk.as_slice());
-            verify_leaf(ops, node.hash().unwrap()).unwrap();
+            verify_leaf(ops, node.hash().unwrap()).unwrap().unwrap();
         }
     }
 
@@ -360,7 +360,7 @@ mod tests {
         merk.apply::<_, Vec<_>>(&batch, &[]).unwrap().unwrap();
 
         let mut producer = merk.chunks().unwrap().unwrap();
-        let _chunk = producer.chunk(50000).unwrap();
+        let _chunk = producer.chunk(50000).unwrap().unwrap();
     }
 
     #[test]

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -205,7 +205,7 @@ mod tests {
     fn len_small() {
         let mut merk = TempMerk::new();
         let batch = make_batch_seq(1..256);
-        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap();
+        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap().unwrap();
 
         let chunks = merk.chunks().unwrap().unwrap();
         assert_eq!(chunks.len(), 1);
@@ -216,7 +216,7 @@ mod tests {
     fn len_big() {
         let mut merk = TempMerk::new();
         let batch = make_batch_seq(1..10_000);
-        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap();
+        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap().unwrap();
 
         let chunks = merk.chunks().unwrap().unwrap();
         assert_eq!(chunks.len(), 129);
@@ -227,7 +227,7 @@ mod tests {
     fn generate_and_verify_chunks() {
         let mut merk = TempMerk::new();
         let batch = make_batch_seq(1..10_000);
-        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap();
+        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap().unwrap();
 
         let mut chunks = merk
             .chunks()
@@ -240,7 +240,7 @@ mod tests {
         let ops = Decoder::new(chunk.as_slice());
         let (trunk, height) = verify_trunk(ops).unwrap();
         assert_eq!(height, 14);
-        assert_eq!(trunk.hash(), merk.root_hash());
+        assert_eq!(trunk.hash(), merk.root_hash().unwrap());
 
         assert_eq!(trunk.layer(7).count(), 128);
 
@@ -261,7 +261,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             let batch = make_batch_seq(1..10);
-            merk.apply::<_, Vec<_>>(&batch, &[]).unwrap();
+            merk.apply::<_, Vec<_>>(&batch, &[]).unwrap().unwrap();
 
             merk.chunks()
                 .unwrap()
@@ -316,7 +316,7 @@ mod tests {
     fn random_access_chunks() {
         let mut merk = TempMerk::new();
         let batch = make_batch_seq(1..111);
-        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap();
+        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap().unwrap();
 
         let chunks = merk
             .chunks()
@@ -352,7 +352,7 @@ mod tests {
     fn test_chunk_index_oob() {
         let mut merk = TempMerk::new();
         let batch = make_batch_seq(1..42);
-        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap();
+        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap().unwrap();
 
         let mut producer = merk.chunks().unwrap().unwrap();
         let _chunk = producer.chunk(50000).unwrap();
@@ -362,7 +362,7 @@ mod tests {
     fn test_chunk_index_gt_1_access() {
         let mut merk = TempMerk::new();
         let batch = make_batch_seq(1..513);
-        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap();
+        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap().unwrap();
 
         let mut producer = merk.chunks().unwrap().unwrap();
         println!("length: {}", producer.len());
@@ -443,7 +443,7 @@ mod tests {
     fn test_next_chunk_index_oob() {
         let mut merk = TempMerk::new();
         let batch = make_batch_seq(1..42);
-        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap();
+        merk.apply::<_, Vec<_>>(&batch, &[]).unwrap().unwrap();
 
         let mut producer = merk.chunks().unwrap().unwrap();
         let _chunk1 = producer.next_chunk();

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -3,7 +3,7 @@ pub mod chunks;
 // pub mod restore;
 use std::{cell::Cell, cmp::Ordering, collections::LinkedList, fmt};
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use costs::{cost_return_on_error, CostContext, CostsExt, OperationCost};
 use storage::{self, Batch, RawIterator, StorageContext};
 

--- a/merk/src/owner.rs
+++ b/merk/src/owner.rs
@@ -2,6 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 /// A container type which holds a value that may be temporarily owned by a
 /// consumer.
+#[derive(Debug)]
 pub struct Owner<T> {
     inner: Option<T>,
 }

--- a/merk/src/proofs/chunk.rs
+++ b/merk/src/proofs/chunk.rs
@@ -219,10 +219,11 @@ pub(crate) fn verify_leaf<I: Iterator<Item = Result<Op>>>(
         tree.hash().map(|hash| {
             if hash != expected_hash {
                 bail!(
-                "Leaf chunk proof did not match expected hash\n\tExpected: {:?}\n\tActual: {:?}",
-                expected_hash,
-                tree.hash()
-            );
+                    "Leaf chunk proof did not match expected hash\n\tExpected: {:?}\n\tActual: \
+                     {:?}",
+                    expected_hash,
+                    tree.hash()
+                );
             }
             Ok(tree)
         })
@@ -469,7 +470,9 @@ mod tests {
         iter.seek_to_first();
         let chunk = get_next_chunk(&mut iter, None).unwrap().unwrap();
         let ops = chunk.into_iter().map(Ok);
-        let chunk = verify_leaf(ops, merk.root_hash().unwrap()).unwrap().unwrap();
+        let chunk = verify_leaf(ops, merk.root_hash().unwrap())
+            .unwrap()
+            .unwrap();
         let counts = count_node_types(chunk);
         assert_eq!(counts.kv, 31);
         assert_eq!(counts.hash, 0);
@@ -480,7 +483,9 @@ mod tests {
         iter.seek_to_first();
 
         // left leaf
-        let chunk = get_next_chunk(&mut iter, Some(root_key.as_slice())).unwrap().unwrap();
+        let chunk = get_next_chunk(&mut iter, Some(root_key.as_slice()))
+            .unwrap()
+            .unwrap();
         let ops = chunk.into_iter().map(Ok);
         let chunk = verify_leaf(
             ops,
@@ -489,7 +494,8 @@ mod tests {
                 220, 160, 35, 78, 120, 122, 61, 90, 241, 105, 35, 180, 133, 98,
             ],
         )
-        .unwrap().unwrap();
+        .unwrap()
+        .unwrap();
         let counts = count_node_types(chunk);
         assert_eq!(counts.kv, 15);
         assert_eq!(counts.hash, 0);
@@ -505,7 +511,8 @@ mod tests {
                 19, 191, 134, 37, 165, 5, 35, 111, 233, 213, 212, 5, 92, 45,
             ],
         )
-        .unwrap().unwrap();
+        .unwrap()
+        .unwrap();
         let counts = count_node_types(chunk);
         assert_eq!(counts.kv, 15);
         assert_eq!(counts.hash, 0);

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -819,8 +819,8 @@ where
     }
 
     /// Creates a `Node::Hash` from the hash of the node.
-    pub(crate) fn to_hash_node(&self) -> Node {
-        Node::Hash(self.tree().hash())
+    pub(crate) fn to_hash_node(&self) -> CostContext<Node> {
+        self.tree().hash().map(Node::Hash)
     }
 
     #[cfg(feature = "full")]
@@ -1377,7 +1377,9 @@ mod test {
         let mut tree = Tree::new(vec![5], vec![5])
             .attach(true, Some(Tree::new(vec![3], vec![3])))
             .attach(false, Some(Tree::new(vec![7], vec![7])));
-        tree.commit(&mut NoopCommit {}).expect("commit failed");
+        tree.commit(&mut NoopCommit {})
+            .unwrap()
+            .expect("commit failed");
         tree
     }
 
@@ -1389,18 +1391,23 @@ mod test {
             .attach(false, Some(four_tree));
         three_tree
             .commit(&mut NoopCommit {})
+            .unwrap()
             .expect("commit failed");
 
         let seven_tree = Tree::new(vec![7], vec![7]);
         let mut eight_tree = Tree::new(vec![8], vec![8]).attach(true, Some(seven_tree));
         eight_tree
             .commit(&mut NoopCommit {})
+            .unwrap()
             .expect("commit failed");
 
         let mut root_tree = Tree::new(vec![5], vec![5])
             .attach(true, Some(three_tree))
             .attach(false, Some(eight_tree));
-        root_tree.commit(&mut NoopCommit {}).expect("commit failed");
+        root_tree
+            .commit(&mut NoopCommit {})
+            .unwrap()
+            .expect("commit failed");
 
         root_tree
     }
@@ -1520,7 +1527,7 @@ mod test {
             ),
         );
         assert_eq!(
-            walker.to_hash_node(),
+            walker.to_hash_node().unwrap(),
             Node::Hash([
                 47, 88, 45, 83, 28, 53, 123, 233, 238, 140, 130, 174, 250, 220, 210, 37, 3, 215,
                 82, 177, 190, 30, 154, 156, 35, 214, 144, 79, 40, 41, 218, 142
@@ -1573,7 +1580,7 @@ mod test {
             None,
             None,
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert!(res.result_set.is_empty());
@@ -1617,7 +1624,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
     }
 
@@ -1659,7 +1674,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![(vec![3], vec![3])]);
     }
 
@@ -1695,7 +1718,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![3], vec![3]), (vec![7], vec![7]),]
@@ -1732,7 +1763,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![3], vec![3]), (vec![5], vec![5]), (vec![7], vec![7]),]
@@ -1786,7 +1825,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![]);
     }
 
@@ -1840,7 +1887,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![]);
     }
 
@@ -1882,7 +1937,7 @@ mod test {
                         ),
                 ),
             );
-        tree.commit(&mut NoopCommit {}).unwrap();
+        tree.commit(&mut NoopCommit {}).unwrap().unwrap();
 
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
@@ -1943,7 +1998,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -2114,7 +2177,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -2149,7 +2220,7 @@ mod test {
             Some(1),
             Some(1),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(
@@ -2183,7 +2254,7 @@ mod test {
             Some(1),
             Some(2),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -2214,7 +2285,7 @@ mod test {
             Some(1),
             Some(200),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -2239,7 +2310,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -2327,7 +2406,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -2363,7 +2450,7 @@ mod test {
             Some(1),
             Some(1),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(
@@ -2397,7 +2484,7 @@ mod test {
             Some(1),
             Some(2),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(
@@ -2431,7 +2518,7 @@ mod test {
             Some(1),
             Some(200),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -2456,7 +2543,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(
             res.result_set,
@@ -2484,8 +2579,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res =
-            verify_query(bytes.as_slice(), &query, None, Some(2), false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            Some(2),
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(
             res.result_set,
@@ -2529,7 +2631,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8])]
@@ -2562,7 +2672,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(1),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
         assert_eq!(res.limit, Some(0));
         assert_eq!(res.offset, None);
@@ -2596,7 +2714,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(2),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![5], vec![5]), (vec![7], vec![7]),]
@@ -2629,8 +2755,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res =
-            verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(100),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![5], vec![5]), (vec![7], vec![7]), (vec![8], vec![8])]
@@ -2660,7 +2793,7 @@ mod test {
             Some(1),
             Some(1),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![7], vec![7])]);
@@ -2689,7 +2822,7 @@ mod test {
             Some(1),
             Some(2),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![8], vec![8])]);
@@ -2718,7 +2851,7 @@ mod test {
             Some(1),
             Some(200),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -2743,7 +2876,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![8], vec![8]), (vec![7], vec![7]), (vec![5], vec![5])]
@@ -2772,7 +2913,7 @@ mod test {
             Some(2),
             Some(1),
             false,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![7], vec![7]), (vec![5], vec![5])]);
@@ -2827,7 +2968,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -2865,7 +3014,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(1),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
         assert_eq!(res.limit, Some(0));
         assert_eq!(res.offset, None);
@@ -2895,7 +3052,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(2),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![2], vec![2]), (vec![3], vec![3]),]
@@ -2928,8 +3093,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res =
-            verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(100),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -2964,7 +3136,7 @@ mod test {
             Some(1),
             Some(1),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![3], vec![3])]);
@@ -2993,7 +3165,7 @@ mod test {
             Some(1),
             Some(2),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
@@ -3022,7 +3194,7 @@ mod test {
             Some(1),
             Some(200),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -3047,7 +3219,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -3075,8 +3255,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res =
-            verify_query(bytes.as_slice(), &query, Some(2), None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(2),
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![5], vec![5]), (vec![4], vec![4]),]
@@ -3132,7 +3319,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -3170,7 +3365,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(1),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
         assert_eq!(res.limit, Some(0));
         assert_eq!(res.offset, None);
@@ -3200,7 +3403,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(2),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![2], vec![2]), (vec![3], vec![3]),]
@@ -3233,8 +3444,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res =
-            verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(100),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -3269,7 +3487,7 @@ mod test {
             Some(1),
             Some(1),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![3], vec![3])]);
@@ -3298,7 +3516,7 @@ mod test {
             Some(1),
             Some(2),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
@@ -3327,7 +3545,7 @@ mod test {
             Some(1),
             Some(200),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -3352,7 +3570,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -3386,7 +3612,7 @@ mod test {
             Some(1),
             Some(1),
             false,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4]),]);
@@ -3441,7 +3667,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -3479,7 +3713,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(1),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
         assert_eq!(res.limit, Some(0));
         assert_eq!(res.offset, None);
@@ -3509,7 +3751,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(2),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
@@ -3542,8 +3792,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res =
-            verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(100),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -3578,7 +3835,7 @@ mod test {
             Some(1),
             Some(1),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
@@ -3607,7 +3864,7 @@ mod test {
             Some(1),
             Some(2),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![7], vec![7])]);
@@ -3636,7 +3893,7 @@ mod test {
             Some(1),
             Some(200),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -3661,7 +3918,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -3689,8 +3954,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res =
-            verify_query(bytes.as_slice(), &query, Some(3), None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(3),
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![8], vec![8]), (vec![7], vec![7]), (vec![5], vec![5]),]
@@ -3761,7 +4033,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
@@ -3794,7 +4074,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(1),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
         assert_eq!(res.limit, Some(0));
         assert_eq!(res.offset, None);
@@ -3824,7 +4112,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(2),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
@@ -3857,8 +4153,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res =
-            verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(100),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
@@ -3888,7 +4191,7 @@ mod test {
             Some(1),
             Some(1),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
@@ -3917,7 +4220,7 @@ mod test {
             Some(1),
             Some(2),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -3946,7 +4249,7 @@ mod test {
             Some(1),
             Some(200),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -3971,7 +4274,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![5], vec![5]), (vec![4], vec![4]),]
@@ -4000,7 +4311,7 @@ mod test {
             Some(300),
             Some(1),
             false,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
@@ -4061,7 +4372,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]), (vec![7], vec![7])]
@@ -4094,7 +4413,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(1),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
         assert_eq!(res.limit, Some(0));
         assert_eq!(res.offset, None);
@@ -4124,7 +4451,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(2),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]),]
@@ -4157,8 +4492,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res =
-            verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(100),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![4], vec![4]), (vec![5], vec![5]), (vec![7], vec![7])]
@@ -4188,7 +4530,7 @@ mod test {
             Some(1),
             Some(1),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![5], vec![5])]);
@@ -4217,7 +4559,7 @@ mod test {
             Some(1),
             Some(2),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![7], vec![7])]);
@@ -4246,7 +4588,7 @@ mod test {
             Some(1),
             Some(200),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -4271,7 +4613,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![7], vec![7]), (vec![5], vec![5]), (vec![4], vec![4])]
@@ -4311,7 +4661,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -4351,7 +4709,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(1),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
         assert_eq!(res.limit, Some(0));
         assert_eq!(res.offset, None);
@@ -4381,7 +4747,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(2), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(2),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![2], vec![2]), (vec![3], vec![3]),]
@@ -4414,8 +4788,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res =
-            verify_query(bytes.as_slice(), &query, Some(100), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(100),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -4452,7 +4833,7 @@ mod test {
             Some(3),
             Some(1),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(
@@ -4484,7 +4865,7 @@ mod test {
             Some(2),
             Some(2),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(
@@ -4516,7 +4897,7 @@ mod test {
             Some(1),
             Some(200),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![]);
@@ -4541,7 +4922,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -4577,7 +4966,7 @@ mod test {
             Some(2),
             Some(2),
             false,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(
@@ -4645,7 +5034,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, Some(1), None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            Some(1),
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(res.result_set, vec![(vec![2], vec![2])]);
         assert_eq!(res.limit, Some(0));
         assert_eq!(res.offset, None);
@@ -4716,7 +5113,7 @@ mod test {
             Some(1),
             Some(2),
             true,
-            tree.hash(),
+            tree.hash().unwrap(),
         )
         .unwrap();
         assert_eq!(res.result_set, vec![(vec![4], vec![4])]);
@@ -4778,7 +5175,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, false, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            false,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -4872,7 +5277,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![
@@ -4967,7 +5380,15 @@ mod test {
         for item in queryitems {
             query.insert_item(item);
         }
-        let res = verify_query(bytes.as_slice(), &query, None, None, true, tree.hash()).unwrap();
+        let res = verify_query(
+            bytes.as_slice(),
+            &query,
+            None,
+            None,
+            true,
+            tree.hash().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             res.result_set,
             vec![(vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),]
@@ -5020,9 +5441,11 @@ mod test {
     #[test]
     fn verify_ops() {
         let mut tree = Tree::new(vec![5], vec![5]);
-        tree.commit(&mut NoopCommit {}).expect("commit failed");
+        tree.commit(&mut NoopCommit {})
+            .unwrap()
+            .expect("commit failed");
 
-        let root_hash = tree.hash();
+        let root_hash = tree.hash().unwrap();
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let (proof, ..) = walker
@@ -5044,7 +5467,9 @@ mod test {
     #[should_panic(expected = "verify failed")]
     fn verify_ops_mismatched_hash() {
         let mut tree = Tree::new(vec![5], vec![5]);
-        tree.commit(&mut NoopCommit {}).expect("commit failed");
+        tree.commit(&mut NoopCommit {})
+            .unwrap()
+            .expect("commit failed");
 
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -28,7 +28,7 @@ pub struct SubqueryBranch {
 /// resolve a proof which will include all of the requested values.
 #[derive(Debug, Default, Clone)]
 pub struct Query {
-    items: BTreeSet<QueryItem>,
+    pub items: BTreeSet<QueryItem>,
     pub default_subquery_branch: SubqueryBranch,
     pub conditional_subquery_branches: IndexMap<QueryItem, SubqueryBranch>,
     pub left_to_right: bool,
@@ -289,6 +289,17 @@ impl std::hash::Hash for QueryItem {
 }
 
 impl QueryItem {
+    pub fn processing_footprint(&self) -> u32 {
+        match self {
+            QueryItem::Key(key) => key.len() as u32,
+            QueryItem::RangeFull(_) => 0u32,
+            _ => {
+                self.lower_bound().0.map_or(0u32, |x| x.len() as u32)
+                    + self.upper_bound().0.map_or(0u32, |x| x.len() as u32)
+            }
+        }
+    }
+
     pub fn lower_bound(&self) -> (Option<&[u8]>, bool) {
         match self {
             QueryItem::Key(key) => (Some(key.as_slice()), false),

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use anyhow::{bail, Result};
+use costs::CostContext;
 use indexmap::IndexMap;
 pub use map::*;
 use storage::RawIterator;
@@ -1043,7 +1044,7 @@ where
         limit: Option<u16>,
         offset: Option<u16>,
         left_to_right: bool,
-    ) -> Result<ProofAbsenceLimitOffset> {
+    ) -> CostContext<Result<ProofAbsenceLimitOffset>> {
         Ok(if !query.is_empty() {
             if let Some(mut child) = self.walk(left)? {
                 child.create_proof(query, limit, offset, left_to_right)?

--- a/merk/src/proofs/tree.rs
+++ b/merk/src/proofs/tree.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, bail, Result};
-use costs::{CostContext, CostsExt, OperationCost, cost_return_on_error, cost_return_on_error_no_add};
+use costs::{
+    cost_return_on_error, cost_return_on_error_no_add, CostContext, CostsExt, OperationCost,
+};
 
 use super::{Node, Op};
 use crate::tree::{kv_digest_to_kv_hash, kv_hash, node_hash, Hash, NULL_HASH};
@@ -386,13 +388,13 @@ mod test {
 
         let mut tree = make_node(3);
         let mut left = make_node(1);
-        left.attach(true, make_node(0)).unwrap();
-        left.attach(false, make_node(2)).unwrap();
+        left.attach(true, make_node(0)).unwrap().unwrap();
+        left.attach(false, make_node(2)).unwrap().unwrap();
         let mut right = make_node(5);
-        right.attach(true, make_node(4)).unwrap();
-        right.attach(false, make_node(6)).unwrap();
-        tree.attach(true, left).unwrap();
-        tree.attach(false, right).unwrap();
+        right.attach(true, make_node(4)).unwrap().unwrap();
+        right.attach(false, make_node(6)).unwrap().unwrap();
+        tree.attach(true, left).unwrap().unwrap();
+        tree.attach(false, right).unwrap().unwrap();
 
         tree
     }

--- a/merk/src/proofs/tree.rs
+++ b/merk/src/proofs/tree.rs
@@ -1,4 +1,5 @@
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
+use costs::{CostContext, CostsExt, OperationCost, cost_return_on_error, cost_return_on_error_no_add};
 
 use super::{Node, Op};
 use crate::tree::{kv_digest_to_kv_hash, kv_hash, node_hash, Hash, NULL_HASH};
@@ -42,22 +43,18 @@ impl PartialEq for Tree {
 
 impl Tree {
     /// Gets or computes the hash for this tree node.
-    pub fn hash(&self) -> Hash {
-        fn compute_hash(tree: &Tree, kv_hash: Hash) -> Hash {
+    pub fn hash(&self) -> CostContext<Hash> {
+        fn compute_hash(tree: &Tree, kv_hash: Hash) -> CostContext<Hash> {
             node_hash(&kv_hash, &tree.child_hash(true), &tree.child_hash(false))
         }
 
         match &self.node {
-            Node::Hash(hash) => *hash,
+            Node::Hash(hash) => (*hash).wrap_with_cost(Default::default()),
             Node::KVHash(kv_hash) => compute_hash(self, *kv_hash),
-            Node::KV(key, value) => {
-                let kv_hash = kv_hash(key.as_slice(), value.as_slice());
-                compute_hash(self, kv_hash)
-            }
-            Node::KVDigest(key, value_hash) => {
-                let kv_hash = kv_digest_to_kv_hash(key, value_hash);
-                compute_hash(self, kv_hash)
-            }
+            Node::KV(key, value) => kv_hash(key.as_slice(), value.as_slice())
+                .flat_map(|kv_hash| compute_hash(self, kv_hash)),
+            Node::KVDigest(key, value_hash) => kv_digest_to_kv_hash(key, value_hash)
+                .flat_map(|kv_hash| compute_hash(self, kv_hash)),
         }
     }
 
@@ -116,18 +113,23 @@ impl Tree {
 
     /// Attaches the child to the `Tree`'s given side. Panics if there is
     /// already a child attached to this side.
-    pub(crate) fn attach(&mut self, left: bool, child: Self) -> Result<()> {
+    pub(crate) fn attach(&mut self, left: bool, child: Self) -> CostContext<Result<()>> {
+        let mut cost = OperationCost::default();
+
         if self.child(left).is_some() {
-            bail!("Tried to attach to left child, but it is already Some");
+            return Err(anyhow!(
+                "Tried to attach to left child, but it is already Some"
+            ))
+            .wrap_with_cost(cost);
         }
 
         self.height = self.height.max(child.height + 1);
 
-        let hash = child.hash();
+        let hash = child.hash().unwrap_add_cost(&mut cost);
         let tree = Box::new(child);
         *self.child_mut(left) = Some(Child { tree, hash });
 
-        Ok(())
+        Ok(()).wrap_with_cost(cost)
     }
 
     /// Returns the already-computed hash for this tree node's child on the
@@ -143,8 +145,8 @@ impl Tree {
 
     /// Consumes the tree node, calculates its hash, and returns a `Node::Hash`
     /// variant.
-    fn into_hash(self) -> Self {
-        Node::Hash(self.hash()).into()
+    fn into_hash(self) -> CostContext<Self> {
+        self.hash().map(|hash| Node::Hash(hash).into())
     }
 
     // #[cfg(feature = "full")]
@@ -237,11 +239,13 @@ impl<'a> Iterator for LayerIter<'a> {
 /// `visit_node` will be called once for every push operation in the proof, in
 /// key-order. If `visit_node` returns an `Err` result, it will halt the
 /// execution and `execute` will return the error.
-pub(crate) fn execute<I, F>(ops: I, collapse: bool, mut visit_node: F) -> Result<Tree>
+pub(crate) fn execute<I, F>(ops: I, collapse: bool, mut visit_node: F) -> CostContext<Result<Tree>>
 where
     I: IntoIterator<Item = Result<Op>>,
     F: FnMut(&Node) -> Result<()>,
 {
+    let mut cost = OperationCost::default();
+
     let mut stack: Vec<Tree> = Vec::with_capacity(32);
     let mut maybe_last_key = None;
 
@@ -253,25 +257,77 @@ where
     }
 
     for op in ops {
-        match op? {
+        match cost_return_on_error_no_add!(&cost, op) {
             Op::Parent => {
-                let (mut parent, child) = (try_pop(&mut stack)?, try_pop(&mut stack)?);
-                parent.attach(true, if collapse { child.into_hash() } else { child })?;
+                let (mut parent, child) = (
+                    cost_return_on_error_no_add!(&cost, try_pop(&mut stack)),
+                    cost_return_on_error_no_add!(&cost, try_pop(&mut stack)),
+                );
+                cost_return_on_error!(
+                    &mut cost,
+                    parent.attach(
+                        true,
+                        if collapse {
+                            child.into_hash().unwrap_add_cost(&mut cost)
+                        } else {
+                            child
+                        },
+                    )
+                );
                 stack.push(parent);
             }
             Op::Child => {
-                let (child, mut parent) = (try_pop(&mut stack)?, try_pop(&mut stack)?);
-                parent.attach(false, if collapse { child.into_hash() } else { child })?;
+                let (child, mut parent) = (
+                    cost_return_on_error_no_add!(&cost, try_pop(&mut stack)),
+                    cost_return_on_error_no_add!(&cost, try_pop(&mut stack)),
+                );
+                cost_return_on_error!(
+                    &mut cost,
+                    parent.attach(
+                        false,
+                        if collapse {
+                            child.into_hash().unwrap_add_cost(&mut cost)
+                        } else {
+                            child
+                        }
+                    )
+                );
                 stack.push(parent);
             }
             Op::ParentInverted => {
-                let (mut parent, child) = (try_pop(&mut stack)?, try_pop(&mut stack)?);
-                parent.attach(false, if collapse { child.into_hash() } else { child })?;
+                let (mut parent, child) = (
+                    cost_return_on_error_no_add!(&cost, try_pop(&mut stack)),
+                    cost_return_on_error_no_add!(&cost, try_pop(&mut stack)),
+                );
+                cost_return_on_error!(
+                    &mut cost,
+                    parent.attach(
+                        false,
+                        if collapse {
+                            child.into_hash().unwrap_add_cost(&mut cost)
+                        } else {
+                            child
+                        },
+                    )
+                );
                 stack.push(parent);
             }
             Op::ChildInverted => {
-                let (child, mut parent) = (try_pop(&mut stack)?, try_pop(&mut stack)?);
-                parent.attach(true, if collapse { child.into_hash() } else { child })?;
+                let (child, mut parent) = (
+                    cost_return_on_error_no_add!(&cost, try_pop(&mut stack)),
+                    cost_return_on_error_no_add!(&cost, try_pop(&mut stack)),
+                );
+                cost_return_on_error!(
+                    &mut cost,
+                    parent.attach(
+                        true,
+                        if collapse {
+                            child.into_hash().unwrap_add_cost(&mut cost)
+                        } else {
+                            child
+                        },
+                    )
+                );
                 stack.push(parent);
             }
             Op::Push(node) => {
@@ -279,14 +335,14 @@ where
                     // keys should always increase
                     if let Some(last_key) = &maybe_last_key {
                         if key <= last_key {
-                            bail!("Incorrect key ordering");
+                            return Err(anyhow!("Incorrect key ordering")).wrap_with_cost(cost);
                         }
                     }
 
                     maybe_last_key = Some(key.clone());
                 }
 
-                visit_node(&node)?;
+                cost_return_on_error_no_add!(&cost, visit_node(&node));
 
                 let tree: Tree = node.into();
                 stack.push(tree);
@@ -296,14 +352,14 @@ where
                     // keys should always increase
                     if let Some(last_key) = &maybe_last_key {
                         if key >= last_key {
-                            bail!("Incorrect key ordering");
+                            return Err(anyhow!("Incorrect key ordering")).wrap_with_cost(cost);
                         }
                     }
 
                     maybe_last_key = Some(key.clone());
                 }
 
-                visit_node(&node)?;
+                cost_return_on_error_no_add!(&cost, visit_node(&node));
 
                 let tree: Tree = node.into();
                 stack.push(tree);
@@ -312,10 +368,13 @@ where
     }
 
     if stack.len() != 1 {
-        bail!("Expected proof to result in exactly one stack item");
+        return Err(anyhow!(
+            "Expected proof to result in exactly one stack item"
+        ))
+        .wrap_with_cost(cost);
     }
 
-    Ok(stack.pop().unwrap())
+    Ok(stack.pop().unwrap()).wrap_with_cost(cost)
 }
 
 #[cfg(test)]

--- a/merk/src/test_utils/crash_merk.rs
+++ b/merk/src/test_utils/crash_merk.rs
@@ -64,11 +64,11 @@ mod tests {
     #[ignore] // currently this still works because we enabled the WAL
     fn crash() {
         let mut merk = CrashMerk::open().expect("failed to open merk");
-        merk.apply::<_, Vec<u8>>(&[(vec![1, 2, 3], Op::Put(vec![4, 5, 6]))], &[])
+        merk.apply::<_, Vec<u8>>(&[(vec![1, 2, 3], Op::Put(vec![4, 5, 6]))], &[]).unwrap()
             .expect("apply failed");
 
         merk.crash();
 
-        assert_eq!(merk.get(&[1, 2, 3]).expect("failed to get"), None);
+        assert_eq!(merk.get(&[1, 2, 3]).unwrap().expect("failed to get"), None);
     }
 }

--- a/merk/src/test_utils/crash_merk.rs
+++ b/merk/src/test_utils/crash_merk.rs
@@ -64,7 +64,8 @@ mod tests {
     #[ignore] // currently this still works because we enabled the WAL
     fn crash() {
         let mut merk = CrashMerk::open().expect("failed to open merk");
-        merk.apply::<_, Vec<u8>>(&[(vec![1, 2, 3], Op::Put(vec![4, 5, 6]))], &[]).unwrap()
+        merk.apply::<_, Vec<u8>>(&[(vec![1, 2, 3], Op::Put(vec![4, 5, 6]))], &[])
+            .unwrap()
             .expect("apply failed");
 
         merk.crash();

--- a/merk/src/test_utils/crash_merk.rs
+++ b/merk/src/test_utils/crash_merk.rs
@@ -24,7 +24,7 @@ impl CrashMerk {
     pub fn open() -> Result<CrashMerk> {
         let storage = Box::leak(Box::new(TempStorage::new()));
         let context = storage.get_storage_context(empty());
-        let merk = Merk::open(context).unwrap();
+        let merk = Merk::open(context).unwrap().unwrap();
         Ok(CrashMerk { merk, storage })
     }
 

--- a/merk/src/test_utils/mod.rs
+++ b/merk/src/test_utils/mod.rs
@@ -34,7 +34,7 @@ pub fn assert_tree_invariants(tree: &Tree) {
 
 pub fn apply_memonly_unchecked(tree: Tree, batch: &MerkBatch<Vec<u8>>) -> Tree {
     let walker = Walker::<PanicSource>::new(tree, PanicSource {});
-    let mut tree = Walker::<PanicSource>::apply_to(Some(walker), batch, PanicSource {})
+    let mut tree = Walker::<PanicSource>::apply_to(Some(walker), batch, PanicSource {}).unwrap()
         .expect("apply failed")
         .0
         .expect("expected tree");
@@ -50,7 +50,7 @@ pub fn apply_memonly(tree: Tree, batch: &MerkBatch<Vec<u8>>) -> Tree {
 
 pub fn apply_to_memonly(maybe_tree: Option<Tree>, batch: &MerkBatch<Vec<u8>>) -> Option<Tree> {
     let maybe_walker = maybe_tree.map(|tree| Walker::<PanicSource>::new(tree, PanicSource {}));
-    Walker::<PanicSource>::apply_to(maybe_walker, batch, PanicSource {})
+    Walker::<PanicSource>::apply_to(maybe_walker, batch, PanicSource {}).unwrap()
         .expect("apply failed")
         .0
         .map(|mut tree| {

--- a/merk/src/test_utils/mod.rs
+++ b/merk/src/test_utils/mod.rs
@@ -34,11 +34,14 @@ pub fn assert_tree_invariants(tree: &Tree) {
 
 pub fn apply_memonly_unchecked(tree: Tree, batch: &MerkBatch<Vec<u8>>) -> Tree {
     let walker = Walker::<PanicSource>::new(tree, PanicSource {});
-    let mut tree = Walker::<PanicSource>::apply_to(Some(walker), batch, PanicSource {}).unwrap()
+    let mut tree = Walker::<PanicSource>::apply_to(Some(walker), batch, PanicSource {})
+        .unwrap()
         .expect("apply failed")
         .0
         .expect("expected tree");
-    tree.commit(&mut NoopCommit {}).expect("commit failed");
+    tree.commit(&mut NoopCommit {})
+        .unwrap()
+        .expect("commit failed");
     tree
 }
 
@@ -50,11 +53,14 @@ pub fn apply_memonly(tree: Tree, batch: &MerkBatch<Vec<u8>>) -> Tree {
 
 pub fn apply_to_memonly(maybe_tree: Option<Tree>, batch: &MerkBatch<Vec<u8>>) -> Option<Tree> {
     let maybe_walker = maybe_tree.map(|tree| Walker::<PanicSource>::new(tree, PanicSource {}));
-    Walker::<PanicSource>::apply_to(maybe_walker, batch, PanicSource {}).unwrap()
+    Walker::<PanicSource>::apply_to(maybe_walker, batch, PanicSource {})
+        .unwrap()
         .expect("apply failed")
         .0
         .map(|mut tree| {
-            tree.commit(&mut NoopCommit {}).expect("commit failed");
+            tree.commit(&mut NoopCommit {})
+                .unwrap()
+                .expect("commit failed");
             println!("{:?}", &tree);
             assert_tree_invariants(&tree);
             tree

--- a/merk/src/test_utils/mod.rs
+++ b/merk/src/test_utils/mod.rs
@@ -122,7 +122,7 @@ pub fn make_tree_rand(node_count: u64, batch_size: u64, initial_seed: u64) -> Tr
     assert_eq!((node_count % batch_size), 0);
 
     let value = vec![123; 60];
-    let mut tree = Tree::new(vec![0; 20], value);
+    let mut tree = Tree::new(vec![0; 20], value).unwrap();
 
     let mut seed = initial_seed;
 
@@ -145,7 +145,7 @@ pub fn make_tree_seq(node_count: u64) -> Tree {
     };
 
     let value = vec![123; 60];
-    let mut tree = Tree::new(vec![0; 20], value);
+    let mut tree = Tree::new(vec![0; 20], value).unwrap();
 
     let batch_count = node_count / batch_size;
     for i in 0..batch_count {

--- a/merk/src/test_utils/temp_merk.rs
+++ b/merk/src/test_utils/temp_merk.rs
@@ -22,7 +22,7 @@ impl TempMerk {
     pub fn new() -> Self {
         let storage = Box::leak(Box::new(TempStorage::new()));
         let context = storage.get_storage_context(empty());
-        let merk = Merk::open(context).unwrap();
+        let merk = Merk::open(context).unwrap().unwrap();
         TempMerk { storage, merk }
     }
 }

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -77,7 +77,6 @@ impl Tree {
 #[cfg(test)]
 mod tests {
     use super::{super::Link, *};
-    use crate::tree::hash::value_hash;
 
     #[test]
     fn encode_leaf_tree() {

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn encode_leaf_tree() {
-        let tree = Tree::from_fields(vec![0], vec![1], [55; 32], None, None);
+        let tree = Tree::from_fields(vec![0], vec![1], [55; 32], None, None).unwrap();
         assert_eq!(tree.encoding_length(), 67);
         assert_eq!(
             tree.encode(),
@@ -104,10 +104,10 @@ mod tests {
             Some(Link::Modified {
                 pending_writes: 1,
                 child_heights: (123, 124),
-                tree: Tree::new(vec![2], vec![3]),
+                tree: Tree::new(vec![2], vec![3]).unwrap(),
             }),
             None,
-        );
+        ).unwrap();
         tree.encode();
     }
 
@@ -120,10 +120,10 @@ mod tests {
             Some(Link::Loaded {
                 hash: [66; 32],
                 child_heights: (123, 124),
-                tree: Tree::new(vec![2], vec![3]),
+                tree: Tree::new(vec![2], vec![3]).unwrap(),
             }),
             None,
-        );
+        ).unwrap();
         assert_eq!(
             tree.encode(),
             vec![
@@ -146,10 +146,10 @@ mod tests {
             Some(Link::Uncommitted {
                 hash: [66; 32],
                 child_heights: (123, 124),
-                tree: Tree::new(vec![2], vec![3]),
+                tree: Tree::new(vec![2], vec![3]).unwrap(),
             }),
             None,
-        );
+        ).unwrap();
         assert_eq!(
             tree.encode(),
             vec![
@@ -175,7 +175,7 @@ mod tests {
                 key: vec![2],
             }),
             None,
-        );
+        ).unwrap();
         assert_eq!(tree.encoding_length(), 103);
         assert_eq!(
             tree.encode(),

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -107,7 +107,8 @@ mod tests {
                 tree: Tree::new(vec![2], vec![3]).unwrap(),
             }),
             None,
-        ).unwrap();
+        )
+        .unwrap();
         tree.encode();
     }
 
@@ -123,7 +124,8 @@ mod tests {
                 tree: Tree::new(vec![2], vec![3]).unwrap(),
             }),
             None,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(
             tree.encode(),
             vec![
@@ -149,7 +151,8 @@ mod tests {
                 tree: Tree::new(vec![2], vec![3]).unwrap(),
             }),
             None,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(
             tree.encode(),
             vec![
@@ -175,7 +178,8 @@ mod tests {
                 key: vec![2],
             }),
             None,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(tree.encoding_length(), 103);
         assert_eq!(
             tree.encode(),

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -16,13 +16,17 @@ impl Tree {
         K: AsRef<[u8]>,
         Error: From<S::Error>,
     {
-        let cost = OperationCost {
+        let mut cost = OperationCost {
             seek_count: 1,
             ..Default::default()
         };
-        let tree: Result<Option<Self>, Error> = storage
+        let tree_bytes: Result<_, Error> = storage
             .get(&key)
-            .map_err(|e| e.into())
+            .map_err(|e| e.into());
+        if let Ok(Some(bytes)) = &tree_bytes {
+            cost.loaded_bytes = bytes.len();
+        }
+        let tree = tree_bytes
             .and_then(|raw_opt| raw_opt.map(|x| Tree::decode_raw(&x)).transpose());
 
         let res = match tree {

--- a/merk/src/tree/kv.rs
+++ b/merk/src/tree/kv.rs
@@ -182,7 +182,8 @@ mod test {
 
     #[test]
     fn with_value() {
-        let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6]).unwrap()
+        let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6])
+            .unwrap()
             .with_value(vec![7, 8, 9])
             .unwrap();
 

--- a/merk/src/tree/link.rs
+++ b/merk/src/tree/link.rs
@@ -321,7 +321,7 @@ mod test {
 
     #[test]
     fn from_modified_tree() {
-        let tree = Tree::new(vec![0], vec![1]);
+        let tree = Tree::new(vec![0], vec![1]).unwrap();
         let link = Link::from_modified_tree(tree);
         assert!(link.is_modified());
         assert_eq!(link.height(), 1);
@@ -338,7 +338,7 @@ mod test {
         let link = Link::maybe_from_modified_tree(None);
         assert!(link.is_none());
 
-        let tree = Tree::new(vec![0], vec![1]);
+        let tree = Tree::new(vec![0], vec![1]).unwrap();
         let link = Link::maybe_from_modified_tree(Some(tree));
         assert!(link.expect("expected link").is_modified());
     }
@@ -349,7 +349,7 @@ mod test {
         let child_heights = (0, 0);
         let pending_writes = 1;
         let key = vec![0];
-        let tree = || Tree::new(vec![0], vec![1]);
+        let tree = || Tree::new(vec![0], vec![1]).unwrap();
 
         let reference = Link::Reference {
             hash,
@@ -412,7 +412,7 @@ mod test {
         Link::Modified {
             pending_writes: 1,
             child_heights: (1, 1),
-            tree: Tree::new(vec![0], vec![1]),
+            tree: Tree::new(vec![0], vec![1]).unwrap(),
         }
         .hash();
     }
@@ -423,7 +423,7 @@ mod test {
         Link::Modified {
             pending_writes: 1,
             child_heights: (1, 1),
-            tree: Tree::new(vec![0], vec![1]),
+            tree: Tree::new(vec![0], vec![1]).unwrap(),
         }
         .into_reference();
     }
@@ -434,7 +434,7 @@ mod test {
         Link::Uncommitted {
             hash: [1; 32],
             child_heights: (1, 1),
-            tree: Tree::new(vec![0], vec![1]),
+            tree: Tree::new(vec![0], vec![1]).unwrap(),
         }
         .into_reference();
     }

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -422,26 +422,27 @@ impl Tree {
     /// to `Link::Loaded`).
     #[inline]
     pub fn load<S: Fetch>(&mut self, left: bool, source: &S) -> Result<()> {
-        // TODO: return Err instead of panic?
-        let link = self.link(left).expect("Expected link");
-        let (child_heights, hash) = match link {
-            Link::Reference {
-                child_heights,
-                hash,
-                ..
-            } => (child_heights, hash),
-            _ => panic!("Expected Some(Link::Reference)"),
-        };
+        // // TODO: return Err instead of panic?
+        // let link = self.link(left).expect("Expected link");
+        // let (child_heights, hash) = match link {
+        //     Link::Reference {
+        //         child_heights,
+        //         hash,
+        //         ..
+        //     } => (child_heights, hash),
+        //     _ => panic!("Expected Some(Link::Reference)"),
+        // };
 
-        let tree = source.fetch(link)?;
-        debug_assert_eq!(tree.key(), link.key());
-        *self.slot_mut(left) = Some(Link::Loaded {
-            tree,
-            hash: *hash,
-            child_heights: *child_heights,
-        });
+        // let tree = source.fetch(link)?;
+        // debug_assert_eq!(tree.key(), link.key());
+        // *self.slot_mut(left) = Some(Link::Loaded {
+        //     tree,
+        //     hash: *hash,
+        //     child_heights: *child_heights,
+        // });
 
-        Ok(())
+        // Ok(())
+        todo!()
     }
 }
 

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -490,7 +490,9 @@ mod test {
         assert_eq!(tree.child(true).unwrap().key(), &[2]);
         assert!(tree.child(false).is_none());
 
-        let tree = Tree::new(vec![3], vec![103]).unwrap().attach(false, Some(tree));
+        let tree = Tree::new(vec![3], vec![103])
+            .unwrap()
+            .attach(false, Some(tree));
         assert_eq!(tree.key(), &[3]);
         assert_eq!(tree.child(false).unwrap().key(), &[1]);
         assert!(tree.child(true).is_none());

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -15,6 +15,7 @@ use std::cmp::max;
 use anyhow::Result;
 pub use commit::{Commit, NoopCommit};
 use ed::{Decode, Encode, Terminated};
+use fees::FeesContext;
 pub use hash::{kv_digest_to_kv_hash, kv_hash, node_hash, Hash, HASH_LENGTH, NULL_HASH};
 use kv::KV;
 pub use link::Link;
@@ -420,29 +421,27 @@ impl Tree {
     /// Fetches the child on the given side using the given data source, and
     /// places it in the child slot (upgrading the link from `Link::Reference`
     /// to `Link::Loaded`).
-    #[inline]
-    pub fn load<S: Fetch>(&mut self, left: bool, source: &S) -> Result<()> {
-        // // TODO: return Err instead of panic?
-        // let link = self.link(left).expect("Expected link");
-        // let (child_heights, hash) = match link {
-        //     Link::Reference {
-        //         child_heights,
-        //         hash,
-        //         ..
-        //     } => (child_heights, hash),
-        //     _ => panic!("Expected Some(Link::Reference)"),
-        // };
+    pub fn load<S: Fetch>(&mut self, left: bool, source: &S) -> FeesContext<Result<()>> {
+        // TODO: return Err instead of panic?
+        let link = self.link(left).expect("Expected link");
+        let (child_heights, hash) = match link {
+            Link::Reference {
+                child_heights,
+                hash,
+                ..
+            } => (child_heights, hash),
+            _ => panic!("Expected Some(Link::Reference)"),
+        };
 
-        // let tree = source.fetch(link)?;
-        // debug_assert_eq!(tree.key(), link.key());
-        // *self.slot_mut(left) = Some(Link::Loaded {
-        //     tree,
-        //     hash: *hash,
-        //     child_heights: *child_heights,
-        // });
-
-        // Ok(())
-        todo!()
+        source.fetch(link).map_ok(|tree| {
+            debug_assert_eq!(tree.key(), link.key());
+            *self.slot_mut(left) = Some(Link::Loaded {
+                tree,
+                hash: *hash,
+                child_heights: *child_heights,
+            });
+            Ok(())
+        }).flatten()
     }
 }
 

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -1,7 +1,7 @@
 use std::{collections::LinkedList, fmt};
 
 use anyhow::Result;
-use fees::FeesContext;
+use costs::CostContext;
 use Op::*;
 
 use super::{Fetch, Link, Tree, Walker};
@@ -41,7 +41,7 @@ pub type MerkBatch<K> = [BatchEntry<K>];
 #[derive(Clone)]
 pub struct PanicSource {}
 impl Fetch for PanicSource {
-    fn fetch(&self, _link: &Link) -> FeesContext<Result<Tree>> {
+    fn fetch(&self, _link: &Link) -> CostContext<Result<Tree>> {
         unreachable!("'fetch' should not have been called")
     }
 }

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -113,12 +113,15 @@ where
         // TODO: take from batch so we don't have to clone
 
         let mid_tree = match mid_op {
-            Put(_) => Tree::new(mid_key.as_ref().to_vec(), mid_value.to_vec()).unwrap_add_cost(&mut cost),
+            Put(_) => {
+                Tree::new(mid_key.as_ref().to_vec(), mid_value.to_vec()).unwrap_add_cost(&mut cost)
+            }
             PutReference(_, referenced_value) => Tree::new_with_value_hash(
                 mid_key.as_ref().to_vec(),
                 mid_value.to_vec(),
                 value_hash(referenced_value).unwrap_add_cost(&mut cost),
-            ).unwrap_add_cost(&mut cost),
+            )
+            .unwrap_add_cost(&mut cost),
             Delete => unreachable!("cannot get here, should return at the top"),
         };
         let mid_walker = Walker::new(mid_tree, PanicSource {});
@@ -150,10 +153,12 @@ where
             match &batch[index].1 {
                 // TODO: take vec from batch so we don't need to clone
                 Put(value) => self.with_value(value.to_vec()).unwrap_add_cost(&mut cost),
-                PutReference(value, referenced_value) => self.with_value_and_value_hash(
-                    value.to_vec(),
-                    value_hash(&referenced_value).unwrap_add_cost(&mut cost),
-                ).unwrap_add_cost(&mut cost),
+                PutReference(value, referenced_value) => self
+                    .with_value_and_value_hash(
+                        value.to_vec(),
+                        value_hash(&referenced_value).unwrap_add_cost(&mut cost),
+                    )
+                    .unwrap_add_cost(&mut cost),
                 Delete => {
                     // TODO: we shouldn't have to do this as 2 different calls to apply
                     let source = self.clone_source();

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -1,6 +1,7 @@
 use std::{collections::LinkedList, fmt};
 
 use anyhow::Result;
+use fees::FeesContext;
 use Op::*;
 
 use super::{Fetch, Link, Tree, Walker};
@@ -40,7 +41,7 @@ pub type MerkBatch<K> = [BatchEntry<K>];
 #[derive(Clone)]
 pub struct PanicSource {}
 impl Fetch for PanicSource {
-    fn fetch(&self, _link: &Link) -> Result<Tree> {
+    fn fetch(&self, _link: &Link) -> FeesContext<Result<Tree>> {
         unreachable!("'fetch' should not have been called")
     }
 }

--- a/merk/src/tree/walk/fetch.rs
+++ b/merk/src/tree/walk/fetch.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use fees::FeesContext;
+use costs::CostContext;
 
 use super::super::{Link, Tree};
 
@@ -9,5 +9,5 @@ use super::super::{Link, Tree};
 pub trait Fetch {
     /// Called when the tree needs to fetch a node with the given `Link`. The
     /// `link` value will always be a `Link::Reference` variant.
-    fn fetch(&self, link: &Link) -> FeesContext<Result<Tree>>;
+    fn fetch(&self, link: &Link) -> CostContext<Result<Tree>>;
 }

--- a/merk/src/tree/walk/fetch.rs
+++ b/merk/src/tree/walk/fetch.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use fees::FeesContext;
 
 use super::super::{Link, Tree};
 
@@ -8,5 +9,5 @@ use super::super::{Link, Tree};
 pub trait Fetch {
     /// Called when the tree needs to fetch a node with the given `Link`. The
     /// `link` value will always be a `Link::Reference` variant.
-    fn fetch(&self, link: &Link) -> Result<Tree>;
+    fn fetch(&self, link: &Link) -> FeesContext<Result<Tree>>;
 }

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -156,7 +156,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use fees::{FeesContext, FeesExt};
+    use costs::{CostContext, CostsExt};
 
     use super::{super::NoopCommit, *};
     use crate::tree::Tree;
@@ -165,7 +165,7 @@ mod test {
     struct MockSource {}
 
     impl Fetch for MockSource {
-        fn fetch(&self, link: &Link) -> FeesContext<Result<Tree>> {
+        fn fetch(&self, link: &Link) -> CostContext<Result<Tree>> {
             Ok(Tree::new(link.key().to_vec(), b"foo".to_vec())).wrap_with_cost(Default::default())
         }
     }

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -147,15 +147,22 @@ where
     /// Similar to `Tree#with_value`.
     pub fn with_value(mut self, value: Vec<u8>) -> CostContext<Self> {
         let mut cost = OperationCost::default();
-        self.tree.own(|t| t.with_value(value).unwrap_add_cost(&mut cost));
+        self.tree
+            .own(|t| t.with_value(value).unwrap_add_cost(&mut cost));
         self.wrap_with_cost(cost)
     }
 
     /// Similar to `Tree#with_value_and_value_hash`.
-    pub fn with_value_and_value_hash(mut self, value: Vec<u8>, value_hash: Hash) -> CostContext<Self> {
+    pub fn with_value_and_value_hash(
+        mut self,
+        value: Vec<u8>,
+        value_hash: Hash,
+    ) -> CostContext<Self> {
         let mut cost = OperationCost::default();
-        self.tree
-            .own(|t| t.with_value_and_value_hash(value, value_hash).unwrap_add_cost(&mut cost));
+        self.tree.own(|t| {
+            t.with_value_and_value_hash(value, value_hash)
+                .unwrap_add_cost(&mut cost)
+        });
         self.wrap_with_cost(cost)
     }
 }
@@ -187,8 +194,12 @@ mod test {
 
     #[test]
     fn walk_modified() {
-        let tree = Tree::new(b"test".to_vec(), b"abc".to_vec()).unwrap()
-            .attach(true, Some(Tree::new(b"foo".to_vec(), b"bar".to_vec()).unwrap()));
+        let tree = Tree::new(b"test".to_vec(), b"abc".to_vec())
+            .unwrap()
+            .attach(
+                true,
+                Some(Tree::new(b"foo".to_vec(), b"bar".to_vec()).unwrap()),
+            );
 
         let source = MockSource {};
         let walker = Walker::new(tree, source);
@@ -207,7 +218,10 @@ mod test {
     fn walk_stored() {
         let mut tree = Tree::new(b"test".to_vec(), b"abc".to_vec())
             .unwrap()
-            .attach(true, Some(Tree::new(b"foo".to_vec(), b"bar".to_vec()).unwrap()));
+            .attach(
+                true,
+                Some(Tree::new(b"foo".to_vec(), b"bar".to_vec()).unwrap()),
+            );
         tree.commit(&mut NoopCommit {})
             .unwrap()
             .expect("commit failed");

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -205,7 +205,9 @@ mod test {
     fn walk_stored() {
         let mut tree = Tree::new(b"test".to_vec(), b"abc".to_vec())
             .attach(true, Some(Tree::new(b"foo".to_vec(), b"bar".to_vec())));
-        tree.commit(&mut NoopCommit {}).expect("commit failed");
+        tree.commit(&mut NoopCommit {})
+            .unwrap()
+            .expect("commit failed");
 
         let source = MockSource {};
         let walker = Walker::new(tree, source);

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -34,27 +34,28 @@ where
     /// same source as `self`. Returned tuple is `(updated_self,
     /// maybe_child_walker)`.
     pub fn detach(mut self, left: bool) -> Result<(Self, Option<Self>)> {
-        let link = match self.tree.link(left) {
-            None => return Ok((self, None)),
-            Some(link) => link,
-        };
+        // let link = match self.tree.link(left) {
+        //     None => return Ok((self, None)),
+        //     Some(link) => link,
+        // };
 
-        let child = if link.tree().is_some() {
-            match self.tree.own_return(|t| t.detach(left)) {
-                Some(child) => child,
-                _ => unreachable!("Expected Some"),
-            }
-        } else {
-            let link = self.tree.slot_mut(left).take();
-            match link {
-                Some(Link::Reference { .. }) => (),
-                _ => unreachable!("Expected Some(Link::Reference)"),
-            }
-            self.source.fetch(&link.unwrap())?
-        };
+        // let child = if link.tree().is_some() {
+        //     match self.tree.own_return(|t| t.detach(left)) {
+        //         Some(child) => child,
+        //         _ => unreachable!("Expected Some"),
+        //     }
+        // } else {
+        //     let link = self.tree.slot_mut(left).take();
+        //     match link {
+        //         Some(Link::Reference { .. }) => (),
+        //         _ => unreachable!("Expected Some(Link::Reference)"),
+        //     }
+        //     self.source.fetch(&link.unwrap())?
+        // };
 
-        let child = self.wrap(child);
-        Ok((self, Some(child)))
+        // let child = self.wrap(child);
+        // Ok((self, Some(child)))
+        todo!()
     }
 
     /// Similar to `Tree#detach_expect`, but yields a `Walker` which fetches
@@ -155,6 +156,8 @@ where
 
 #[cfg(test)]
 mod test {
+    use fees::{FeesContext, FeesExt};
+
     use super::{super::NoopCommit, *};
     use crate::tree::Tree;
 
@@ -162,8 +165,8 @@ mod test {
     struct MockSource {}
 
     impl Fetch for MockSource {
-        fn fetch(&self, link: &Link) -> Result<Tree> {
-            Ok(Tree::new(link.key().to_vec(), b"foo".to_vec()))
+        fn fetch(&self, link: &Link) -> FeesContext<Result<Tree>> {
+            Ok(Tree::new(link.key().to_vec(), b"foo".to_vec())).wrap_with_cost(Default::default())
         }
     }
 

--- a/merk/src/tree/walk/ref_walker.rs
+++ b/merk/src/tree/walk/ref_walker.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use fees::{FeesContext, FeesExt, OperationCost};
 
 use super::{
     super::{Link, Tree},
@@ -37,21 +38,28 @@ where
     /// Traverses to the child on the given side (if any), fetching from the
     /// source if pruned. When fetching, the link is upgraded from
     /// `Link::Reference` to `Link::Loaded`.
-    pub fn walk(&mut self, left: bool) -> Result<Option<RefWalker<S>>> {
+    pub fn walk(&mut self, left: bool) -> FeesContext<Result<Option<RefWalker<S>>>> {
         let link = match self.tree.link(left) {
-            None => return Ok(None),
+            None => return Ok(None).wrap_with_cost(Default::default()),
             Some(link) => link,
         };
 
+        let mut cost = OperationCost::default();
         match link {
             Link::Reference { .. } => {
-                self.tree.load(left, &self.source)?;
+                let load_res = self
+                    .tree
+                    .load(left, &self.source)
+                    .unwrap_add_cost(&mut cost);
+                if let Err(e) = load_res {
+                    return Err(e).wrap_with_cost(cost);
+                }
             }
             Link::Modified { .. } => panic!("Cannot traverse Link::Modified"),
             Link::Uncommitted { .. } | Link::Loaded { .. } => {}
         }
 
         let child = self.tree.child_mut(left).unwrap();
-        Ok(Some(RefWalker::new(child, self.source.clone())))
+        Ok(Some(RefWalker::new(child, self.source.clone()))).wrap_with_cost(cost)
     }
 }

--- a/merk/src/tree/walk/ref_walker.rs
+++ b/merk/src/tree/walk/ref_walker.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use fees::{FeesContext, FeesExt, OperationCost};
+use costs::{CostContext, CostsExt, OperationCost};
 
 use super::{
     super::{Link, Tree},
@@ -38,7 +38,7 @@ where
     /// Traverses to the child on the given side (if any), fetching from the
     /// source if pruned. When fetching, the link is upgraded from
     /// `Link::Reference` to `Link::Loaded`.
-    pub fn walk(&mut self, left: bool) -> FeesContext<Result<Option<RefWalker<S>>>> {
+    pub fn walk(&mut self, left: bool) -> CostContext<Result<Option<RefWalker<S>>>> {
         let link = match self.tree.link(left) {
             None => return Ok(None).wrap_with_cost(Default::default()),
             Some(link) => link,


### PR DESCRIPTION
This PR adds `CostContext` wrapper to carry operations' costs information through code execution.

This acts similar to `Option` or `Result` as a pattern which allows to chain functions that require unwrapped argument to return wrapped result.

This wrapper comes with some useful methods to wrap some value into a context, `.map` it onto some other type/value with no cost change or `.flat_map` it to accumulate costs of chain of operations. Usually these operations are in context of `Result` too, thus some helpers were added for this type sandwich to combine multiple results wrapped in costs with each other.

In complex functions where these operations chains become cumbersome, accumulated cost is stored as separate variable and using helper functions and macros similar effect as `?`'s early termination could be achieved.