### PR TITLE
feat: populate key value storage cost

### DIFF
--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -137,7 +137,7 @@ impl OperationCost {
         let (key_storage_cost, value_storage_costs) = match storage_cost_info {
             None => (None, None),
             Some(s) => {
-                s.key_storage_cost.verify(key_len)?;
+                // s.key_storage_cost.verify(key_len)?;
                 s.value_storage_cost.verify(value_len)?;
                 (Some(s.key_storage_cost), Some(s.value_storage_cost))
             }

--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -50,8 +50,10 @@ impl StorageCost {
     /// Verify that the len of the item matches the given storage cost
     pub fn verify(&self, len: u32) -> Result<(), Error> {
         let size = self.added_bytes + self.replaced_bytes;
+        dbg!(size);
+        dbg!(len + len.required_space() as u32);
 
-        match size + size.required_space() as u32 == len {
+        match size == len + len.required_space() as u32 {
             true => Ok(()),
             false => Err(Error::StorageCostMismatch),
         }

--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -58,6 +58,16 @@ impl StorageCost {
     }
 }
 
+impl Default for StorageCost {
+    fn default() -> Self {
+        Self {
+            added_bytes: 0,
+            replaced_bytes: 0,
+            removed_bytes: 0,
+        }
+    }
+}
+
 impl OperationCost {
     /// Helper function to build default `OperationCost` with different
     /// `seek_count`.

--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -135,7 +135,7 @@ impl OperationCost {
         let (key_storage_cost, value_storage_costs) = match storage_cost_info {
             None => (None, None),
             Some(s) => {
-                s.key_storage_cost.verify(key_len)?;
+                // s.key_storage_cost.verify(key_len)?;
                 s.value_storage_cost.verify(value_len)?;
                 (Some(s.key_storage_cost), Some(s.value_storage_cost))
             }

--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -50,8 +50,6 @@ impl StorageCost {
     /// Verify that the len of the item matches the given storage cost
     pub fn verify(&self, len: u32) -> Result<(), Error> {
         let size = self.added_bytes + self.replaced_bytes;
-        dbg!(size);
-        dbg!(len + len.required_space() as u32);
 
         match size == len + len.required_space() as u32 {
             true => Ok(()),

--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -150,7 +150,8 @@ impl OperationCost {
         let (key_storage_cost, value_storage_costs) = match storage_cost_info {
             None => (None, None),
             Some(s) => {
-                s.key_storage_cost.verify_key_storage_cost(key_len, s.new_node)?;
+                s.key_storage_cost
+                    .verify_key_storage_cost(key_len, s.new_node)?;
                 s.value_storage_cost.verify(value_len)?;
                 (Some(s.key_storage_cost), Some(s.value_storage_cost))
             }

--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -137,7 +137,7 @@ impl OperationCost {
         let (key_storage_cost, value_storage_costs) = match storage_cost_info {
             None => (None, None),
             Some(s) => {
-                // s.key_storage_cost.verify(key_len)?;
+                s.key_storage_cost.verify(key_len)?;
                 s.value_storage_cost.verify(value_len)?;
                 (Some(s.key_storage_cost), Some(s.value_storage_cost))
             }

--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -34,6 +34,8 @@ pub struct KeyValueStorageCost {
     pub key_storage_cost: StorageCost,
     /// Value storage costs
     pub value_storage_cost: StorageCost,
+    /// New Node
+    pub new_node: bool,
 }
 
 /// Storage only Operation Costs

--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -34,7 +34,7 @@ pub struct KeyValueStorageCost {
     pub key_storage_cost: StorageCost,
     /// Value storage costs
     pub value_storage_cost: StorageCost,
-    /// New Node
+    /// Is this a new node
     pub new_node: bool,
 }
 

--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -52,8 +52,6 @@ impl StorageCost {
     /// Verify that the len of the item matches the given storage cost
     pub fn verify(&self, len: u32) -> Result<(), Error> {
         let size = self.added_bytes + self.replaced_bytes;
-        dbg!(size);
-        dbg!(len + len.required_space() as u32);
 
         match size == len + len.required_space() as u32 {
             true => Ok(()),
@@ -64,7 +62,6 @@ impl StorageCost {
     /// Verifies the len of a key item only if the node is new
     /// doesn't need to verify for the update case since the key never changes
     pub fn verify_key_storage_cost(&self, len: u32, new_node: bool) -> Result<(), Error> {
-        dbg!(new_node);
         if new_node {
             self.verify(len)
         } else {

--- a/grovedb/src/subtree.rs
+++ b/grovedb/src/subtree.rs
@@ -1040,7 +1040,7 @@ pub struct ElementsIterator<I: RawIterator> {
 }
 
 pub fn raw_decode(bytes: &[u8]) -> Result<Element, Error> {
-    let tree = Tree::decode_raw(bytes).map_err(|e| Error::CorruptedData(e.to_string()))?;
+    let tree = Tree::decode_raw(bytes, vec![]).map_err(|e| Error::CorruptedData(e.to_string()))?;
     let element: Element = Element::deserialize(tree.value())?;
     Ok(element)
 }

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -396,38 +396,6 @@ fn test_insert_value_to_subtree() {
 }
 
 #[test]
-fn test_update_value_in_subtree() {
-    let tmp_dir = TempDir::new().unwrap();
-    let mut db = GroveDb::open(tmp_dir.path()).unwrap();
-    add_test_leaves(&mut db);
-
-    let element = Element::new_item(b"ayy".to_vec());
-    let element2 = Element::new_item(b"byy".to_vec());
-
-    // Insert a subtree first
-    db.insert([TEST_LEAF], b"key1", Element::empty_tree(), None)
-        .unwrap()
-        .expect("successful subtree insert");
-    // Insert an element into subtree
-    db.insert([TEST_LEAF, b"key1"], b"key2", element.clone(), None)
-        .unwrap()
-        .expect("successful value insert");
-
-    // Reopen db
-    drop(db);
-    let mut db = GroveDb::open(tmp_dir.path()).unwrap();
-    db.insert([TEST_LEAF, b"key1"], b"key2", element2.clone(), None)
-        .unwrap()
-        .expect("successful value insert");
-    assert_eq!(
-        db.get([TEST_LEAF, b"key1"], b"key2", None)
-            .unwrap()
-            .expect("successful get"),
-        element2
-    );
-}
-
-#[test]
 fn test_element_with_flags() {
     let db = make_test_grovedb();
 

--- a/grovedb/src/tests.rs
+++ b/grovedb/src/tests.rs
@@ -396,6 +396,38 @@ fn test_insert_value_to_subtree() {
 }
 
 #[test]
+fn test_update_value_in_subtree() {
+    let tmp_dir = TempDir::new().unwrap();
+    let mut db = GroveDb::open(tmp_dir.path()).unwrap();
+    add_test_leaves(&mut db);
+
+    let element = Element::new_item(b"ayy".to_vec());
+    let element2 = Element::new_item(b"byy".to_vec());
+
+    // Insert a subtree first
+    db.insert([TEST_LEAF], b"key1", Element::empty_tree(), None)
+        .unwrap()
+        .expect("successful subtree insert");
+    // Insert an element into subtree
+    db.insert([TEST_LEAF, b"key1"], b"key2", element.clone(), None)
+        .unwrap()
+        .expect("successful value insert");
+
+    // Reopen db
+    drop(db);
+    let mut db = GroveDb::open(tmp_dir.path()).unwrap();
+    db.insert([TEST_LEAF, b"key1"], b"key2", element2.clone(), None)
+        .unwrap()
+        .expect("successful value insert");
+    assert_eq!(
+        db.get([TEST_LEAF, b"key1"], b"key2", None)
+            .unwrap()
+            .expect("successful get"),
+        element2
+    );
+}
+
+#[test]
 fn test_element_with_flags() {
     let db = make_test_grovedb();
 

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -550,7 +550,7 @@ where
                 cost_return_on_error_no_add!(
                     &cost,
                     batch.put(&key, &value, maybe_cost).map_err(|e| e.into())
-                ); // todo: fix the None asap
+                );
             } else {
                 batch.delete(&key);
             }

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -735,11 +735,11 @@ impl Commit for MerkCommitter {
         } else if current_tree_size > tree.decode_size {
             // updating an existing tree, but would need more storage
             value_storage_cost.replaced_bytes += tree.decode_size as u32;
-            value_storage_cost.added_bytes += (tree.decode_size - current_tree_size) as u32;
+            value_storage_cost.added_bytes += (current_tree_size - tree.decode_size) as u32;
         } else {
-            // decode_size < tree_size, updating an existing tree but freed storage
+            // decode_size > tree_size, updating an existing tree but freed storage
             value_storage_cost.replaced_bytes += current_tree_size as u32;
-            value_storage_cost.removed_bytes += (current_tree_size - tree.decode_size) as u32;
+            value_storage_cost.removed_bytes += (tree.decode_size - current_tree_size) as u32;
         }
 
         let key_value_storage_cost = KeyValueStorageCost {

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -743,7 +743,7 @@ impl Commit for MerkCommitter {
                 value_storage_cost.removed_bytes += (tree.old_size - current_tree_size) as u32;
             }
             Ordering::Less => {
-                // current size is greater then old size, storage will be created
+                // current size is greater than old size, storage will be created
                 // this also handles the case where the tree.old_size = 0
                 value_storage_cost.replaced_bytes += tree.old_size as u32;
                 value_storage_cost.added_bytes += (current_tree_size - tree.old_size) as u32;

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -753,7 +753,7 @@ impl Commit for MerkCommitter {
         let key_value_storage_cost = KeyValueStorageCost {
             key_storage_cost,
             value_storage_cost,
-            new_node: tree.old_size == 0
+            new_node: tree.old_size == 0,
         };
 
         // Update old tree size after generating storage cost

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -732,6 +732,10 @@ impl Commit for MerkCommitter {
             ..Default::default()
         };
 
+        // TODO: WIP
+        // match tree.old_size.cmp(&current_tree_size) {
+        //     Ordering::Greater
+        // }
         // Update the value storage cost
         if tree.old_size == 0 {
             // new node, storage has to be created for entire tree

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -753,6 +753,7 @@ impl Commit for MerkCommitter {
         let key_value_storage_cost = KeyValueStorageCost {
             key_storage_cost,
             value_storage_cost,
+            new_node: tree.old_size == 0
         };
 
         // Update old tree size after generating storage cost

--- a/merk/src/tree/commit.rs
+++ b/merk/src/tree/commit.rs
@@ -7,7 +7,7 @@ use super::Tree;
 pub trait Commit {
     /// Called once per updated node when a finalized tree is to be written to a
     /// backing store or cache.
-    fn write(&mut self, tree: &Tree) -> Result<()>;
+    fn write(&mut self, tree: &mut Tree) -> Result<()>;
 
     /// Called once per node after writing a node and its children. The returned
     /// tuple specifies whether or not to prune the left and right child nodes,
@@ -22,7 +22,7 @@ pub trait Commit {
 /// any nodes from the Tree. Useful when only keeping a tree in memory.
 pub struct NoopCommit {}
 impl Commit for NoopCommit {
-    fn write(&mut self, _tree: &Tree) -> Result<()> {
+    fn write(&mut self, _tree: &mut Tree) -> Result<()> {
         Ok(())
     }
 

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -29,13 +29,7 @@ impl Tree {
                 .transpose()
         );
 
-        Ok(if let Some(mut tree) = tree_opt {
-            tree.set_key(key.as_ref().to_vec());
-            Some(tree)
-        } else {
-            None
-        })
-        .wrap_with_cost(cost)
+        Ok(tree_opt).wrap_with_cost(cost)
     }
 }
 

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -68,9 +68,10 @@ impl Tree {
 
     #[inline]
     pub fn decode(key: Vec<u8>, input: &[u8]) -> ed::Result<Self> {
+        let decode_size = input.len();
         let mut tree_inner: TreeInner = Decode::decode(input)?;
         tree_inner.kv.key = key;
-        Ok(Tree::new_with_tree_inner(tree_inner))
+        Ok(Tree::new_with_tree_inner(tree_inner, decode_size))
     }
 }
 

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -66,8 +66,6 @@ impl Tree {
 
     #[inline]
     pub fn decode(key: Vec<u8>, input: &[u8]) -> ed::Result<Self> {
-        // operation is infallible so it's ok to unwrap
-        // TODO: how said that its infallible?
         let mut tree_inner: TreeInner = Decode::decode(input)?;
         tree_inner.kv.key = key;
         Ok(Tree::new_with_tree_inner(tree_inner))

--- a/merk/src/tree/encoding.rs
+++ b/merk/src/tree/encoding.rs
@@ -4,6 +4,7 @@ use costs::{
 };
 use ed::{Decode, Encode};
 use storage::StorageContext;
+use crate::tree::TreeInner;
 
 use super::Tree;
 
@@ -40,35 +41,36 @@ impl Tree {
     #[inline]
     pub fn encode(&self) -> Vec<u8> {
         // operation is infallible so it's ok to unwrap
-        Encode::encode(self).unwrap()
+        Encode::encode(&self.inner).unwrap()
     }
 
     #[inline]
     pub fn encode_into(&self, dest: &mut Vec<u8>) {
         // operation is infallible so it's ok to unwrap
-        Encode::encode_into(self, dest).unwrap()
+        Encode::encode_into(&self.inner, dest).unwrap()
     }
 
     #[inline]
     pub fn encoding_length(&self) -> usize {
         // operation is infallible so it's ok to unwrap
-        Encode::encoding_length(self).unwrap()
+        Encode::encoding_length(&self.inner).unwrap()
     }
 
     #[inline]
     pub fn decode_into(&mut self, key: Vec<u8>, input: &[u8]) {
         // operation is infallible so it's ok to unwrap
-        Decode::decode_into(self, input).unwrap();
-        self.inner.kv.key = key;
+        let mut tree_inner: TreeInner = Decode::decode(input).unwrap();
+        tree_inner.kv.key = key;
+        self.inner = Box::new(tree_inner);
     }
 
     #[inline]
     pub fn decode(key: Vec<u8>, input: &[u8]) -> Self {
         // operation is infallible so it's ok to unwrap
         // TODO: how said that its infallible?
-        let mut tree: Self = Decode::decode(input).unwrap();
-        tree.inner.kv.key = key;
-        tree
+        let mut tree_inner: TreeInner = Decode::decode(input).unwrap();
+        tree_inner.kv.key = key;
+        Tree::new_with_tree_inner(tree_inner)
     }
 }
 

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -51,7 +51,7 @@ impl Terminated for Box<TreeInner> {}
 #[derive(Clone)]
 pub struct Tree {
     inner: Box<TreeInner>,
-    decode_size: usize,
+    pub(crate) decode_size: usize,
 }
 
 impl Tree {

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -52,7 +52,7 @@ impl Terminated for Box<TreeInner> {}
 #[derive(Clone)]
 pub struct Tree {
     inner: Box<TreeInner>,
-    pub(crate) decode_size: usize,
+    pub(crate) old_size: usize,
 }
 
 impl Tree {
@@ -66,7 +66,7 @@ impl Tree {
                 left: None,
                 right: None,
             }),
-            decode_size: 0,
+            old_size: 0,
         })
     }
 
@@ -75,7 +75,7 @@ impl Tree {
         Self {
             inner: Box::new(inner_tree),
             // TODO: figure out why adding the required space for this doesn't affect the tests
-            decode_size,
+            old_size: decode_size + decode_size.required_space(),
         }
     }
 
@@ -94,7 +94,7 @@ impl Tree {
                 left: None,
                 right: None,
             }),
-            decode_size: 0,
+            old_size: 0,
         })
     }
 
@@ -113,7 +113,7 @@ impl Tree {
                 left,
                 right,
             }),
-            decode_size: 0,
+            old_size: 0,
         })
     }
 

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -70,10 +70,10 @@ impl Tree {
     }
 
     /// Creates a new `Tree` given an inner tree
-    pub fn new_with_tree_inner(inner_tree: TreeInner) -> Self {
+    pub fn new_with_tree_inner(inner_tree: TreeInner, decode_size: usize) -> Self {
         Self {
             inner: Box::new(inner_tree),
-            decode_size: 0,
+            decode_size,
         }
     }
 

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -10,8 +10,10 @@ mod link;
 mod ops;
 mod walk;
 
-use std::cmp::max;
-use std::io::{Read, Write};
+use std::{
+    cmp::max,
+    io::{Read, Write},
+};
 
 use anyhow::Result;
 pub use commit::{Commit, NoopCommit};
@@ -33,7 +35,7 @@ pub use walk::{Fetch, RefWalker, Walker};
 
 /// The fields of the `Tree` type, stored on the heap.
 #[derive(Clone, Encode, Decode)]
-struct TreeInner {
+pub struct TreeInner {
     left: Option<Link>,
     right: Option<Link>,
     kv: KV,
@@ -84,7 +86,7 @@ impl Tree {
     /// Creates a new `Tree` given an inner tree
     pub fn new_with_tree_inner(inner_tree: TreeInner) -> Self {
         Self {
-            inner: Box::new(inner_tree)
+            inner: Box::new(inner_tree),
         }
     }
 

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -25,6 +25,7 @@ pub use hash::{
     kv_digest_to_kv_hash, kv_hash, node_hash, value_hash, CryptoHash, HASH_BLOCK_SIZE, HASH_LENGTH,
     HASH_LENGTH_U32, NULL_HASH,
 };
+use integer_encoding::VarInt;
 use kv::KV;
 pub use link::Link;
 pub use ops::{BatchEntry, MerkBatch, Op, PanicSource};

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -74,6 +74,7 @@ impl Tree {
     pub fn new_with_tree_inner(inner_tree: TreeInner, decode_size: usize) -> Self {
         Self {
             inner: Box::new(inner_tree),
+            // TODO: figure out why adding the required space for this doesn't affect the tests
             decode_size,
         }
     }

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -10,10 +10,7 @@ mod link;
 mod ops;
 mod walk;
 
-use std::{
-    cmp::max,
-    io::{Read, Write},
-};
+use std::cmp::max;
 
 use anyhow::Result;
 pub use commit::{Commit, NoopCommit};

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -11,6 +11,7 @@ mod ops;
 mod walk;
 
 use std::cmp::max;
+use std::io::{Read, Write};
 
 use anyhow::Result;
 pub use commit::{Commit, NoopCommit};
@@ -45,10 +46,26 @@ impl Terminated for Box<TreeInner> {}
 /// Trees' inner fields are stored on the heap so that nodes can recursively
 /// link to each other, and so we can detach nodes from their parents, then
 /// reattach without allocating or freeing heap memory.
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone)]
 pub struct Tree {
     inner: Box<TreeInner>,
 }
+
+// impl Encode for Tree {
+//     fn encode_into<W: Write>(&self, dest: &mut W) -> ed::Result<()> {
+//         Encode::encode_into(&self.inner, dest)
+//     }
+//
+//     fn encoding_length(&self) -> ed::Result<usize> {
+//         Encode::encoding_length(&self.inner)
+//     }
+// }
+//
+// impl Decode for Tree {
+//     fn decode<R: Read>(input: R) -> ed::Result<Self> {
+//         Decode::decode(input)
+//     }
+// }
 
 impl Tree {
     /// Creates a new `Tree` with the given key and value, and no children.
@@ -62,6 +79,13 @@ impl Tree {
                 right: None,
             }),
         })
+    }
+
+    /// Creates a new `Tree` given an inner tree
+    pub fn new_with_tree_inner(inner_tree: TreeInner) -> Self {
+        Self {
+            inner: Box::new(inner_tree)
+        }
     }
 
     /// Creates a new `Tree` with the given key, value and value hash, and no

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -51,23 +51,8 @@ impl Terminated for Box<TreeInner> {}
 #[derive(Clone)]
 pub struct Tree {
     inner: Box<TreeInner>,
+    decode_size: usize,
 }
-
-// impl Encode for Tree {
-//     fn encode_into<W: Write>(&self, dest: &mut W) -> ed::Result<()> {
-//         Encode::encode_into(&self.inner, dest)
-//     }
-//
-//     fn encoding_length(&self) -> ed::Result<usize> {
-//         Encode::encoding_length(&self.inner)
-//     }
-// }
-//
-// impl Decode for Tree {
-//     fn decode<R: Read>(input: R) -> ed::Result<Self> {
-//         Decode::decode(input)
-//     }
-// }
 
 impl Tree {
     /// Creates a new `Tree` with the given key and value, and no children.
@@ -80,6 +65,7 @@ impl Tree {
                 left: None,
                 right: None,
             }),
+            decode_size: 0,
         })
     }
 
@@ -87,6 +73,7 @@ impl Tree {
     pub fn new_with_tree_inner(inner_tree: TreeInner) -> Self {
         Self {
             inner: Box::new(inner_tree),
+            decode_size: 0,
         }
     }
 
@@ -105,6 +92,7 @@ impl Tree {
                 left: None,
                 right: None,
             }),
+            decode_size: 0,
         })
     }
 
@@ -123,6 +111,7 @@ impl Tree {
                 left,
                 right,
             }),
+            decode_size: 0,
         })
     }
 

--- a/storage/src/rocksdb_storage/storage_context/batch.rs
+++ b/storage/src/rocksdb_storage/storage_context/batch.rs
@@ -98,9 +98,9 @@ impl<'db> Batch for PrefixedRocksDbBatch<'db> {
         value: &[u8],
         cost_info: Option<KeyValueStorageCost>,
     ) -> Result<(), costs::error::Error> {
-        // We prefix the key, we need to update the key value storage cost
         let prefixed_key = make_prefixed_key(self.prefix.clone(), key);
 
+        // Update the key_storage_cost based on the prefixed key
         let updated_cost_info = cost_info.map(|mut key_value_storage_cost| {
             if key_value_storage_cost.new_node {
                 // key is new, storage needs to be created for it

--- a/storage/src/rocksdb_storage/storage_context/batch.rs
+++ b/storage/src/rocksdb_storage/storage_context/batch.rs
@@ -196,7 +196,6 @@ impl Batch for PrefixedMultiContextBatchPart {
         value: &[u8],
         cost_info: Option<KeyValueStorageCost>,
     ) -> Result<(), costs::error::Error> {
-
         let prefixed_key = make_prefixed_key(self.prefix.clone(), key);
 
         // Update the key_storage_cost based on the prefixed key
@@ -210,11 +209,7 @@ impl Batch for PrefixedMultiContextBatchPart {
         });
 
         self.batch
-            .put(
-                prefixed_key,
-                value.to_vec(),
-                updated_cost_info,
-            )
+            .put(prefixed_key, value.to_vec(), updated_cost_info)
             .unwrap_add_cost(&mut self.acc_cost);
         Ok(())
     }


### PR DESCRIPTION
For better cost UX, written storage cost should be split into added_storage, replaced_storage and removed_storage
where replaced_storage is much less than added_storage.
This PR modifies merk to return the information needed to compute the added, replaced and removed storage