### PR TITLE
feat: query return different types of results

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -3,6 +3,7 @@ extern crate core;
 pub mod batch;
 mod operations;
 mod query;
+pub mod query_result_type;
 mod subtree;
 #[cfg(test)]
 mod tests;

--- a/grovedb/src/operations/get.rs
+++ b/grovedb/src/operations/get.rs
@@ -6,7 +6,7 @@ use costs::{
 use storage::StorageContext;
 
 use crate::{
-    subtree::{KeyElementPair, QueryResultItem, QueryResultType},
+    subtree::{QueryResultItem, QueryResultType},
     util::{merk_optional_tx, storage_context_optional_tx},
     Element, Error, GroveDb, PathQuery, TransactionArg,
 };
@@ -249,12 +249,7 @@ where {
         result_type: QueryResultType,
         transaction: TransactionArg,
     ) -> CostResult<(Vec<QueryResultItem>, u16), Error> {
-        let path_slices = path_query
-            .path
-            .iter()
-            .map(|x| x.as_slice())
-            .collect::<Vec<_>>();
-        Element::get_raw_path_query(&self.db, &path_slices, path_query, result_type, transaction)
+        Element::get_raw_path_query(&self.db, path_query, result_type, transaction)
     }
 
     fn check_subtree_exists<'p, P>(

--- a/grovedb/src/operations/get.rs
+++ b/grovedb/src/operations/get.rs
@@ -6,7 +6,7 @@ use costs::{
 use storage::StorageContext;
 
 use crate::{
-    subtree::{QueryResultItem, QueryResultType},
+    query_result_type::{QueryResultItem, QueryResultType},
     util::{merk_optional_tx, storage_context_optional_tx},
     Element, Error, GroveDb, PathQuery, TransactionArg,
 };

--- a/grovedb/src/operations/get.rs
+++ b/grovedb/src/operations/get.rs
@@ -6,7 +6,7 @@ use costs::{
 use storage::StorageContext;
 
 use crate::{
-    query_result_type::{QueryResultItem, QueryResultType},
+    query_result_type::{QueryResultElement, QueryResultElements, QueryResultType},
     util::{merk_optional_tx, storage_context_optional_tx},
     Element, Error, GroveDb, PathQuery, TransactionArg,
 };
@@ -142,7 +142,7 @@ impl GroveDb {
         let results_wrapped = elements
             .into_iter()
             .map(|result_item| match result_item {
-                QueryResultItem::ElementResultItem(Element::Reference(reference_path, _)) => {
+                QueryResultElement::ElementResultItem(Element::Reference(reference_path, _)) => {
                     let maybe_item = self
                         .follow_reference(reference_path, transaction)
                         .unwrap_add_cost(&mut cost)?;
@@ -166,7 +166,7 @@ impl GroveDb {
         path_queries: &[&PathQuery],
         result_type: QueryResultType,
         transaction: TransactionArg,
-    ) -> CostResult<Vec<QueryResultItem>, Error>
+    ) -> CostResult<QueryResultElements, Error>
 where {
         let mut cost = OperationCost::default();
 
@@ -210,7 +210,7 @@ where {
         let results_wrapped = elements
             .into_iter()
             .map(|result_item| match result_item {
-                QueryResultItem::ElementResultItem(element) => {
+                QueryResultElement::ElementResultItem(element) => {
                     match element {
                         Element::Reference(reference_path, _) => {
                             // While `map` on iterator is lazy, we should accumulate costs even if
@@ -248,7 +248,7 @@ where {
         path_query: &PathQuery,
         result_type: QueryResultType,
         transaction: TransactionArg,
-    ) -> CostResult<(Vec<QueryResultItem>, u16), Error> {
+    ) -> CostResult<(QueryResultElements, u16), Error> {
         Element::get_raw_path_query(&self.db, path_query, result_type, transaction)
     }
 

--- a/grovedb/src/query.rs
+++ b/grovedb/src/query.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use costs::{CostContext, CostsExt, OperationCost};
 use merk::proofs::{query::QueryItem, Query};
 

--- a/grovedb/src/query_result_type.rs
+++ b/grovedb/src/query_result_type.rs
@@ -9,31 +9,53 @@ pub enum QueryResultType {
 
 pub type QueryResultItems = Vec<QueryResultItem>;
 
-pub fn query_result_items_to_elements(query_result_items: QueryResultItems) -> Vec<Element> {
+pub trait GetItemResults {
+    fn to_elements(self) -> Vec<Element>;
+    fn to_key_elements(self) -> Vec<KeyElementPair>;
+    fn to_path_key_elements(self) -> Vec<PathKeyElementTrio>;
+}
+
+impl GetItemResults for QueryResultItems {
+    fn to_elements(self) -> Vec<Element> {
+        query_result_items_to_elements(self)
+    }
+
+    fn to_key_elements(self) -> Vec<KeyElementPair> {
+        query_result_items_to_key_elements(self)
+    }
+
+    fn to_path_key_elements(self) -> Vec<PathKeyElementTrio> {
+        query_result_items_to_path_key_elements(self)
+    }
+}
+
+fn query_result_items_to_elements(query_result_items: QueryResultItems) -> Vec<Element> {
     query_result_items
         .into_iter()
         .filter_map(|result_item| match result_item {
             QueryResultItem::ElementResultItem(element) => Some(element),
-            QueryResultItem::KeyElementPairResultItem(_) => None,
-            QueryResultItem::PathKeyElementTrioResultItem(_) => None,
+            QueryResultItem::KeyElementPairResultItem(element_key_pair) => Some(element_key_pair.1),
+            QueryResultItem::PathKeyElementTrioResultItem(path_key_element_trio) => {
+                Some(path_key_element_trio.2)
+            }
         })
         .collect()
 }
 
-pub fn query_result_items_to_key_elements(
-    query_result_items: QueryResultItems,
-) -> Vec<KeyElementPair> {
+fn query_result_items_to_key_elements(query_result_items: QueryResultItems) -> Vec<KeyElementPair> {
     query_result_items
         .into_iter()
         .filter_map(|result_item| match result_item {
             QueryResultItem::ElementResultItem(_) => None,
             QueryResultItem::KeyElementPairResultItem(key_element_pair) => Some(key_element_pair),
-            QueryResultItem::PathKeyElementTrioResultItem(_) => None,
+            QueryResultItem::PathKeyElementTrioResultItem(path_key_element_trio) => {
+                Some((path_key_element_trio.1, path_key_element_trio.2))
+            }
         })
         .collect()
 }
 
-pub fn query_result_items_to_path_key_elements(
+fn query_result_items_to_path_key_elements(
     query_result_items: QueryResultItems,
 ) -> Vec<PathKeyElementTrio> {
     query_result_items

--- a/grovedb/src/query_result_type.rs
+++ b/grovedb/src/query_result_type.rs
@@ -1,0 +1,61 @@
+use crate::Element;
+
+#[derive(Copy, Clone)]
+pub enum QueryResultType {
+    QueryElementResultType,
+    QueryKeyElementPairResultType,
+    QueryPathKeyElementTrioResultType,
+}
+
+pub type QueryResultItems = Vec<QueryResultItem>;
+
+pub fn query_result_items_to_elements(query_result_items: QueryResultItems) -> Vec<Element> {
+    query_result_items
+        .into_iter()
+        .filter_map(|result_item| match result_item {
+            QueryResultItem::ElementResultItem(element) => Some(element),
+            QueryResultItem::KeyElementPairResultItem(_) => None,
+            QueryResultItem::PathKeyElementTrioResultItem(_) => None,
+        })
+        .collect()
+}
+
+pub fn query_result_items_to_key_elements(
+    query_result_items: QueryResultItems,
+) -> Vec<KeyElementPair> {
+    query_result_items
+        .into_iter()
+        .filter_map(|result_item| match result_item {
+            QueryResultItem::ElementResultItem(_) => None,
+            QueryResultItem::KeyElementPairResultItem(key_element_pair) => Some(key_element_pair),
+            QueryResultItem::PathKeyElementTrioResultItem(_) => None,
+        })
+        .collect()
+}
+
+pub fn query_result_items_to_path_key_elements(
+    query_result_items: QueryResultItems,
+) -> Vec<PathKeyElementTrio> {
+    query_result_items
+        .into_iter()
+        .filter_map(|result_item| match result_item {
+            QueryResultItem::ElementResultItem(_) => None,
+            QueryResultItem::KeyElementPairResultItem(_) => None,
+            QueryResultItem::PathKeyElementTrioResultItem(path_key_element_pair) => {
+                Some(path_key_element_pair)
+            }
+        })
+        .collect()
+}
+
+pub enum QueryResultItem {
+    ElementResultItem(Element),
+    KeyElementPairResultItem(KeyElementPair),
+    PathKeyElementTrioResultItem(PathKeyElementTrio),
+}
+
+/// Type alias for key-element common pattern.
+pub type KeyElementPair = (Vec<u8>, Element);
+
+/// Type alias for path-key-element common pattern.
+pub type PathKeyElementTrio = (Vec<Vec<u8>>, Vec<u8>, Element);

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -383,10 +383,7 @@ impl Element {
                 }
                 QueryResultType::QueryPathKeyElementTrioResultType => {
                     let key = key.ok_or(Error::CorruptedPath("basic push must have a key"))?;
-                    let path = path
-                        .iter()
-                        .map(|a| a.to_vec())
-                        .collect();
+                    let path = path.iter().map(|a| a.to_vec()).collect();
                     results.push(QueryResultItem::PathKeyElementTrioResultItem((
                         path,
                         Vec::from(key),
@@ -497,10 +494,7 @@ impl Element {
                                 );
                             }
                             QueryResultType::QueryPathKeyElementTrioResultType => {
-                                let original_path_vec = path
-                                .iter()
-                                .map(|a| a.to_vec())
-                                .collect();
+                                let original_path_vec = path.iter().map(|a| a.to_vec()).collect();
                                 merk_optional_tx!(
                                     &mut cost,
                                     storage,
@@ -1062,11 +1056,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        subtree::QueryResultType::{QueryKeyElementPairResultType},
+        subtree::QueryResultType::{
+            QueryKeyElementPairResultType, QueryPathKeyElementTrioResultType,
+        },
         tests::{make_grovedb, TEST_LEAF},
     };
-    
-    use crate::subtree::QueryResultType::QueryPathKeyElementTrioResultType;
 
     #[test]
     fn test_success_insert() {
@@ -1238,7 +1232,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn test_get_query_with_path() {
         let db = make_grovedb();
@@ -1271,12 +1264,28 @@ mod tests {
         query.insert_key(b"c".to_vec());
         query.insert_key(b"a".to_vec());
         assert_eq!(
-            query_result_items_to_path_key_elements(Element::get_query(&storage, &[TEST_LEAF], &query, QueryPathKeyElementTrioResultType, None)
+            query_result_items_to_path_key_elements(
+                Element::get_query(
+                    &storage,
+                    &[TEST_LEAF],
+                    &query,
+                    QueryPathKeyElementTrioResultType,
+                    None
+                )
                 .unwrap()
-                .expect("expected successful get_query")),
+                .expect("expected successful get_query")
+            ),
             vec![
-                (vec![TEST_LEAF.to_vec()], b"a".to_vec(), Element::new_item(b"ayya".to_vec())),
-                (vec![TEST_LEAF.to_vec()], b"c".to_vec(), Element::new_item(b"ayyc".to_vec()))
+                (
+                    vec![TEST_LEAF.to_vec()],
+                    b"a".to_vec(),
+                    Element::new_item(b"ayya".to_vec())
+                ),
+                (
+                    vec![TEST_LEAF.to_vec()],
+                    b"c".to_vec(),
+                    Element::new_item(b"ayyc".to_vec())
+                )
             ]
         );
     }

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -13,7 +13,7 @@ use integer_encoding::VarInt;
 use merk::{
     proofs::{query::QueryItem, Query},
     tree::Tree,
-    BatchEntry, MerkBatch, Op, HASH_LENGTH,
+    BatchEntry, Op, HASH_LENGTH,
 };
 use serde::{Deserialize, Serialize};
 use storage::{rocksdb_storage::RocksDbStorage, RawIterator, StorageContext};
@@ -1062,10 +1062,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        subtree::QueryResultType::{QueryElementResultType, QueryKeyElementPairResultType},
+        subtree::QueryResultType::{QueryKeyElementPairResultType},
         tests::{make_grovedb, TEST_LEAF},
     };
-    use crate::subtree::QueryResultItem::PathKeyElementTrioResultItem;
+    
     use crate::subtree::QueryResultType::QueryPathKeyElementTrioResultType;
 
     #[test]
@@ -1326,7 +1326,7 @@ mod tests {
         let elements: Vec<KeyElementPair> = elements
             .into_iter()
             .filter_map(|result_item| match result_item {
-                QueryResultItem::ElementResultItem(element) => None,
+                QueryResultItem::ElementResultItem(_element) => None,
                 QueryResultItem::KeyElementPairResultItem(key_element_pair) => {
                     Some(key_element_pair)
                 }
@@ -1359,7 +1359,7 @@ mod tests {
         let elements: Vec<KeyElementPair> = elements
             .into_iter()
             .filter_map(|result_item| match result_item {
-                QueryResultItem::ElementResultItem(element) => None,
+                QueryResultItem::ElementResultItem(_element) => None,
                 QueryResultItem::KeyElementPairResultItem(key_element_pair) => {
                     Some(key_element_pair)
                 }

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -998,9 +998,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        query_result_type::{
-            query_result_items_to_key_elements, query_result_items_to_path_key_elements,
-        },
+        query_result_type::GetItemResults,
         subtree::QueryResultType::{
             QueryKeyElementPairResultType, QueryPathKeyElementTrioResultType,
         },
@@ -1209,17 +1207,16 @@ mod tests {
         query.insert_key(b"c".to_vec());
         query.insert_key(b"a".to_vec());
         assert_eq!(
-            query_result_items_to_path_key_elements(
-                Element::get_query(
-                    &storage,
-                    &[TEST_LEAF],
-                    &query,
-                    QueryPathKeyElementTrioResultType,
-                    None
-                )
-                .unwrap()
-                .expect("expected successful get_query")
-            ),
+            Element::get_query(
+                &storage,
+                &[TEST_LEAF],
+                &query,
+                QueryPathKeyElementTrioResultType,
+                None
+            )
+            .unwrap()
+            .expect("expected successful get_query")
+            .to_path_key_elements(),
             vec![
                 (
                     vec![TEST_LEAF.to_vec()],
@@ -1376,7 +1373,7 @@ mod tests {
             if reverse {
                 expected.reverse();
             }
-            assert_eq!(query_result_items_to_key_elements(elements), expected);
+            assert_eq!(elements.to_key_elements(), expected);
             assert_eq!(skipped, 0);
         }
 
@@ -1473,7 +1470,7 @@ mod tests {
         .unwrap()
         .expect("expected successful get_query");
         assert_eq!(
-            query_result_items_to_key_elements(elements),
+            elements.to_key_elements(),
             vec![
                 (b"a".to_vec(), Element::new_item(b"ayya".to_vec())),
                 (b"c".to_vec(), Element::new_item(b"ayyc".to_vec())),
@@ -1498,7 +1495,7 @@ mod tests {
         .unwrap()
         .expect("expected successful get_query");
         assert_eq!(
-            query_result_items_to_key_elements(elements),
+            elements.to_key_elements(),
             vec![
                 (b"c".to_vec(), Element::new_item(b"ayyc".to_vec())),
                 (b"a".to_vec(), Element::new_item(b"ayya".to_vec())),
@@ -1518,7 +1515,7 @@ mod tests {
         .unwrap()
         .expect("expected successful get_query");
         assert_eq!(
-            query_result_items_to_key_elements(elements),
+            elements.to_key_elements(),
             vec![(b"c".to_vec(), Element::new_item(b"ayyc".to_vec())),]
         );
         assert_eq!(skipped, 0);
@@ -1538,7 +1535,7 @@ mod tests {
         .unwrap()
         .expect("expected successful get_query");
         assert_eq!(
-            query_result_items_to_key_elements(elements),
+            elements.to_key_elements(),
             vec![
                 (b"a".to_vec(), Element::new_item(b"ayya".to_vec())),
                 (b"b".to_vec(), Element::new_item(b"ayyb".to_vec()))
@@ -1557,7 +1554,7 @@ mod tests {
         .unwrap()
         .expect("expected successful get_query");
         assert_eq!(
-            query_result_items_to_key_elements(elements),
+            elements.to_key_elements(),
             vec![
                 (b"b".to_vec(), Element::new_item(b"ayyb".to_vec())),
                 (b"c".to_vec(), Element::new_item(b"ayyc".to_vec()))
@@ -1581,7 +1578,7 @@ mod tests {
         .unwrap()
         .expect("expected successful get_query");
         assert_eq!(
-            query_result_items_to_key_elements(elements),
+            elements.to_key_elements(),
             vec![
                 (b"b".to_vec(), Element::new_item(b"ayyb".to_vec())),
                 (b"a".to_vec(), Element::new_item(b"ayya".to_vec()))
@@ -1604,7 +1601,7 @@ mod tests {
         .unwrap()
         .expect("expected successful get_query");
         assert_eq!(
-            query_result_items_to_key_elements(elements),
+            elements.to_key_elements(),
             vec![
                 (b"b".to_vec(), Element::new_item(b"ayyb".to_vec())),
                 (b"c".to_vec(), Element::new_item(b"ayyc".to_vec())),
@@ -1628,7 +1625,7 @@ mod tests {
         .unwrap()
         .expect("expected successful get_query");
         assert_eq!(
-            query_result_items_to_key_elements(elements),
+            elements.to_key_elements(),
             vec![
                 (b"c".to_vec(), Element::new_item(b"ayyc".to_vec())),
                 (b"b".to_vec(), Element::new_item(b"ayyb".to_vec())),
@@ -1652,7 +1649,7 @@ mod tests {
         .unwrap()
         .expect("expected successful get_query");
         assert_eq!(
-            query_result_items_to_key_elements(elements),
+            elements.to_key_elements(),
             vec![
                 (b"b".to_vec(), Element::new_item(b"ayyb".to_vec())),
                 (b"a".to_vec(), Element::new_item(b"ayya".to_vec())),

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -20,70 +20,12 @@ use storage::{rocksdb_storage::RocksDbStorage, RawIterator, StorageContext};
 use visualize::visualize_to_vec;
 
 use crate::{
-    subtree::QueryResultType::QueryElementResultType,
+    query_result_type::{
+        KeyElementPair, QueryResultItem, QueryResultType, QueryResultType::QueryElementResultType,
+    },
     util::{merk_optional_tx, storage_context_optional_tx},
     Error, Merk, PathQuery, SizedQuery, TransactionArg,
 };
-
-#[derive(Copy, Clone)]
-pub enum QueryResultType {
-    QueryElementResultType,
-    QueryKeyElementPairResultType,
-    QueryPathKeyElementTrioResultType,
-}
-
-pub type QueryResultItems = Vec<QueryResultItem>;
-
-pub fn query_result_items_to_elements(query_result_items: QueryResultItems) -> Vec<Element> {
-    query_result_items
-        .into_iter()
-        .filter_map(|result_item| match result_item {
-            QueryResultItem::ElementResultItem(element) => Some(element),
-            QueryResultItem::KeyElementPairResultItem(_) => None,
-            QueryResultItem::PathKeyElementTrioResultItem(_) => None,
-        })
-        .collect()
-}
-
-pub fn query_result_items_to_key_elements(
-    query_result_items: QueryResultItems,
-) -> Vec<KeyElementPair> {
-    query_result_items
-        .into_iter()
-        .filter_map(|result_item| match result_item {
-            QueryResultItem::ElementResultItem(_) => None,
-            QueryResultItem::KeyElementPairResultItem(key_element_pair) => Some(key_element_pair),
-            QueryResultItem::PathKeyElementTrioResultItem(_) => None,
-        })
-        .collect()
-}
-
-pub fn query_result_items_to_path_key_elements(
-    query_result_items: QueryResultItems,
-) -> Vec<PathKeyElementTrio> {
-    query_result_items
-        .into_iter()
-        .filter_map(|result_item| match result_item {
-            QueryResultItem::ElementResultItem(_) => None,
-            QueryResultItem::KeyElementPairResultItem(_) => None,
-            QueryResultItem::PathKeyElementTrioResultItem(path_key_element_pair) => {
-                Some(path_key_element_pair)
-            }
-        })
-        .collect()
-}
-
-pub enum QueryResultItem {
-    ElementResultItem(Element),
-    KeyElementPairResultItem(KeyElementPair),
-    PathKeyElementTrioResultItem(PathKeyElementTrio),
-}
-
-/// Type alias for key-element common pattern.
-pub type KeyElementPair = (Vec<u8>, Element);
-
-/// Type alias for path-key-element common pattern.
-pub type PathKeyElementTrio = (Vec<Vec<u8>>, Vec<u8>, Element);
 
 /// Optional single byte meta-data to be stored per element
 pub type ElementFlags = Option<Vec<u8>>;
@@ -1056,6 +998,9 @@ mod tests {
 
     use super::*;
     use crate::{
+        query_result_type::{
+            query_result_items_to_key_elements, query_result_items_to_path_key_elements,
+        },
         subtree::QueryResultType::{
             QueryKeyElementPairResultType, QueryPathKeyElementTrioResultType,
         },

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -5,9 +5,7 @@ use rand::Rng;
 use tempfile::TempDir;
 
 use super::*;
-use crate::query_result_type::{
-    query_result_items_to_key_elements, QueryResultType::QueryKeyElementPairResultType,
-};
+use crate::query_result_type::{GetItemResults, QueryResultType::QueryKeyElementPairResultType};
 
 pub const TEST_LEAF: &[u8] = b"test_leaf";
 pub const ANOTHER_TEST_LEAF: &[u8] = b"test_leaf2";
@@ -469,7 +467,7 @@ fn test_element_with_flags() {
         Element::Item(b"flagged".to_vec(), Some([4, 5, 6, 7, 8].to_vec()))
     );
     assert_eq!(
-        query_result_items_to_key_elements(flagged_ref_no_follow)[0],
+        flagged_ref_no_follow.to_key_elements()[0],
         (
             b"elem4".to_vec(),
             Element::Reference(
@@ -2338,15 +2336,14 @@ fn test_get_full_query() {
     let path_query2 = PathQuery::new_unsized(path2, query2);
 
     assert_eq!(
-        query_result_items_to_key_elements(
-            db.query_many_raw(
-                &[&path_query1, &path_query2],
-                QueryKeyElementPairResultType,
-                None
-            )
-            .unwrap()
-            .expect("expected successful get_query")
-        ),
+        db.query_many_raw(
+            &[&path_query1, &path_query2],
+            QueryKeyElementPairResultType,
+            None
+        )
+        .unwrap()
+        .expect("expected successful get_query")
+        .to_key_elements(),
         vec![
             (b"key3".to_vec(), Element::new_item(b"ayya".to_vec())),
             (b"key4".to_vec(), Element::new_item(b"ayyb".to_vec())),

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -5,6 +5,10 @@ use rand::Rng;
 use tempfile::TempDir;
 
 use super::*;
+use crate::subtree::{
+    query_result_items_to_key_elements, QueryResultType,
+    QueryResultType::QueryKeyElementPairResultType,
+};
 
 pub const TEST_LEAF: &[u8] = b"test_leaf";
 pub const ANOTHER_TEST_LEAF: &[u8] = b"test_leaf2";
@@ -448,7 +452,7 @@ fn test_element_with_flags() {
         SizedQuery::new(query, None, None),
     );
     let (flagged_ref_no_follow, _) = db
-        .query_raw(&path_query, None)
+        .query_raw(&path_query, QueryKeyElementPairResultType, None)
         .unwrap()
         .expect("should get successfully");
 
@@ -466,7 +470,7 @@ fn test_element_with_flags() {
         Element::Item(b"flagged".to_vec(), Some([4, 5, 6, 7, 8].to_vec()))
     );
     assert_eq!(
-        flagged_ref_no_follow[0],
+        query_result_items_to_key_elements(flagged_ref_no_follow)[0],
         (
             b"elem4".to_vec(),
             Element::Reference(
@@ -2335,9 +2339,15 @@ fn test_get_full_query() {
     let path_query2 = PathQuery::new_unsized(path2, query2);
 
     assert_eq!(
-        db.query_many_raw(&[&path_query1, &path_query2], None)
+        query_result_items_to_key_elements(
+            db.query_many_raw(
+                &[&path_query1, &path_query2],
+                QueryKeyElementPairResultType,
+                None
+            )
             .unwrap()
-            .expect("expected successful get_query"),
+            .expect("expected successful get_query")
+        ),
         vec![
             (b"key3".to_vec(), Element::new_item(b"ayya".to_vec())),
             (b"key4".to_vec(), Element::new_item(b"ayyb".to_vec())),

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -1749,7 +1749,7 @@ fn transaction_insert_item_with_transaction_should_use_transaction() {
     assert_eq!(result_with_transaction, Element::new_item(b"ayy".to_vec()));
 
     // Test that commit works
-    db.commit_transaction(transaction).unwrap();
+    db.commit_transaction(transaction).unwrap().unwrap();
 
     // Check that the change was committed
     let result = db
@@ -1788,7 +1788,7 @@ fn transaction_insert_tree_with_transaction_should_use_transaction() {
         .expect("Expected to work");
     assert_eq!(result_with_transaction, Element::empty_tree());
 
-    db.commit_transaction(transaction).unwrap();
+    db.commit_transaction(transaction).unwrap().unwrap();
 
     let result = db
         .get([TEST_LEAF], subtree_key, None)
@@ -3777,7 +3777,7 @@ fn test_root_hash() {
     );
 
     assert_eq!(db.root_hash(None).unwrap().unwrap(), root_hash_outside);
-    db.commit_transaction(transaction).unwrap();
+    db.commit_transaction(transaction).unwrap().unwrap();
     assert_ne!(db.root_hash(None).unwrap().unwrap(), root_hash_outside);
 }
 

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -6,8 +6,7 @@ use tempfile::TempDir;
 
 use super::*;
 use crate::subtree::{
-    query_result_items_to_key_elements,
-    QueryResultType::QueryKeyElementPairResultType,
+    query_result_items_to_key_elements, QueryResultType::QueryKeyElementPairResultType,
 };
 
 pub const TEST_LEAF: &[u8] = b"test_leaf";

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -6,7 +6,7 @@ use tempfile::TempDir;
 
 use super::*;
 use crate::subtree::{
-    query_result_items_to_key_elements, QueryResultType,
+    query_result_items_to_key_elements,
     QueryResultType::QueryKeyElementPairResultType,
 };
 

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use tempfile::TempDir;
 
 use super::*;
-use crate::query_result_type::{GetItemResults, QueryResultType::QueryKeyElementPairResultType};
+use crate::query_result_type::QueryResultType::QueryKeyElementPairResultType;
 
 pub const TEST_LEAF: &[u8] = b"test_leaf";
 pub const ANOTHER_TEST_LEAF: &[u8] = b"test_leaf2";

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 use tempfile::TempDir;
 
 use super::*;
-use crate::subtree::{
+use crate::query_result_type::{
     query_result_items_to_key_elements, QueryResultType::QueryKeyElementPairResultType,
 };
 

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use costs::{
-    cost_return_on_error, cost_return_on_error_no_add, CostContext, CostsExt, OperationCost,
+    cost_return_on_error, CostContext, CostsExt, OperationCost,
 };
 use storage::{self, Batch, RawIterator, StorageContext};
 

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -10,9 +10,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use costs::{
-    cost_return_on_error, CostContext, CostsExt, OperationCost,
-};
+use costs::{cost_return_on_error, CostContext, CostsExt, OperationCost};
 use storage::{self, Batch, RawIterator, StorageContext};
 
 use crate::{

--- a/node-grove/src/lib.rs
+++ b/node-grove/src/lib.rs
@@ -90,7 +90,7 @@ impl GroveDbWrapper {
                     DbMessage::CommitTransaction(callback) => {
                         grove_db
                             .commit_transaction(transaction.take().unwrap())
-                            .unwrap();
+                            .unwrap().unwrap();
                         callback(&channel);
                     }
                     DbMessage::RollbackTransaction(callback) => {

--- a/node-grove/src/lib.rs
+++ b/node-grove/src/lib.rs
@@ -90,7 +90,8 @@ impl GroveDbWrapper {
                     DbMessage::CommitTransaction(callback) => {
                         grove_db
                             .commit_transaction(transaction.take().unwrap())
-                            .unwrap().unwrap();
+                            .unwrap()
+                            .unwrap();
                         callback(&channel);
                     }
                     DbMessage::RollbackTransaction(callback) => {


### PR DESCRIPTION
Sometimes on a query we are interested in the value, sometimes the key value, and even some other times the path key and the value. This PR allows us to specify the return type of items.