### PR TITLE
fix: handle path pointing to empty tree case

### DIFF
--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -452,9 +452,9 @@ impl GroveDb {
 
         let mut validated_operations = if validate {
             cost_return_on_error!(
-            &mut cost,
-            self.validate_batch(sorted_operations, &temp_root_leaves, transaction)
-        )
+                &mut cost,
+                self.validate_batch(sorted_operations, &temp_root_leaves, transaction)
+            )
         } else {
             sorted_operations
         };
@@ -606,8 +606,9 @@ mod tests {
         let db = make_grovedb();
         let tx = db.start_transaction();
 
-        db.insert(vec![], b"keyb", Element::empty_tree(), Some(&tx)).
-            unwrap().expect("successful root tree leaf insert");
+        db.insert(vec![], b"keyb", Element::empty_tree(), Some(&tx))
+            .unwrap()
+            .expect("successful root tree leaf insert");
 
         let element = Element::new_item(b"ayy".to_vec());
         let element2 = Element::new_item(b"ayy2".to_vec());
@@ -639,30 +640,41 @@ mod tests {
                 element2.clone(),
             ),
         ];
-        db.apply_batch(ops, true, Some(&tx)).
-        unwrap().expect("cannot apply batch");
-        db.get([], b"keyb", None).unwrap()
+        db.apply_batch(ops, true, Some(&tx))
+            .unwrap()
+            .expect("cannot apply batch");
+        db.get([], b"keyb", None)
+            .unwrap()
             .expect_err("we should not get an element");
-        db.get([], b"keyb", Some(&tx)).unwrap()
+        db.get([], b"keyb", Some(&tx))
+            .unwrap()
             .expect("we should get an element");
 
-        db.get([], b"key1", None).unwrap()
+        db.get([], b"key1", None)
+            .unwrap()
             .expect_err("we should not get an element");
-        db.get([], b"key1", Some(&tx)).unwrap().expect("cannot get element");
-        db.get([b"key1".as_ref()], b"key2", Some(&tx)).unwrap()
+        db.get([], b"key1", Some(&tx))
+            .unwrap()
             .expect("cannot get element");
-        db.get([b"key1".as_ref(), b"key2"], b"key3", Some(&tx)).unwrap()
+        db.get([b"key1".as_ref()], b"key2", Some(&tx))
+            .unwrap()
             .expect("cannot get element");
-        db.get([b"key1".as_ref(), b"key2", b"key3"], b"key4", Some(&tx)).unwrap()
+        db.get([b"key1".as_ref(), b"key2"], b"key3", Some(&tx))
+            .unwrap()
+            .expect("cannot get element");
+        db.get([b"key1".as_ref(), b"key2", b"key3"], b"key4", Some(&tx))
+            .unwrap()
             .expect("cannot get element");
 
         assert_eq!(
-            db.get([b"key1".as_ref(), b"key2", b"key3"], b"key4", Some(&tx)).unwrap()
+            db.get([b"key1".as_ref(), b"key2", b"key3"], b"key4", Some(&tx))
+                .unwrap()
                 .expect("cannot get element"),
             element
         );
         assert_eq!(
-            db.get([TEST_LEAF, b"key1"], b"key2", Some(&tx)).unwrap()
+            db.get([TEST_LEAF, b"key1"], b"key2", Some(&tx))
+                .unwrap()
                 .expect("cannot get element"),
             element2
         );

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -141,7 +141,6 @@ impl GroveDb {
                     let new_path_owned = new_path.iter().map(|x| x.to_vec()).collect();
                     let new_path_query = PathQuery::new_unsized(new_path_owned, query.unwrap());
 
-                    // TODO: check if empty tree issue is here also
                     if self
                         .check_subtree_exists_path_not_found(new_path.clone(), None)
                         .unwrap_add_cost(&mut cost)
@@ -175,9 +174,6 @@ impl GroveDb {
             }
         }
 
-        // TODO: Explore the chance that a subquery key might lead to non tree element
-        // might be a leaf tree, but might able be an empty tree
-        // what to do in the case of an empty tree
         if is_leaf_tree {
             // if no useful subtree, then we care about the result set of this subtree.
             // apply the sized query

--- a/grovedb/src/operations/proof/util.rs
+++ b/grovedb/src/operations/proof/util.rs
@@ -9,6 +9,7 @@ pub enum ProofType {
     MerkProof,
     SizedMerkProof,
     RootProof,
+    EmptyTreeProof,
     InvalidProof,
 }
 
@@ -18,6 +19,7 @@ impl From<ProofType> for u8 {
             ProofType::MerkProof => 0x01,
             ProofType::SizedMerkProof => 0x02,
             ProofType::RootProof => 0x03,
+            ProofType::EmptyTreeProof => 0x04,
             ProofType::InvalidProof => 0x10,
         }
     }
