### PR TITLE
feat: merk batches

### DIFF
--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -1254,13 +1254,18 @@ mod tests {
         grove_db_ops
     }
 
+    // This test no longer works as of version 5, there might be support for it in
+    // the future
+    #[ignore]
     #[test]
     fn test_batch_produces_same_result() {
         let db = make_grovedb();
         let tx = db.start_transaction();
 
         let ops = grove_db_ops_for_contract_insert();
-        db.apply_batch(ops, None, Some(&tx));
+        db.apply_batch(ops, None, Some(&tx))
+            .unwrap()
+            .expect("expected to apply batch");
 
         db.root_hash(None).unwrap().expect("cannot get root hash");
 
@@ -1268,7 +1273,9 @@ mod tests {
         let tx = db.start_transaction();
 
         let ops = grove_db_ops_for_contract_insert();
-        db.apply_batch(ops.clone(), None, Some(&tx));
+        db.apply_batch(ops.clone(), None, Some(&tx))
+            .unwrap()
+            .expect("expected to apply batch");
 
         let batch_hash = db
             .root_hash(Some(&tx))
@@ -1277,7 +1284,9 @@ mod tests {
 
         db.rollback_transaction(&tx).expect("expected to rollback");
 
-        db.apply_operations_without_batching(ops, Some(&tx));
+        db.apply_operations_without_batching(ops, Some(&tx))
+            .unwrap()
+            .expect("expected to apply batch");
 
         let no_batch_hash = db
             .root_hash(Some(&tx))
@@ -1287,6 +1296,7 @@ mod tests {
         assert_eq!(batch_hash, no_batch_hash);
     }
 
+    #[ignore]
     #[test]
     fn test_batch_contract_with_document_produces_same_result() {
         let db = make_grovedb();

--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -412,6 +412,8 @@ where
             .unwrap_or_else(|| (self.get_merk_fn)(path));
         let mut merk = cost_return_on_error!(&mut cost, merk_wrapped);
 
+        let ops_at_path_by_key: BTreeMap<Vec<u8>, Op> = ops_at_path_by_key.into_iter().map(| (key, value)| (key, value)).collect();
+
         let mut batch_operations: Vec<(Vec<u8>, _)> = vec![];
         for (key, op) in ops_at_path_by_key.into_iter() {
             match op {

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -13,7 +13,7 @@ use integer_encoding::VarInt;
 use merk::{
     proofs::{query::QueryItem, Query},
     tree::Tree,
-    Op, HASH_LENGTH,
+    BatchEntry, MerkBatch, Op, HASH_LENGTH,
 };
 use serde::{Deserialize, Serialize};
 use storage::{rocksdb_storage::RocksDbStorage, RawIterator, StorageContext};
@@ -221,6 +221,16 @@ impl Element {
         let batch = [(key, Op::Delete)];
         merk.apply::<_, Vec<u8>>(&batch, &[])
             .map_err(|e| Error::CorruptedData(e.to_string()))
+    }
+
+    /// Delete an element from Merk under a key to batch operations
+    pub fn delete_into_batch_operations<K: AsRef<[u8]>>(
+        key: K,
+        batch_operations: &mut Vec<BatchEntry<K>>,
+    ) -> CostResult<(), Error> {
+        let entry = (key, Op::Delete);
+        batch_operations.push(entry);
+        Ok(()).wrap_with_cost(Default::default())
     }
 
     /// Get an element from Merk under a key; path should be resolved and proper
@@ -677,6 +687,21 @@ impl Element {
             .map_err(|e| Error::CorruptedData(e.to_string()))
     }
 
+    pub fn insert_into_batch_operations<K: AsRef<[u8]>>(
+        &self,
+        key: K,
+        batch_operations: &mut Vec<BatchEntry<K>>,
+    ) -> CostResult<(), Error> {
+        let serialized = match self.serialize() {
+            Ok(s) => s,
+            Err(e) => return Err(e).wrap_with_cost(Default::default()),
+        };
+
+        let entry = (key, Op::Put(serialized));
+        batch_operations.push(entry);
+        Ok(()).wrap_with_cost(Default::default())
+    }
+
     /// Insert an element in Merk under a key if it doesn't yet exist; path
     /// should be resolved and proper Merk should be loaded by this moment
     /// If transaction is not passed, the batch will be written immediately.
@@ -717,6 +742,21 @@ impl Element {
         let batch_operations = [(key, Op::PutReference(serialized, referenced_value))];
         merk.apply::<_, Vec<u8>>(&batch_operations, &[])
             .map_err(|e| Error::CorruptedData(e.to_string()))
+    }
+
+    pub fn insert_reference_into_batch_operations<K: AsRef<[u8]>>(
+        &self,
+        key: K,
+        referenced_value: Vec<u8>,
+        batch_operations: &mut Vec<BatchEntry<K>>,
+    ) -> CostResult<(), Error> {
+        let serialized = match self.serialize() {
+            Ok(s) => s,
+            Err(e) => return Err(e).wrap_with_cost(Default::default()),
+        };
+        let entry = (key, Op::PutReference(serialized, referenced_value));
+        batch_operations.push(entry);
+        Ok(()).wrap_with_cost(Default::default())
     }
 
     pub fn serialize(&self) -> Result<Vec<u8>, Error> {

--- a/merk/src/tree/kv.rs
+++ b/merk/src/tree/kv.rs
@@ -67,7 +67,7 @@ impl KV {
     /// Replaces the `KV`'s value with the given value, updates the hash,
     /// value hash and returns the modified `KV`.
     #[inline]
-    pub fn with_value(mut self, value: Vec<u8>) -> CostContext<Self> {
+    pub fn put_value_then_update(mut self, value: Vec<u8>) -> CostContext<Self> {
         let mut cost = OperationCost::default();
         // TODO: length check?
         self.value = value;
@@ -79,7 +79,7 @@ impl KV {
     /// Replaces the `KV`'s value with the given value and value hash,
     /// updates the hash and returns the modified `KV`.
     #[inline]
-    pub fn with_value_and_value_hash(
+    pub fn put_value_and_value_hash_then_update(
         mut self,
         value: Vec<u8>,
         value_hash: Hash,
@@ -184,7 +184,7 @@ mod test {
     fn with_value() {
         let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6])
             .unwrap()
-            .with_value(vec![7, 8, 9])
+            .put_value_then_update(vec![7, 8, 9])
             .unwrap();
 
         assert_eq!(kv.key(), &[1, 2, 3]);

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -347,16 +347,16 @@ impl Tree {
     /// Replaces the root node's value with the given value and returns the
     /// modified `Tree`.
     #[inline]
-    pub fn with_value(mut self, value: Vec<u8>) -> CostContext<Self> {
+    pub fn put_value(mut self, value: Vec<u8>) -> CostContext<Self> {
         let mut cost = OperationCost::default();
-        self.inner.kv = self.inner.kv.with_value(value).unwrap_add_cost(&mut cost);
+        self.inner.kv = self.inner.kv.put_value_then_update(value).unwrap_add_cost(&mut cost);
         self.wrap_with_cost(cost)
     }
 
     /// Replaces the root node's value with the given value and value hash
     /// and returns the modified `Tree`.
     #[inline]
-    pub fn with_value_and_value_hash(
+    pub fn put_value_and_value_hash(
         mut self,
         value: Vec<u8>,
         value_hash: Hash,
@@ -365,7 +365,7 @@ impl Tree {
         self.inner.kv = self
             .inner
             .kv
-            .with_value_and_value_hash(value, value_hash)
+            .put_value_and_value_hash_then_update(value, value_hash)
             .unwrap_add_cost(&mut cost);
         self.wrap_with_cost(cost)
     }

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -349,7 +349,11 @@ impl Tree {
     #[inline]
     pub fn put_value(mut self, value: Vec<u8>) -> CostContext<Self> {
         let mut cost = OperationCost::default();
-        self.inner.kv = self.inner.kv.put_value_then_update(value).unwrap_add_cost(&mut cost);
+        self.inner.kv = self
+            .inner
+            .kv
+            .put_value_then_update(value)
+            .unwrap_add_cost(&mut cost);
         self.wrap_with_cost(cost)
     }
 

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -101,7 +101,9 @@ where
                     cost_return_on_error!(&mut cost, Self::build(left_batch, source.clone()))
                         .map(|tree| Self::new(tree, source.clone()));
                 let maybe_tree = match maybe_tree {
-                    Some(tree) => cost_return_on_error!(&mut cost, tree.apply_sorted(right_batch)).0,
+                    Some(tree) => {
+                        cost_return_on_error!(&mut cost, tree.apply_sorted(right_batch)).0
+                    }
                     None => {
                         cost_return_on_error!(&mut cost, Self::build(right_batch, source.clone()))
                             .map(|tree| Self::new(tree, source.clone()))

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -145,22 +145,22 @@ where
     }
 
     /// Similar to `Tree#with_value`.
-    pub fn with_value(mut self, value: Vec<u8>) -> CostContext<Self> {
+    pub fn put_value(mut self, value: Vec<u8>) -> CostContext<Self> {
         let mut cost = OperationCost::default();
         self.tree
-            .own(|t| t.with_value(value).unwrap_add_cost(&mut cost));
+            .own(|t| t.put_value(value).unwrap_add_cost(&mut cost));
         self.wrap_with_cost(cost)
     }
 
     /// Similar to `Tree#with_value_and_value_hash`.
-    pub fn with_value_and_value_hash(
+    pub fn put_value_and_value_hash(
         mut self,
         value: Vec<u8>,
         value_hash: Hash,
     ) -> CostContext<Self> {
         let mut cost = OperationCost::default();
         self.tree.own(|t| {
-            t.with_value_and_value_hash(value, value_hash)
+            t.put_value_and_value_hash(value, value_hash)
                 .unwrap_add_cost(&mut cost)
         });
         self.wrap_with_cost(cost)


### PR DESCRIPTION
This reverses the use of the index map and batches having the same execution order as non batches, but allows for Merk batches.