### PR TITLE
feat: return result during tree decode

### DIFF
--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -631,7 +631,7 @@ where
 fn fetch_node<'db>(db: &impl StorageContext<'db>, key: &[u8]) -> Result<Option<Tree>> {
     let bytes = db.get(key).unwrap()?; // TODO: get_pinned ?
     if let Some(bytes) = bytes {
-        Ok(Some(Tree::decode(key.to_vec(), &bytes)))
+        Ok(Some(Tree::decode(key.to_vec(), &bytes)?))
     } else {
         Ok(None)
     }

--- a/merk/src/merk/restore.rs
+++ b/merk/src/merk/restore.rs
@@ -222,7 +222,7 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
             }
 
             let mut cloned_node =
-                Tree::decode(node.tree().key().to_vec(), node.tree().encode().as_slice());
+                Tree::decode(node.tree().key().to_vec(), node.tree().encode().as_slice())?;
 
             let left_child = node.walk(true).unwrap()?.unwrap();
             let left_child_heights = recurse(left_child, remaining_depth - 1, batch)?;

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -64,11 +64,9 @@ impl Tree {
 
     #[inline]
     pub fn decode(key: Vec<u8>, input: &[u8]) -> ed::Result<Self> {
-        let tree: ed::Result<Self> = Decode::decode(input);
-        tree.map(|mut t| {
-            t.inner.kv.key = key;
-            t
-        })
+        let mut tree: Tree = Decode::decode(input)?;
+        tree.inner.kv.key = key;
+        Ok(tree)
     }
 }
 

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -56,19 +56,19 @@ impl Tree {
     }
 
     #[inline]
-    pub fn decode_into(&mut self, key: Vec<u8>, input: &[u8]) {
-        // operation is infallible so it's ok to unwrap
-        Decode::decode_into(self, input).unwrap();
+    pub fn decode_into(&mut self, key: Vec<u8>, input: &[u8]) -> ed::Result<()>{
+        Decode::decode_into(self, input)?;
         self.inner.kv.key = key;
+        Ok(())
     }
 
     #[inline]
-    pub fn decode(key: Vec<u8>, input: &[u8]) -> Self {
-        // operation is infallible so it's ok to unwrap
-        // TODO: how said that its infallible?
-        let mut tree: Self = Decode::decode(input).unwrap();
-        tree.inner.kv.key = key;
-        tree
+    pub fn decode(key: Vec<u8>, input: &[u8]) -> ed::Result<Self> {
+        let tree: ed::Result<Self> = Decode::decode(input);
+        tree.map(|mut t| {
+            t.inner.kv.key = key;
+            t
+        })
     }
 }
 
@@ -199,7 +199,7 @@ mod tests {
             208, 25, 73, 98, 245, 209, 227, 170, 26, 72, 212, 134, 166, 126, 39, 98, 166, 199, 149,
             144, 21, 1,
         ];
-        let tree = Tree::decode(vec![0], bytes.as_slice());
+        let tree = Tree::decode(vec![0], bytes.as_slice()).expect("should decode correctly");
         assert_eq!(tree.key(), &[0]);
         assert_eq!(tree.value(), &[1]);
     }
@@ -213,7 +213,7 @@ mod tests {
             55, 55, 55, 55, 55, 32, 34, 236, 157, 87, 27, 167, 116, 207, 158, 131, 208, 25, 73, 98,
             245, 209, 227, 170, 26, 72, 212, 134, 166, 126, 39, 98, 166, 199, 149, 144, 21, 1,
         ];
-        let tree = Tree::decode(vec![0], bytes.as_slice());
+        let tree = Tree::decode(vec![0], bytes.as_slice()).expect("should decode correctly");
         assert_eq!(tree.key(), &[0]);
         assert_eq!(tree.value(), &[1]);
         if let Some(Link::Reference {
@@ -234,5 +234,6 @@ mod tests {
     fn decode_invalid_bytes_as_tree() {
         let bytes = vec![2,3,4,5];
         let tree = Tree::decode(vec![0], bytes.as_slice());
+        assert!(matches!(tree, Err(_)));
     }
 }

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -229,4 +229,10 @@ mod tests {
             panic!("Expected Link::Reference");
         }
     }
+
+    #[test]
+    fn decode_invalid_bytes_as_tree() {
+        let bytes = vec![2,3,4,5];
+        let tree = Tree::decode(vec![0], bytes.as_slice());
+    }
 }


### PR DESCRIPTION
Decoding operation would panic if input bytes are invalid, this handles such cases. 