### PR TITLE
perf: single hop reference insert

### DIFF
--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -17,7 +17,7 @@ use nohash_hasher::IntMap;
 use storage::{Storage, StorageBatch, StorageContext};
 use visualize::{DebugByteVectors, DebugBytes, Drawer, Visualize};
 
-use crate::{operations::get::MAX_REFERENCE_HOPS, Element, Error, GroveDb, TransactionArg};
+use crate::{Element, Error, GroveDb, TransactionArg};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Op {
@@ -285,7 +285,6 @@ trait TreeCache {
         &mut self,
         path: &[Vec<u8>],
         ops_at_path_by_key: BTreeMap<Vec<u8>, Op>,
-        ops_by_qualified_paths: &HashMap<Vec<Vec<u8>>, Op>,
         batch_apply_options: &BatchApplyOptions,
     ) -> CostResult<[u8; 32], Error>;
 }
@@ -407,7 +406,6 @@ where
         &mut self,
         path: &[Vec<u8>],
         ops_at_path_by_key: BTreeMap<Vec<u8>, Op>,
-        ops_by_qualified_paths: &HashMap<Vec<Vec<u8>>, Op>,
         batch_apply_options: &BatchApplyOptions,
     ) -> CostResult<[u8; 32], Error> {
         let mut cost = OperationCost::default();
@@ -519,7 +517,6 @@ impl TreeCache for TreeCacheKnownPaths {
         &mut self,
         path: &[Vec<u8>],
         ops_at_path_by_key: BTreeMap<Vec<u8>, Op>,
-        _ops_by_qualified_paths: &HashMap<Vec<Vec<u8>>, Op>,
         _batch_apply_options: &BatchApplyOptions,
     ) -> CostResult<[u8; 32], Error> {
         let mut cost = OperationCost::default();
@@ -659,7 +656,7 @@ impl GroveDb {
         let mut cost = OperationCost::default();
         let BatchStructure {
             mut ops_by_level_paths,
-            ops_by_qualified_paths,
+            ops_by_qualified_paths: _,
             mut merk_tree_cache,
             last_level,
         } = batch_structure;
@@ -694,7 +691,6 @@ impl GroveDb {
                         merk_tree_cache.execute_ops_on_path(
                             &path,
                             root_tree_ops,
-                            &ops_by_qualified_paths,
                             &batch_apply_options,
                         )
                     );
@@ -704,7 +700,6 @@ impl GroveDb {
                         merk_tree_cache.execute_ops_on_path(
                             &path,
                             ops_at_path,
-                            &ops_by_qualified_paths,
                             &batch_apply_options,
                         )
                     );

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -46,20 +46,14 @@ impl GroveDb {
                     self.check_subtree_exists_invalid_path(path_iter.clone(), transaction)
                 );
 
-                // Rather than getting the referenced element, can't we get the serialized value
-                // directly??
-                let referenced_path_iter = reference_path.iter().map(|x| x.as_slice()).collect::<Vec<_>>();
-                let (reference_key, reference_path) = referenced_path_iter.split_last().unwrap();
-                // let referenced_element = cost_return_on_error!(
-                //     &mut cost,
-                //     self.follow_reference(reference_path.to_owned(), transaction)
-                // );
+                let (referenced_key, referenced_path) = reference_path.split_last().unwrap();
 
-                // need
+                let referenced_path_iter = referenced_path.iter().map(|x| x.as_slice());
+
                 let referenced_element_value_hash_opt = merk_optional_tx!(
                     &mut cost,
                     self.db,
-                    reference_path.to_vec(),
+                    referenced_path_iter,
                     transaction,
                     subtree,
                     {
@@ -72,7 +66,7 @@ impl GroveDb {
                 let referenced_element_value_hash = cost_return_on_error!(
                     &mut cost,
                     referenced_element_value_hash_opt
-                        .ok_or(Error::MissingReference("bsdf"))
+                        .ok_or(Error::MissingReference("cannot find referenced value"))
                         .wrap_with_cost(OperationCost::default())
                 );
 

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -57,7 +57,7 @@ impl GroveDb {
                     transaction,
                     subtree,
                     {
-                        Element::get_value_hash(&subtree, reference_key)
+                        Element::get_value_hash(&subtree,referenced_key)
                             .unwrap_add_cost(&mut cost)
                             .unwrap()
                     }

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -57,7 +57,7 @@ impl GroveDb {
                     transaction,
                     subtree,
                     {
-                        Element::get_value_hash(&subtree,referenced_key)
+                        Element::get_value_hash(&subtree, referenced_key)
                             .unwrap_add_cost(&mut cost)
                             .unwrap()
                     }

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -45,6 +45,9 @@ impl GroveDb {
                     &mut cost,
                     self.check_subtree_exists_invalid_path(path_iter.clone(), transaction)
                 );
+
+                // Rather than getting the referenced element, can't we get the serialized value
+                // directly??
                 let referenced_element = cost_return_on_error!(
                     &mut cost,
                     self.follow_reference(reference_path.to_owned(), transaction)

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -48,20 +48,22 @@ impl GroveDb {
 
                 // Rather than getting the referenced element, can't we get the serialized value
                 // directly??
-                let referenced_path_iter = reference_path.iter().map(|x| x.as_slice());
-                let referenced_element = cost_return_on_error!(
-                    &mut cost,
-                    self.follow_reference(reference_path.to_owned(), transaction)
-                );
+                let referenced_path_iter = reference_path.iter().map(|x| x.as_slice()).collect::<Vec<_>>();
+                let (reference_key, reference_path) = referenced_path_iter.split_last().unwrap();
+                // let referenced_element = cost_return_on_error!(
+                //     &mut cost,
+                //     self.follow_reference(reference_path.to_owned(), transaction)
+                // );
 
+                // need
                 let referenced_element_value_hash_opt = merk_optional_tx!(
                     &mut cost,
                     self.db,
-                    referenced_path_iter,
+                    reference_path.to_vec(),
                     transaction,
                     subtree,
                     {
-                        Element::get_value_hash(&subtree, key)
+                        Element::get_value_hash(&subtree, reference_key)
                             .unwrap_add_cost(&mut cost)
                             .unwrap()
                     }

--- a/grovedb/src/query.rs
+++ b/grovedb/src/query.rs
@@ -43,8 +43,8 @@ impl PathQuery {
     /// [a, b] + [a, b]
     ///     valid if they both point queries of the same depth
     ///     invalid if they point to queries of different depth
-    /// TODO: Currently not allowing unlimited depth queries when paths are equal
-    ///     this is possible, should handle later.
+    /// TODO: Currently not allowing unlimited depth queries when paths are
+    /// equal     this is possible, should handle later.
     /// [a] + [b] (valid, unique and non subset)
     pub fn merge(path_queries: Vec<&PathQuery>) -> CostContext<Result<Self, Error>> {
         let cost = OperationCost::default();
@@ -106,8 +106,10 @@ impl PathQuery {
 
                 if path_one_len == path_two_len {
                     // paths are equal, confirm that queries have no subquery
-                    if path_queries[i].query.query.has_subquery() || path_queries[j].query.query.has_subquery() {
-                       return true
+                    if path_queries[i].query.query.has_subquery()
+                        || path_queries[j].query.query.has_subquery()
+                    {
+                        return true;
                     }
                 }
 

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -641,7 +641,6 @@ fn test_reference_must_point_to_item() {
             None,
         )
         .unwrap();
-    dbg!(&result);
 
     assert!(matches!(result, Err(Error::MissingReference(_))));
 }
@@ -673,19 +672,20 @@ fn test_too_many_indirections() {
         .expect("successful reference insert");
     }
 
-    let result = db.insert(
+    // Add one more reference
+    db.insert(
         [TEST_LEAF],
         &keygen(MAX_REFERENCE_HOPS + 1),
         Element::new_reference(vec![TEST_LEAF.to_vec(), keygen(MAX_REFERENCE_HOPS)]),
         None,
     )
+    .unwrap();
+
+    let result = db
+        .get([TEST_LEAF], &keygen(MAX_REFERENCE_HOPS + 1), None)
         .unwrap();
 
-    // No longer doing max hops on insertion as value hash is in previous element
-    assert!(matches!(
-        result,
-        Ok(_)
-    ))
+    assert!(matches!(result, Err(Error::ReferenceLimit)));
 }
 
 #[test]

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -641,8 +641,9 @@ fn test_reference_must_point_to_item() {
             None,
         )
         .unwrap();
+    dbg!(&result);
 
-    assert!(matches!(result, Err(Error::PathKeyNotFound(_))));
+    assert!(matches!(result, Err(Error::MissingReference(_))));
 }
 
 #[test]
@@ -672,15 +673,18 @@ fn test_too_many_indirections() {
         .expect("successful reference insert");
     }
 
+    let result = db.insert(
+        [TEST_LEAF],
+        &keygen(MAX_REFERENCE_HOPS + 1),
+        Element::new_reference(vec![TEST_LEAF.to_vec(), keygen(MAX_REFERENCE_HOPS)]),
+        None,
+    )
+        .unwrap();
+
+    // No longer doing max hops on insertion as value hash is in previous element
     assert!(matches!(
-        db.insert(
-            [TEST_LEAF],
-            &keygen(MAX_REFERENCE_HOPS + 1),
-            Element::new_reference(vec![TEST_LEAF.to_vec(), keygen(MAX_REFERENCE_HOPS)]),
-            None,
-        )
-        .unwrap(),
-        Err(Error::ReferenceLimit)
+        result,
+        Ok(_)
     ))
 }
 

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -218,8 +218,18 @@ where
 
     /// Gets a hash of a node by a given key, `None` is returned in case
     /// when node not found by the key.
-    pub fn get_hash(&self, key: &[u8]) -> CostContext<Result<Option<[u8; 32]>>> {
+    pub fn get_hash(&self, key: &[u8]) -> CostContext<Result<Option<Hash>>> {
         self.get_node_fn(key, |node| node.hash())
+    }
+
+    /// Gets the value hash of a node by a given key, `None` is returned in case
+    /// when node not found by the key.
+    pub fn get_value_hash(&self, key: &[u8]) -> CostContext<Result<Option<Hash>>> {
+        self.get_node_fn(key, |node| {
+            node.value_hash()
+                .clone()
+                .wrap_with_cost(OperationCost::default())
+        })
     }
 
     /// See if a node's field exists

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -5,7 +5,7 @@ use costs::{cost_return_on_error, CostContext, CostsExt, OperationCost};
 use Op::*;
 
 use super::{Fetch, Link, Tree, Walker};
-use crate::{Hash};
+use crate::Hash;
 
 /// Type alias to add more sense to function signatures.
 type DeletedKeys = LinkedList<Vec<u8>>;

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -5,7 +5,7 @@ use costs::{cost_return_on_error, CostContext, CostsExt, OperationCost};
 use Op::*;
 
 use super::{Fetch, Link, Tree, Walker};
-use crate::{tree::hash::value_hash, Hash};
+use crate::{Hash};
 
 /// Type alias to add more sense to function signatures.
 type DeletedKeys = LinkedList<Vec<u8>>;

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -5,7 +5,7 @@ use costs::{cost_return_on_error, CostContext, CostsExt, OperationCost};
 use Op::*;
 
 use super::{Fetch, Link, Tree, Walker};
-use crate::tree::hash::value_hash;
+use crate::{tree::hash::value_hash, Hash};
 
 /// Type alias to add more sense to function signatures.
 type DeletedKeys = LinkedList<Vec<u8>>;
@@ -14,7 +14,7 @@ type DeletedKeys = LinkedList<Vec<u8>>;
 #[derive(PartialEq, Eq)]
 pub enum Op {
     Put(Vec<u8>),
-    PutReference(Vec<u8>, Vec<u8>),
+    PutReference(Vec<u8>, Hash),
     Delete,
 }
 
@@ -124,7 +124,7 @@ where
             PutReference(_, referenced_value) => Tree::new_with_value_hash(
                 mid_key.as_ref().to_vec(),
                 mid_value.to_vec(),
-                value_hash(referenced_value).unwrap_add_cost(&mut cost),
+                referenced_value.clone(),
             )
             .unwrap_add_cost(&mut cost),
             Delete => unreachable!("cannot get here, should return at the top"),
@@ -159,10 +159,7 @@ where
                 // TODO: take vec from batch so we don't need to clone
                 Put(value) => self.put_value(value.to_vec()).unwrap_add_cost(&mut cost),
                 PutReference(value, referenced_value) => self
-                    .put_value_and_value_hash(
-                        value.to_vec(),
-                        value_hash(referenced_value).unwrap_add_cost(&mut cost),
-                    )
+                    .put_value_and_value_hash(value.to_vec(), referenced_value.clone())
                     .unwrap_add_cost(&mut cost),
                 Delete => {
                     // TODO: we shouldn't have to do this as 2 different calls to apply

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -124,7 +124,7 @@ where
             PutReference(_, referenced_value) => Tree::new_with_value_hash(
                 mid_key.as_ref().to_vec(),
                 mid_value.to_vec(),
-                referenced_value.clone(),
+                referenced_value.to_owned(),
             )
             .unwrap_add_cost(&mut cost),
             Delete => unreachable!("cannot get here, should return at the top"),


### PR DESCRIPTION
Currently, when inserting a reference in some reference chain, we hop all the way back to the base element to get the value hash.
This has a worst-case get of MAX_REFERENCE_HOP on every reference insert.

This pr makes reference insertion more efficient, by only fetching the last element in the chain and retrieving the value hash directly from that element. 

example.
Base Element - Ref 1 -> Ref 2
To insert Ref 3, we fetch Ref 2, get the value hash and build Ref 3.
Before we had to fetch Ref 2, then Ref 1, then Base Element, serialize and hash that before building Ref 3.

This reduces get cost to 1 and removes the unnecessary hashing of the serialized base element as that work has been done already.