### PR TITLE
Batch worst case fees typelevel fixes

### DIFF
--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -16,7 +16,7 @@ use merk::{
 };
 use serde::{Deserialize, Serialize};
 use storage::{rocksdb_storage::RocksDbStorage, RawIterator, StorageContext};
-use visualize::{visualize_to_vec, DebugBytes};
+use visualize::visualize_to_vec;
 
 use crate::{
     util::{merk_optional_tx, storage_context_optional_tx},

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -156,15 +156,6 @@ where
         merk.load_root().map_ok(|_| merk)
     }
 
-    pub fn open_optional(storage: S) -> CostContext<Result<Option<Self>>> {
-        let mut merk = Self {
-            tree: Cell::new(None),
-            storage,
-        };
-
-        merk.load_root().map_ok(|_| Some(merk))
-    }
-
     /// Deletes tree data
     pub fn clear(&mut self) -> CostContext<Result<()>> {
         let mut cost = OperationCost::default();


### PR DESCRIPTION
This PR makes `BatchStructure` generic over trees cache rather than storage, thus `get_merk_fn` is hidden in cache implementation and occurs only in places where it needs to be and this ends up in better separation of two cache implementations (and according code paths)

TODO: switch on develop after feat/worstCaseFees got merged