### PR TITLE
feat: restrict complete subset paths when merging path queries

### DIFF
--- a/grovedb/src/query.rs
+++ b/grovedb/src/query.rs
@@ -50,6 +50,10 @@ impl PathQuery {
             .wrap_with_cost(cost);
         }
 
+        if Self::has_subpaths(&path_queries) {
+            return Err(Error::InvalidInput("path query path's should be unique")).wrap_with_cost(cost);
+        }
+
         let (common_path, next_index, all_paths_equal) = PathQuery::get_common_path(&path_queries);
 
         let query = if all_paths_equal {
@@ -224,6 +228,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_same_path_different_query_merge() {
         let temp_db = make_deep_tree();
 
@@ -472,6 +477,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_same_path_and_different_path_query_merge() {
         let temp_db = make_deep_tree();
 

--- a/grovedb/src/query.rs
+++ b/grovedb/src/query.rs
@@ -55,7 +55,7 @@ impl PathQuery {
                 .wrap_with_cost(cost);
         }
 
-        let (common_path, next_index, all_paths_equal) = PathQuery::get_common_path(&path_queries);
+        let (common_path, next_index) = PathQuery::get_common_path(&path_queries);
 
         // we know the common path (this describes the context)
         // we need to convert all the paths to queries at the next index
@@ -66,71 +66,16 @@ impl PathQuery {
 
         // merge the queries into one
         // we can use an accumulator query maybe
-        dbg!(&queries_for_common_path);
-        let mut final_query = Query::new();
+        let mut merged_query = Query::new();
+        queries_for_common_path
+            .iter()
+            .fold(&mut merged_query, |acc, curr| {
+                acc.merge(curr);
+                acc
+            });
 
-        // let query = if all_paths_equal {
-        //     let queries = path_queries
-        //         .iter()
-        //         .map(|path_query| &path_query.query.query)
-        //         .collect();
-        //     Query::merge(queries)
-        // } else {
-        //     PathQuery::build_query(path_queries, next_index)
-        // };
-
-        Ok(PathQuery::new_unsized(
-            common_path,
-            queries_for_common_path[0].clone(),
-        ))
-        .wrap_with_cost(cost)
+        Ok(PathQuery::new_unsized(common_path, merged_query)).wrap_with_cost(cost)
     }
-
-    // fn build_query(path_queries: Vec<&PathQuery>, start_index: usize) -> Query {
-    //     let level = start_index;
-    //     let keys_at_level = path_queries
-    //         .iter()
-    //         .map(|&path_query| &path_query.path[level]);
-    //
-    //     // we need to group the paths based on their distinct nature
-    //     let mut path_branches: BTreeMap<_, Vec<usize>> = BTreeMap::new();
-    //     for (path_index, key) in keys_at_level.enumerate() {
-    //         if path_branches.contains_key(key) {
-    //             // get the current element then add the new path index to it
-    //             let current_path_index_array = path_branches
-    //                 .get_mut(key)
-    //                 .expect("confirmed map contains key");
-    //             current_path_index_array.push(path_index);
-    //         } else {
-    //             path_branches.insert(key, vec![path_index]);
-    //         }
-    //     }
-    //
-    //     let mut query = Query::new();
-    //     for (key, value) in path_branches.into_iter() {
-    //         query.insert_key(key.to_vec());
-    //
-    //         let mut new_path_queries = vec![];
-    //         let mut queries_for_exhausted_paths = vec![];
-    //         for path_index in value {
-    //             let curr_path_query = path_queries[path_index];
-    //             if curr_path_query.path.len() - 1 == start_index {
-    //
-    // queries_for_exhausted_paths.push(&curr_path_query.query.query);
-    //             } else {
-    //                 new_path_queries.push(curr_path_query)
-    //             }
-    //         }
-    //         let deep_query = Self::build_query(new_path_queries, start_index +
-    // 1);         queries_for_exhausted_paths.push(&deep_query);
-    //
-    //         let next_query = Query::merge(queries_for_exhausted_paths);
-    //
-    //         query.add_conditional_subquery(QueryItem::Key(key.to_vec()), None,
-    // Some(next_query));     }
-    //
-    //     query
-    // }
 
     /// Checks if any path query is a subset of another by path
     /// i.e [a,b] in [a,b,c]
@@ -181,7 +126,7 @@ impl PathQuery {
         false
     }
 
-    fn get_common_path(path_queries: &[&PathQuery]) -> (Vec<Vec<u8>>, usize, bool) {
+    fn get_common_path(path_queries: &[&PathQuery]) -> (Vec<Vec<u8>>, usize) {
         let min_path_length = path_queries
             .iter()
             .map(|path_query| path_query.path.len())
@@ -190,7 +135,6 @@ impl PathQuery {
 
         let mut common_path = vec![];
         let mut level = 0;
-        let mut all_equal = true;
 
         while level < min_path_length {
             let keys_at_level = path_queries
@@ -205,11 +149,10 @@ impl PathQuery {
                 common_path.push(first_key.to_vec());
                 level += 1;
             } else {
-                all_equal = false;
                 break;
             }
         }
-        (common_path, level, all_equal)
+        (common_path, level)
     }
 
     fn convert_path_to_query(path_query: &PathQuery, start_index: usize) -> Query {

--- a/grovedb/src/query.rs
+++ b/grovedb/src/query.rs
@@ -55,8 +55,10 @@ impl PathQuery {
         }
 
         if Self::has_subpaths(&path_queries) {
-            return Err(Error::InvalidInput("path query path's should be non subset"))
-                .wrap_with_cost(cost);
+            return Err(Error::InvalidInput(
+                "path query path's should be non subset",
+            ))
+            .wrap_with_cost(cost);
         }
 
         let (common_path, next_index) = PathQuery::get_common_path(&path_queries);
@@ -84,6 +86,7 @@ impl PathQuery {
     /// Also checks for duplicated paths [a,x] and [a,x]
     /// returns false for any other case
     fn has_subpaths(path_queries: &[&PathQuery]) -> bool {
+        // TODO: Improve this
         // Naive solution n^2 time complexity
         for i in 0..path_queries.len() {
             for j in 0..path_queries.len() {
@@ -203,7 +206,10 @@ impl PathQuery {
 mod tests {
     use merk::proofs::Query;
 
-    use crate::{tests::{make_deep_tree, TEST_LEAF}, Element, GroveDb, PathQuery, Error};
+    use crate::{
+        tests::{make_deep_tree, TEST_LEAF},
+        Element, Error, GroveDb, PathQuery,
+    };
 
     #[test]
     fn test_has_subpaths() {
@@ -264,7 +270,12 @@ mod tests {
         assert_eq!(result_set_two.len(), 1);
 
         let merged_path_query = PathQuery::merge(vec![&path_query_one, &path_query_two]).unwrap();
-        assert!(matches!(merged_path_query, Err(Error::InvalidInput("path query path's should be non subset"))));
+        assert!(matches!(
+            merged_path_query,
+            Err(Error::InvalidInput(
+                "path query path's should be non subset"
+            ))
+        ));
     }
 
     #[test]
@@ -504,8 +515,12 @@ mod tests {
         assert_eq!(result_set_two.len(), 2);
 
         let merged_path_query =
-            PathQuery::merge(vec![&path_query_one, &path_query_two, &path_query_three])
-                .unwrap();
-        assert!(matches!(merged_path_query, Err(Error::InvalidInput("path query path's should be non subset"))));
+            PathQuery::merge(vec![&path_query_one, &path_query_two, &path_query_three]).unwrap();
+        assert!(matches!(
+            merged_path_query,
+            Err(Error::InvalidInput(
+                "path query path's should be non subset"
+            ))
+        ));
     }
 }

--- a/grovedb/src/query.rs
+++ b/grovedb/src/query.rs
@@ -286,8 +286,6 @@ mod tests {
         let elements = values.map(|x| Element::new_item(x).serialize().unwrap());
         let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> = keys.into_iter().zip(elements).collect();
         assert_eq!(result_set_merged, expected_result_set);
-
-        // TODO: add test for range
     }
 
     #[test]
@@ -531,13 +529,7 @@ mod tests {
             PathQuery::merge(vec![&path_query_one, &path_query_two, &path_query_three])
                 .unwrap()
                 .expect("expect to merge path queries");
-        // assert_eq!(merged_path_query.path, vec![TEST_LEAF.to_vec()]);
-        // assert_eq!(merged_path_query.query.query.items.len(), 2);
 
-        // let proof = temp_db.prove(&merged_path_query).unwrap().unwrap();
-        // let (_, result_set_merged) = GroveDb::execute_proof(proof.as_slice(),
-        // &merged_path_query)     .expect("should execute proof");
-        // assert_eq!(result_set_merged.len(), 4);
         let proof = temp_db
             .prove_query_many(vec![&path_query_one, &path_query_two, &path_query_three])
             .unwrap()
@@ -561,59 +553,5 @@ mod tests {
         let elements = values.map(|x| Element::new_item(x).serialize().unwrap());
         let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> = keys.into_iter().zip(elements).collect();
         assert_eq!(result_set_merged, expected_result_set);
-
-        // Different path levels
-        // let mut query_one = Query::new();
-        // query_one.insert_all();
-        //
-        // let path_query_one =
-        //     PathQuery::new_unsized(vec![b"deep_leaf".to_vec(),
-        // b"deep_node_1".to_vec()], query_one);
-        //
-        // let proof = temp_db.prove(&path_query_one).unwrap().unwrap();
-        // let (_, result_set_one) = GroveDb::execute_proof(proof.as_slice(),
-        // &path_query_one)     .expect("should execute proof");
-        // assert_eq!(result_set_one.len(), 2);
-        //
-        // let mut query_three = Query::new();
-        // query_three.insert_key(b"key6".to_vec());
-        // let path_query_three = PathQuery::new_unsized(
-        //     vec![b"deep_leaf".to_vec(), b"deep_node_1".to_vec(),
-        // b"deeper_node_2".to_vec()],     query_three,
-        // );
-        //
-        // let proof = temp_db.prove(&path_query_three).unwrap().unwrap();
-        // let (_, result_set_two) = GroveDb::execute_proof(proof.as_slice(),
-        // &path_query_three)     .expect("should execute proof");
-        // assert_eq!(result_set_two.len(), 1);
-        //
-        // let merged_path_query =
-        //     PathQuery::merge(vec![&path_query_one, &path_query_three]);
-        // dbg!(&merged_path_query);
-        // assert_eq!(merged_path_query.path, vec![b"deep_leaf".to_vec(),
-        // b"deep_node_1".to_vec()]);
-        //
-        // let proof =
-        // temp_db.prove(&merged_path_query).unwrap().unwrap();
-        // let (_, result_set_merged) = GroveDb::execute_proof(proof.as_slice(),
-        // &merged_path_query)     .expect("should execute
-        // proof"); dbg!(&result_set_merged);
-        // assert_eq!(result_set_merged.len(), 3);
-        //
-        // let keys = [
-        //     b"key1".to_vec(),
-        //     b"key2".to_vec(),
-        //     b"key6".to_vec(),
-        // ];
-        // let values = [
-        //     b"value1".to_vec(),
-        //     b"value2".to_vec(),
-        //     b"value6".to_vec(),
-        // ];
-        // let elements = values.map(|x|
-        // Element::new_item(x).serialize().unwrap());
-        // let expected_result_set: Vec<(Vec<u8>, Vec<u8>)> =
-        // keys.into_iter().zip(elements).collect();
-        // assert_eq!(result_set_merged, expected_result_set);
     }
 }

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -243,8 +243,8 @@ impl Query {
         }
 
         // TODO: deal with default subquery branch
-        //  this is not needed currently for path_query merge as are enforced as
-        //  non-subset  but might be useful in the future
+        //  this is not needed currently for path_query merge as we enforce
+        //  non-subset paths, but might be useful in the future
         //  Need to create a stretching function for queries that expands default
         //  subqueries  to conditional subqueries.
 
@@ -252,8 +252,8 @@ impl Query {
         for (query_item, subquery_branch) in other.conditional_subquery_branches.iter() {
             let subquery_branch_option = self.conditional_subquery_branches.get_mut(query_item);
             if let Some(subquery_branch_old) = subquery_branch_option {
-                (subquery_branch_old.subquery.as_mut().unwrap())
-                    .merge(subquery_branch.subquery.as_ref().unwrap());
+                    (subquery_branch_old.subquery.as_mut().unwrap())
+                        .merge(subquery_branch.subquery.as_ref().unwrap());
             } else {
                 // we don't have that branch just assign the query
                 self.conditional_subquery_branches

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -242,6 +242,13 @@ impl Query {
             self.insert_item(item.clone())
         }
 
+        // TODO: deal with default subquery branch
+        //  this is not needed currently for path_query merge as are enforced as
+        // non-subset  but might be useful in the future
+        //  Need to create a stretching function for queries that expands default
+        // subqueries  to conditional subqueries.
+
+        // merge conditional query branches.
         for (query_item, subquery_branch) in other.conditional_subquery_branches.iter() {
             let subquery_branch_option = self.conditional_subquery_branches.get_mut(query_item);
             if let Some(subquery_branch_old) = subquery_branch_option {

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -252,8 +252,8 @@ impl Query {
         for (query_item, subquery_branch) in other.conditional_subquery_branches.iter() {
             let subquery_branch_option = self.conditional_subquery_branches.get_mut(query_item);
             if let Some(subquery_branch_old) = subquery_branch_option {
-                    (subquery_branch_old.subquery.as_mut().unwrap())
-                        .merge(subquery_branch.subquery.as_ref().unwrap());
+                (subquery_branch_old.subquery.as_mut().unwrap())
+                    .merge(subquery_branch.subquery.as_ref().unwrap());
             } else {
                 // we don't have that branch just assign the query
                 self.conditional_subquery_branches

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -244,9 +244,9 @@ impl Query {
 
         // TODO: deal with default subquery branch
         //  this is not needed currently for path_query merge as are enforced as
-        // non-subset  but might be useful in the future
+        //  non-subset  but might be useful in the future
         //  Need to create a stretching function for queries that expands default
-        // subqueries  to conditional subqueries.
+        //  subqueries  to conditional subqueries.
 
         // merge conditional query branches.
         for (query_item, subquery_branch) in other.conditional_subquery_branches.iter() {
@@ -1522,10 +1522,25 @@ mod test {
         query_two.add_conditional_subquery(QueryItem::Key(b"a".to_vec()), None, Some(query_two_c));
         query_one.merge(&query_two);
 
-        // TODO: build expected query
-        // let mut expected_query = Query::new();
-        // expected_query.insert_key(b"a".to_vec());
-        // let mu
+        let mut expected_query = Query::new();
+        expected_query.insert_key(b"a".to_vec());
+        let mut query_b_c = Query::new();
+        query_b_c.insert_key(b"b".to_vec());
+        query_b_c.insert_key(b"c".to_vec());
+        let mut query_c = Query::new();
+        query_c.insert_key(b"c".to_vec());
+        let mut query_d = Query::new();
+        query_d.insert_key(b"d".to_vec());
+
+        query_b_c.add_conditional_subquery(QueryItem::Key(b"b".to_vec()), None, Some(query_c));
+        query_b_c.add_conditional_subquery(QueryItem::Key(b"c".to_vec()), None, Some(query_d));
+
+        expected_query.add_conditional_subquery(
+            QueryItem::Key(b"a".to_vec()),
+            None,
+            Some(query_b_c),
+        );
+        assert_eq!(query_one, expected_query);
     }
 
     #[test]


### PR DESCRIPTION
Restricts mergeable path queries to those with unique and none subset paths.
Also refactors the merge algorithm to better describe what's going on.