### PR TITLE
perf: insert reference optimization for worst case

### DIFF
--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -316,7 +316,7 @@ where
                 }
                 Op::Insert { element } => match element {
                     Element::Item(..) => Ok(Cow::Borrowed(element)).wrap_with_cost(cost),
-                    Element::Reference(path, _) => {
+                    Element::Reference(path,_, _) => {
                         self.follow_reference(path, ops_by_qualified_paths, recursions_allowed - 1)
                     }
                     Element::Tree(..) => {
@@ -362,7 +362,7 @@ where
 
             match element {
                 Element::Item(..) => Ok(Cow::Owned(element)).wrap_with_cost(cost),
-                Element::Reference(path, _) => self.follow_reference(
+                Element::Reference(path,_,  _) => self.follow_reference(
                     path.as_slice(),
                     ops_by_qualified_paths,
                     recursions_allowed - 1,
@@ -416,7 +416,7 @@ where
         for (key, op) in ops_at_path_by_key.into_iter() {
             match op {
                 Op::Insert { element } => match &element {
-                    Element::Reference(path_reference, _) => {
+                    Element::Reference(path_reference,_, _) => {
                         if path_reference.len() == 0 {
                             return Err(Error::InvalidBatchOperation(
                                 "attempting to insert an empty reference",

--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -422,6 +422,7 @@ where
                             ))
                             .wrap_with_cost(cost);
                         }
+
                         let referenced_element = cost_return_on_error!(
                             &mut cost,
                             self.follow_reference(
@@ -432,6 +433,7 @@ where
                                     .expect("should have a value as MAX_REFERENCE_HOP has a value")
                             )
                         );
+
                         let serialized =
                             cost_return_on_error_no_add!(&cost, referenced_element.serialize());
                         let val_hash = value_hash(&serialized).unwrap_add_cost(&mut cost);

--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -295,12 +295,13 @@ where
     /// A reference assumes the value hash of the base item it points to.
     /// In a reference chain base_item -> ref_1 -> ref_2 e.t.c.
     /// all references in that chain (ref_1, ref_2) assume the value hash of the
-    /// base_item The goal of this function is to figure out what the
-    /// value_hash of a reference chain is If we want to insert ref_3 to the
+    /// base_item. The goal of this function is to figure out what the
+    /// value_hash of a reference chain is. If we want to insert ref_3 to the
     /// chain above and nothing else changes, we can get the value_hash from
     /// ref_2. But when dealing with batches, you can have an operation to
     /// insert ref_3 and another operation to change something in the
     /// reference chain in the same batch.
+    /// All these has to be taken into account.
     fn follow_reference_get_value_hash<'a>(
         &'a mut self,
         qualified_path: &[Vec<u8>],

--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -429,8 +429,7 @@ where
                                 path_reference,
                                 ops_by_qualified_paths,
                                 element_max_reference_hop
-                                    .or(Some(MAX_REFERENCE_HOPS as u8))
-                                    .expect("should have a value as MAX_REFERENCE_HOP has a value")
+                                    .unwrap_or(MAX_REFERENCE_HOPS as u8)
                             )
                         );
 

--- a/grovedb/src/batch.rs
+++ b/grovedb/src/batch.rs
@@ -416,10 +416,6 @@ where
                             )
                         );
 
-                        // let serialized =
-                        //     cost_return_on_error_no_add!(&cost, referenced_element.serialize());
-                        // let val_hash = value_hash(&serialized).unwrap_add_cost(&mut cost);
-
                         cost_return_on_error!(
                             &mut cost,
                             element.insert_reference_into_batch_operations(

--- a/grovedb/src/operations/get.rs
+++ b/grovedb/src/operations/get.rs
@@ -28,7 +28,7 @@ impl GroveDb {
         let mut cost = OperationCost::default();
 
         match cost_return_on_error!(&mut cost, self.get_raw(path, key, transaction)) {
-            Element::Reference(reference_path, _) => self
+            Element::Reference(reference_path, ..) => self
                 .follow_reference(reference_path, transaction)
                 .add_cost(cost),
             other => Ok(other).wrap_with_cost(cost),
@@ -60,7 +60,7 @@ impl GroveDb {
             }
             visited.insert(path);
             match current_element {
-                Element::Reference(reference_path, _) => path = reference_path,
+                Element::Reference(reference_path, ..) => path = reference_path,
                 other => return Ok(other).wrap_with_cost(cost),
             }
             hops_left -= 1;
@@ -142,7 +142,7 @@ impl GroveDb {
         let results_wrapped = elements
             .into_iter()
             .map(|result_item| match result_item {
-                QueryResultElement::ElementResultItem(Element::Reference(reference_path, _)) => {
+                QueryResultElement::ElementResultItem(Element::Reference(reference_path, ..)) => {
                     let maybe_item = self
                         .follow_reference(reference_path, transaction)
                         .unwrap_add_cost(&mut cost)?;
@@ -212,7 +212,7 @@ where {
             .map(|result_item| match result_item {
                 QueryResultElement::ElementResultItem(element) => {
                     match element {
-                        Element::Reference(reference_path, _) => {
+                        Element::Reference(reference_path, ..) => {
                             // While `map` on iterator is lazy, we should accumulate costs even if
                             // `collect` will end in `Err`, so we'll use
                             // external costs accumulator instead of

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -76,7 +76,11 @@ impl GroveDb {
                     {
                         cost_return_on_error!(
                             &mut cost,
-                            element.insert_reference(&mut subtree, key, referenced_element_value_hash)
+                            element.insert_reference(
+                                &mut subtree,
+                                key,
+                                referenced_element_value_hash
+                            )
                         );
                     }
                 );

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -33,7 +33,7 @@ impl GroveDb {
                 );
                 cost_return_on_error!(&mut cost, self.propagate_changes(path_iter, transaction));
             }
-            Element::Reference(ref reference_path, _) => {
+            Element::Reference(ref reference_path, ..) => {
                 if path_iter.len() == 0 {
                     return Err(Error::InvalidPath(
                         "only subtrees are allowed as root tree's leafs",

--- a/grovedb/src/operations/insert.rs
+++ b/grovedb/src/operations/insert.rs
@@ -45,9 +45,26 @@ impl GroveDb {
                     &mut cost,
                     self.check_subtree_exists_invalid_path(path_iter.clone(), transaction)
                 );
-                let referenced_element = cost_return_on_error!(
+
+                let (referenced_key, referenced_path) = reference_path.split_last().unwrap();
+                let referenced_path_iter = referenced_path.iter().map(|x| x.as_slice());
+                let referenced_element_value_hash_opt = merk_optional_tx!(
                     &mut cost,
-                    self.follow_reference(reference_path.to_owned(), transaction)
+                    self.db,
+                    referenced_path_iter,
+                    transaction,
+                    subtree,
+                    {
+                        Element::get_value_hash(&subtree, referenced_key)
+                            .unwrap_add_cost(&mut cost)
+                            .unwrap()
+                    }
+                );
+                let referenced_element_value_hash = cost_return_on_error!(
+                    &mut cost,
+                    referenced_element_value_hash_opt
+                        .ok_or(Error::MissingReference("cannot find referenced value"))
+                        .wrap_with_cost(OperationCost::default())
                 );
 
                 merk_optional_tx!(
@@ -57,11 +74,9 @@ impl GroveDb {
                     transaction,
                     mut subtree,
                     {
-                        let serialized =
-                            cost_return_on_error_no_add!(&cost, referenced_element.serialize());
                         cost_return_on_error!(
                             &mut cost,
-                            element.insert_reference(&mut subtree, key, serialized)
+                            element.insert_reference(&mut subtree, key, referenced_element_value_hash)
                         );
                     }
                 );

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -340,7 +340,7 @@ impl GroveDb {
                 Op::Push(node) | Op::PushInverted(node) => match node {
                     Node::KV(_, value) => {
                         let elem = Element::deserialize(value);
-                        if let Ok(Element::Reference(reference_path, _)) = elem {
+                        if let Ok(Element::Reference(reference_path, ..)) = elem {
                             let referenced_elem = cost_return_on_error!(
                                 &mut cost,
                                 self.follow_reference(reference_path, None)

--- a/grovedb/src/query.rs
+++ b/grovedb/src/query.rs
@@ -43,8 +43,8 @@ impl PathQuery {
     /// [a, b] + [a, b]
     ///     valid if they both point queries of the same depth
     ///     invalid if they point to queries of different depth
-    /// TODO: Currently not allowing unlimited depth queries when paths are equal
-    ///     this is possible, should handle later.
+    /// TODO: Currently not allowing unlimited depth queries when paths are
+    /// equal     this is possible, should handle later.
     /// [a] + [b] (valid, unique and non subset)
     pub fn merge(path_queries: Vec<&PathQuery>) -> CostContext<Result<Self, Error>> {
         let cost = OperationCost::default();
@@ -106,8 +106,10 @@ impl PathQuery {
 
                 if path_one_len == path_two_len {
                     // paths are equal, confirm that queries have no subquery
-                    if path_queries[i].query.query.has_subquery() || path_queries[j].query.query.has_subquery() {
-                       return true
+                    if path_queries[i].query.query.has_subquery()
+                        || path_queries[j].query.query.has_subquery()
+                    {
+                        return true;
                     }
                 }
 

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -19,15 +19,20 @@ use serde::{Deserialize, Serialize};
 use storage::{rocksdb_storage::RocksDbStorage, RawIterator, StorageContext};
 use visualize::visualize_to_vec;
 
-use crate::{query_result_type::{
-    KeyElementPair, QueryResultElement, QueryResultElements, QueryResultType,
-    QueryResultType::QueryElementResultType,
-}, util::{merk_optional_tx, storage_context_optional_tx}, Error, Merk, PathQuery, SizedQuery, TransactionArg, Hash};
+use crate::{
+    query_result_type::{
+        KeyElementPair, QueryResultElement, QueryResultElements, QueryResultType,
+        QueryResultType::QueryElementResultType,
+    },
+    util::{merk_optional_tx, storage_context_optional_tx},
+    Error, Hash, Merk, PathQuery, SizedQuery, TransactionArg,
+};
 
 /// Optional meta-data to be stored per element
 pub type ElementFlags = Option<Vec<u8>>;
 
-/// Optional single byte to represent the maximum number of reference hop to base element
+/// Optional single byte to represent the maximum number of reference hop to
+/// base element
 pub type MaxReferenceHop = Option<u8>;
 
 /// Variants of GroveDB stored entities
@@ -126,7 +131,7 @@ impl Element {
                     item.len()
                 }
             }
-            Element::Reference(path_reference,_,  element_flag) => {
+            Element::Reference(path_reference, _, element_flag) => {
                 let path_length = path_reference
                     .iter()
                     .map(|inner| inner.len())
@@ -180,10 +185,10 @@ impl Element {
                     })
                     .sum::<usize>()
                     + path_reference.len().required_space()
-                    + 1 // +1 for max_hop_count
                     + flag_len
                     + flag_len.required_space()
-                    + 1 // + 1 for enum
+                    + 1
+                    + 1 // + 1 for enum and +1 for max reference hop
             }
             Element::Tree(_, element_flag) => {
                 let flag_len = if let Some(flag) = element_flag {

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -104,6 +104,21 @@ impl Element {
         Element::Reference(reference_path, None, flags)
     }
 
+    pub fn new_reference_with_hops(
+        reference_path: Vec<Vec<u8>>,
+        max_reference_hop: MaxReferenceHop,
+    ) -> Self {
+        Element::Reference(reference_path, max_reference_hop, None)
+    }
+
+    pub fn new_reference_with_max_hops_and_flags(
+        reference_path: Vec<Vec<u8>>,
+        max_reference_hop: MaxReferenceHop,
+        flags: ElementFlags,
+    ) -> Self {
+        Element::Reference(reference_path, max_reference_hop, flags)
+    }
+
     pub fn new_tree(tree_hash: [u8; 32]) -> Self {
         Element::Tree(tree_hash, None)
     }

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -680,7 +680,7 @@ fn test_too_many_indirections() {
         Element::new_reference(vec![TEST_LEAF.to_vec(), keygen(MAX_REFERENCE_HOPS)]),
         None,
     )
-        .unwrap();
+    .unwrap();
 
     let result = db
         .get([TEST_LEAF], &keygen(MAX_REFERENCE_HOPS + 1), None)

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -642,7 +642,7 @@ fn test_reference_must_point_to_item() {
         )
         .unwrap();
 
-    assert!(matches!(result, Err(Error::PathKeyNotFound(_))));
+    assert!(matches!(result, Err(Error::MissingReference(_))));
 }
 
 #[test]
@@ -672,16 +672,20 @@ fn test_too_many_indirections() {
         .expect("successful reference insert");
     }
 
-    assert!(matches!(
-        db.insert(
-            [TEST_LEAF],
-            &keygen(MAX_REFERENCE_HOPS + 1),
-            Element::new_reference(vec![TEST_LEAF.to_vec(), keygen(MAX_REFERENCE_HOPS)]),
-            None,
-        )
-        .unwrap(),
-        Err(Error::ReferenceLimit)
-    ))
+    // Add one more reference
+    db.insert(
+        [TEST_LEAF],
+        &keygen(MAX_REFERENCE_HOPS + 1),
+        Element::new_reference(vec![TEST_LEAF.to_vec(), keygen(MAX_REFERENCE_HOPS)]),
+        None,
+    )
+        .unwrap();
+
+    let result = db
+        .get([TEST_LEAF], &keygen(MAX_REFERENCE_HOPS + 1), None)
+        .unwrap();
+
+    assert!(matches!(result, Err(Error::ReferenceLimit)));
 }
 
 #[test]

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -472,6 +472,7 @@ fn test_element_with_flags() {
             b"elem4".to_vec(),
             Element::Reference(
                 vec![TEST_LEAF.to_vec(), b"key1".to_vec(), b"elem2".to_vec()],
+                None,
                 Some([9].to_vec())
             )
         )

--- a/grovedb/src/visualize.rs
+++ b/grovedb/src/visualize.rs
@@ -12,7 +12,7 @@ impl Visualize for Element {
                 drawer.write(b"item: ")?;
                 drawer = value.visualize(drawer)?;
             }
-            Element::Reference(_ref, _) => {
+            Element::Reference(_ref, ..) => {
                 drawer.write(b"ref")?;
                 // drawer.write(b"ref: [path: ")?;
                 // let mut path_iter = path.iter();

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -218,8 +218,18 @@ where
 
     /// Gets a hash of a node by a given key, `None` is returned in case
     /// when node not found by the key.
-    pub fn get_hash(&self, key: &[u8]) -> CostContext<Result<Option<[u8; 32]>>> {
+    pub fn get_hash(&self, key: &[u8]) -> CostContext<Result<Option<Hash>>> {
         self.get_node_fn(key, |node| node.hash())
+    }
+
+    /// Gets the value hash of a node by a given key, `None` is returned in case
+    /// when node not found by the key.
+    pub fn get_value_hash(&self, key: &[u8]) -> CostContext<Result<Option<Hash>>> {
+        self.get_node_fn(key, |node| {
+            node.value_hash()
+                .clone()
+                .wrap_with_cost(OperationCost::default())
+        })
     }
 
     /// See if a node's field exists

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -18,7 +18,9 @@ use costs::{
     cost_return_on_error, cost_return_on_error_no_add, CostContext, CostsExt, OperationCost,
 };
 use ed::{Decode, Encode, Terminated};
-pub use hash::{kv_digest_to_kv_hash, kv_hash, node_hash, Hash, HASH_LENGTH, NULL_HASH, value_hash};
+pub use hash::{
+    kv_digest_to_kv_hash, kv_hash, node_hash, value_hash, Hash, HASH_LENGTH, NULL_HASH,
+};
 use kv::KV;
 pub use link::Link;
 pub use ops::{BatchEntry, MerkBatch, Op, PanicSource};

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -18,13 +18,11 @@ use costs::{
     cost_return_on_error, cost_return_on_error_no_add, CostContext, CostsExt, OperationCost,
 };
 use ed::{Decode, Encode, Terminated};
-pub use hash::{kv_digest_to_kv_hash, kv_hash, node_hash, Hash, HASH_LENGTH, NULL_HASH};
+pub use hash::{kv_digest_to_kv_hash, kv_hash, node_hash, Hash, HASH_LENGTH, NULL_HASH, value_hash};
 use kv::KV;
 pub use link::Link;
 pub use ops::{BatchEntry, MerkBatch, Op, PanicSource};
 pub use walk::{Fetch, RefWalker, Walker};
-
-use crate::tree::hash::value_hash;
 
 // TODO: remove need for `TreeInner`, and just use `Box<Self>` receiver for
 // relevant methods

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -3,9 +3,9 @@ use std::{collections::LinkedList, fmt};
 use anyhow::Result;
 use costs::{cost_return_on_error, CostContext, CostsExt, OperationCost};
 use Op::*;
-use crate::{Hash};
 
 use super::{Fetch, Link, Tree, Walker};
+use crate::Hash;
 
 /// Type alias to add more sense to function signatures.
 type DeletedKeys = LinkedList<Vec<u8>>;
@@ -159,10 +159,7 @@ where
                 // TODO: take vec from batch so we don't need to clone
                 Put(value) => self.put_value(value.to_vec()).unwrap_add_cost(&mut cost),
                 PutReference(value, referenced_value) => self
-                    .put_value_and_value_hash(
-                        value.to_vec(),
-                        referenced_value.to_owned(),
-                    )
+                    .put_value_and_value_hash(value.to_vec(), referenced_value.to_owned())
                     .unwrap_add_cost(&mut cost),
                 Delete => {
                     // TODO: we shouldn't have to do this as 2 different calls to apply

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -3,9 +3,9 @@ use std::{collections::LinkedList, fmt};
 use anyhow::Result;
 use costs::{cost_return_on_error, CostContext, CostsExt, OperationCost};
 use Op::*;
+use crate::{Hash};
 
 use super::{Fetch, Link, Tree, Walker};
-use crate::tree::hash::value_hash;
 
 /// Type alias to add more sense to function signatures.
 type DeletedKeys = LinkedList<Vec<u8>>;
@@ -14,7 +14,7 @@ type DeletedKeys = LinkedList<Vec<u8>>;
 #[derive(PartialEq, Eq)]
 pub enum Op {
     Put(Vec<u8>),
-    PutReference(Vec<u8>, Vec<u8>),
+    PutReference(Vec<u8>, Hash),
     Delete,
 }
 
@@ -124,7 +124,7 @@ where
             PutReference(_, referenced_value) => Tree::new_with_value_hash(
                 mid_key.as_ref().to_vec(),
                 mid_value.to_vec(),
-                value_hash(referenced_value).unwrap_add_cost(&mut cost),
+                referenced_value.to_owned(),
             )
             .unwrap_add_cost(&mut cost),
             Delete => unreachable!("cannot get here, should return at the top"),
@@ -161,7 +161,7 @@ where
                 PutReference(value, referenced_value) => self
                     .put_value_and_value_hash(
                         value.to_vec(),
-                        value_hash(referenced_value).unwrap_add_cost(&mut cost),
+                        referenced_value.to_owned(),
                     )
                     .unwrap_add_cost(&mut cost),
                 Delete => {

--- a/node-grove/src/converter.rs
+++ b/node-grove/src/converter.rs
@@ -57,7 +57,7 @@ pub fn element_to_js_object<'a, C: Context<'a>>(
             let js_buffer = JsBuffer::external(cx, item);
             js_buffer.upcast()
         }
-        Element::Reference(reference, _) => nested_vecs_to_js(reference, cx)?,
+        Element::Reference(reference, ..) => nested_vecs_to_js(reference, cx)?,
         Element::Tree(tree, _) => {
             let js_buffer = JsBuffer::external(cx, tree);
             js_buffer.upcast()


### PR DESCRIPTION
For non-batch insert reference 
- Single get call and no node hashing

For batch insert reference
- Clients can specify application-specific max reference hop (allowing worst-case cost to be closer to actual cost)