@@ -29,6 +31,7 @@ impl From<u8> for ProofType {
             0x01 => ProofType::MerkProof,
             0x02 => ProofType::SizedMerkProof,
             0x03 => ProofType::RootProof,
+            0x04 => ProofType::EmptyTreeProof,
             _ => ProofType::InvalidProof,
         }
     }
@@ -79,6 +82,10 @@ impl<'a> ProofReader<'a> {
         }
 
         let proof_type: ProofType = data_type[0].into();
+
+        if proof_type == ProofType::EmptyTreeProof {
+            return Ok((proof_type, vec![]));
+        }
 
         let mut proof_length = [0; 8 as usize];
         self.proof_data

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -181,6 +181,9 @@ impl ProofVerifier {
                     }
                 }
             }
+            ProofType::EmptyTreeProof => {
+                last_root_hash = EMPTY_TREE_HASH;
+            }
             _ => {
                 // execute_subquery_proof only expects proofs for merk trees
                 // root proof is handled separately

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -758,6 +758,24 @@ fn test_root_tree_leaves_are_noted() {
 }
 
 #[test]
+fn test_proof_for_non_existent_data() {
+    let temp_db = make_grovedb();
+
+    let mut query = Query::new();
+    query.insert_key(b"key1".to_vec());
+
+    // path to empty subtree
+    let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
+
+    let proof = temp_db.prove(&path_query).unwrap().unwrap();
+    let (hash, result_set) =
+        GroveDb::execute_proof(proof.as_slice(), &path_query).expect("should execute proof");
+
+    assert_eq!(hash, temp_db.root_hash(None).unwrap().unwrap().unwrap());
+    assert_eq!(result_set.len(), 0);
+}
+
+#[test]
 fn test_path_query_proofs_without_subquery_with_reference() {
     // Tree Structure
     // root
@@ -3770,7 +3788,8 @@ fn test_tree_value_exists_method_no_tx() {
 
     // Test keys for a root tree
     db.insert([], b"leaf", Element::empty_tree(), None)
-        .unwrap().expect("cannot insert item");
+        .unwrap()
+        .expect("cannot insert item");
 
     assert!(db.has_raw([], b"leaf", None).unwrap().unwrap());
     assert!(db.has_raw([], TEST_LEAF, None).unwrap().unwrap());

--- a/node-grove/src/lib.rs
+++ b/node-grove/src/lib.rs
@@ -311,11 +311,13 @@ impl GroveDbWrapper {
 
         db.send_to_db_thread(move |grove_db: &GroveDb, transaction, channel| {
             let path_slice = path.iter().map(|fragment| fragment.as_slice());
-            let result = grove_db.get(
-                path_slice,
-                &key,
-                using_transaction.then(|| transaction).flatten(),
-            ).unwrap(); // Todo: Costs
+            let result = grove_db
+                .get(
+                    path_slice,
+                    &key,
+                    using_transaction.then(|| transaction).flatten(),
+                )
+                .unwrap(); // Todo: Costs
 
             channel.send(move |mut task_context| {
                 let callback = js_callback.into_inner(&mut task_context);
@@ -358,11 +360,13 @@ impl GroveDbWrapper {
 
         db.send_to_db_thread(move |grove_db: &GroveDb, transaction, channel| {
             let path_slice = path.iter().map(|fragment| fragment.as_slice());
-            let result = grove_db.delete(
-                path_slice,
-                &key,
-                using_transaction.then(|| transaction).flatten(),
-            ).unwrap(); // Todo: Costs;
+            let result = grove_db
+                .delete(
+                    path_slice,
+                    &key,
+                    using_transaction.then(|| transaction).flatten(),
+                )
+                .unwrap(); // Todo: Costs;
 
             channel.send(move |mut task_context| {
                 let callback = js_callback.into_inner(&mut task_context);
@@ -404,12 +408,14 @@ impl GroveDbWrapper {
 
         db.send_to_db_thread(move |grove_db: &GroveDb, transaction, channel| {
             let path_slice = path.iter().map(|fragment| fragment.as_slice());
-            let result = grove_db.insert(
-                path_slice,
-                &key,
-                element,
-                using_transaction.then(|| transaction).flatten(),
-            ).unwrap(); // Todo: Costs;
+            let result = grove_db
+                .insert(
+                    path_slice,
+                    &key,
+                    element,
+                    using_transaction.then(|| transaction).flatten(),
+                )
+                .unwrap(); // Todo: Costs;
 
             channel.send(move |mut task_context| {
                 let callback = js_callback.into_inner(&mut task_context);
@@ -445,12 +451,14 @@ impl GroveDbWrapper {
 
         db.send_to_db_thread(move |grove_db: &GroveDb, transaction, channel| {
             let path_slice = path.iter().map(|fragment| fragment.as_slice());
-            let result = grove_db.insert_if_not_exists(
-                path_slice,
-                &key,
-                element,
-                using_transaction.then(|| transaction).flatten(),
-            ).unwrap(); // Todo: Costs;
+            let result = grove_db
+                .insert_if_not_exists(
+                    path_slice,
+                    &key,
+                    element,
+                    using_transaction.then(|| transaction).flatten(),
+                )
+                .unwrap(); // Todo: Costs;
 
             channel.send(move |mut task_context| {
                 let callback = js_callback.into_inner(&mut task_context);
@@ -487,11 +495,13 @@ impl GroveDbWrapper {
         let using_transaction = js_using_transaction.value(&mut cx);
 
         db.send_to_db_thread(move |grove_db: &GroveDb, transaction, channel| {
-            let result = grove_db.put_aux(
-                &key,
-                &value,
-                using_transaction.then(|| transaction).flatten(),
-            ).unwrap(); // Todo: Costs;
+            let result = grove_db
+                .put_aux(
+                    &key,
+                    &value,
+                    using_transaction.then(|| transaction).flatten(),
+                )
+                .unwrap(); // Todo: Costs;
 
             channel.send(move |mut task_context| {
                 let callback = js_callback.into_inner(&mut task_context);
@@ -527,8 +537,9 @@ impl GroveDbWrapper {
         let using_transaction = js_using_transaction.value(&mut cx);
 
         db.send_to_db_thread(move |grove_db: &GroveDb, transaction, channel| {
-            let result =
-                grove_db.delete_aux(&key, using_transaction.then(|| transaction).flatten()).unwrap(); // Todo: Costs;
+            let result = grove_db
+                .delete_aux(&key, using_transaction.then(|| transaction).flatten())
+                .unwrap(); // Todo: Costs;
 
             channel.send(move |mut task_context| {
                 let callback = js_callback.into_inner(&mut task_context);
@@ -564,7 +575,9 @@ impl GroveDbWrapper {
         let using_transaction = js_using_transaction.value(&mut cx);
 
         db.send_to_db_thread(move |grove_db: &GroveDb, transaction, channel| {
-            let result = grove_db.get_aux(&key, using_transaction.then(|| transaction).flatten()).unwrap(); // Todo: Costs;
+            let result = grove_db
+                .get_aux(&key, using_transaction.then(|| transaction).flatten())
+                .unwrap(); // Todo: Costs;
 
             channel.send(move |mut task_context| {
                 let callback = js_callback.into_inner(&mut task_context);
@@ -607,10 +620,12 @@ impl GroveDbWrapper {
         let using_transaction = js_using_transaction.value(&mut cx);
 
         db.send_to_db_thread(move |grove_db: &GroveDb, transaction, channel| {
-            let result = grove_db.get_path_query(
-                &path_query,
-                using_transaction.then(|| transaction).flatten(),
-            ).unwrap(); // Todo: Costs;
+            let result = grove_db
+                .get_path_query(
+                    &path_query,
+                    using_transaction.then(|| transaction).flatten(),
+                )
+                .unwrap(); // Todo: Costs;
 
             channel.send(move |mut task_context| {
                 let callback = js_callback.into_inner(&mut task_context);
@@ -702,7 +717,9 @@ impl GroveDbWrapper {
         let using_transaction = js_using_transaction.value(&mut cx);
 
         db.send_to_db_thread(move |grove_db: &GroveDb, transaction, channel| {
-            let result = grove_db.root_hash(using_transaction.then(|| transaction).flatten()).unwrap(); // Todo: Costs;
+            let result = grove_db
+                .root_hash(using_transaction.then(|| transaction).flatten())
+                .unwrap(); // Todo: Costs;
 
             channel.send(move |mut task_context| {
                 let callback = js_callback.into_inner(&mut task_context);


### PR DESCRIPTION
It is possible that a path query points to a subtree that exists but is empty.
Before this pr, proof generation panics at that point as it can't apply the given query to the empty subtree.

This pr adds a marker to the generated proof to signify this case.
- Verification returns an empty root hash [0; 32] when this marker is hit (allowing for further verification). 