### PR TITLE
feat: add reference value to state

### DIFF
--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -373,12 +373,11 @@ impl GroveDb {
                                 &mut cost,
                                 self.follow_reference(absolute_path, None)
                             );
-                            *node = Node::KVValueRefHash(
+                            *node = Node::KVRefValueHash(
                                 key.to_owned(),
-                                value.to_owned(),
                                 // TODO: remove unwrap
-                                value_hash(&referenced_elem.serialize().unwrap())
-                                    .unwrap_add_cost(&mut cost),
+                                referenced_elem.serialize().unwrap(),
+                                value_hash(value).unwrap_add_cost(&mut cost)
                             )
                         }
                     }

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -3,6 +3,7 @@ use costs::{
 };
 use merk::{
     proofs::{encode_into, Node, Op},
+    tree::value_hash,
     KVIterator, Merk, ProofWithoutEncodingResult,
 };
 use storage::{rocksdb_storage::PrefixedRocksDbStorageContext, Storage, StorageContext};
@@ -372,7 +373,13 @@ impl GroveDb {
                                 &mut cost,
                                 self.follow_reference(absolute_path, None)
                             );
-                            *value = referenced_elem.serialize().unwrap();
+                            *node = Node::KVValueRefHash(
+                                key.to_owned(),
+                                value.to_owned(),
+                                // TODO: remove unwrap
+                                value_hash(&referenced_elem.serialize().unwrap())
+                                    .unwrap_add_cost(&mut cost),
+                            )
                         }
                     }
                     _ => continue,

--- a/grovedb/src/reference_path.rs
+++ b/grovedb/src/reference_path.rs
@@ -11,20 +11,24 @@ use crate::Error;
 pub enum ReferencePathType {
     /// Holds the absolute path to the element the reference points to
     AbsolutePathReference(Vec<Vec<u8>>),
+
     /// This takes the first n elements from the current path and appends a new
     /// path to the subpath. If current path is [a, b, c, d] and we take the
     /// first 2 elements, subpath = [a, b] we can then append some other
     /// path [p, q] result = [a, b, p, q]
     UpstreamRootHeightReference(u8, Vec<Vec<u8>>),
+
     /// This discards the last n elements from the current path and appends a
     /// new path to the subpath. If current path is [a, b, c, d] and we
     /// discard the last element, subpath = [a, b, c] we can then append
     /// some other path [p, q] result = [a, b, c, p, q]
     UpstreamFromElementHeightReference(u8, Vec<Vec<u8>>),
+
     /// This swaps the immediate parent of the stored path with a provided key,
     /// retaining the key value. e.g. current path = [a, b, m, d] you can use
     /// the cousin reference to swap m with c to get [a, b, c, d]
     CousinReference(Vec<u8>),
+
     /// This swaps the key with a new value, you use this to point to an element
     /// in the same tree.
     SiblingReference(Vec<u8>),

--- a/merk/src/proofs/chunk.rs
+++ b/merk/src/proofs/chunk.rs
@@ -341,7 +341,7 @@ mod tests {
                 Node::KV(..) => counts.kv += 1,
                 Node::KVValueHash(..) => counts.kvvaluehash += 1,
                 Node::KVDigest(..) => counts.kvdigest += 1,
-                Node::KVValueRefHash(..) => counts.kvvaluerefhash += 1,
+                Node::KVRefValueHash(..) => counts.kvvaluerefhash += 1,
             };
         });
 

--- a/merk/src/proofs/chunk.rs
+++ b/merk/src/proofs/chunk.rs
@@ -328,6 +328,7 @@ mod tests {
         kv: usize,
         kvvaluehash: usize,
         kvdigest: usize,
+        kvvaluerefhash: usize,
     }
 
     fn count_node_types(tree: Tree) -> NodeCounts {
@@ -340,6 +341,7 @@ mod tests {
                 Node::KV(..) => counts.kv += 1,
                 Node::KVValueHash(..) => counts.kvvaluehash += 1,
                 Node::KVDigest(..) => counts.kvdigest += 1,
+                Node::KVValueRefHash(..) => counts.kvvaluerefhash += 1,
             };
         });
 

--- a/merk/src/proofs/encoding.rs
+++ b/merk/src/proofs/encoding.rs
@@ -44,7 +44,7 @@ impl Encode for Op {
                 dest.write_all(key)?;
                 dest.write_all(value_hash)?;
             }
-            Op::Push(Node::KVValueRefHash(key, value, value_hash)) => {
+            Op::Push(Node::KVRefValueHash(key, value, value_hash)) => {
                 debug_assert!(key.len() < 256);
                 debug_assert!(value.len() < 65536);
 
@@ -90,7 +90,7 @@ impl Encode for Op {
                 dest.write_all(key)?;
                 dest.write_all(value_hash)?;
             }
-            Op::PushInverted(Node::KVValueRefHash(key, value, value_hash)) => {
+            Op::PushInverted(Node::KVRefValueHash(key, value, value_hash)) => {
                 debug_assert!(key.len() < 256);
                 debug_assert!(value.len() < 65536);
 
@@ -116,7 +116,7 @@ impl Encode for Op {
             Op::Push(Node::KVDigest(key, _)) => 2 + key.len() + HASH_LENGTH,
             Op::Push(Node::KV(key, value)) => 4 + key.len() + value.len(),
             Op::Push(Node::KVValueHash(key, value, _)) => 4 + key.len() + value.len() + HASH_LENGTH,
-            Op::Push(Node::KVValueRefHash(key, value, _)) => {
+            Op::Push(Node::KVRefValueHash(key, value, _)) => {
                 4 + key.len() + value.len() + HASH_LENGTH
             }
             Op::PushInverted(Node::Hash(_)) => 1 + HASH_LENGTH,
@@ -126,7 +126,7 @@ impl Encode for Op {
             Op::PushInverted(Node::KVValueHash(key, value, _)) => {
                 4 + key.len() + value.len() + HASH_LENGTH
             }
-            Op::PushInverted(Node::KVValueRefHash(key, value, _)) => {
+            Op::PushInverted(Node::KVRefValueHash(key, value, _)) => {
                 4 + key.len() + value.len() + HASH_LENGTH
             }
             Op::Parent => 1,
@@ -199,7 +199,7 @@ impl Decode for Op {
                 let mut value_hash = [0; HASH_LENGTH];
                 input.read_exact(&mut value_hash)?;
 
-                Self::Push(Node::KVValueRefHash(key, value, value_hash))
+                Self::Push(Node::KVRefValueHash(key, value, value_hash))
             }
             0x08 => {
                 let mut hash = [0; HASH_LENGTH];
@@ -258,7 +258,7 @@ impl Decode for Op {
                 let mut value_hash = [0; HASH_LENGTH];
                 input.read_exact(&mut value_hash)?;
 
-                Self::Push(Node::KVValueRefHash(key, value, value_hash))
+                Self::Push(Node::KVRefValueHash(key, value, value_hash))
             }
             0x10 => Self::Parent,
             0x11 => Self::Child,
@@ -423,7 +423,7 @@ mod test {
 
     #[test]
     fn encode_push_kvvaluerefhash() {
-        let op = Op::Push(Node::KVValueRefHash(vec![1, 2, 3], vec![4, 5, 6], [0; 32]));
+        let op = Op::Push(Node::KVRefValueHash(vec![1, 2, 3], vec![4, 5, 6], [0; 32]));
         assert_eq!(op.encoding_length(), 42);
 
         let mut bytes = vec![];
@@ -516,7 +516,7 @@ mod test {
 
     #[test]
     fn encode_push_inverted_kvvaluerefhash() {
-        let op = Op::PushInverted(Node::KVValueRefHash(vec![1, 2, 3], vec![4, 5, 6], [0; 32]));
+        let op = Op::PushInverted(Node::KVRefValueHash(vec![1, 2, 3], vec![4, 5, 6], [0; 32]));
         assert_eq!(op.encoding_length(), 42);
 
         let mut bytes = vec![];
@@ -641,7 +641,7 @@ mod test {
         let op = Op::decode(&bytes[..]).expect("decode failed");
         assert_eq!(
             op,
-            Op::Push(Node::KVValueRefHash(vec![1, 2, 3], vec![4, 5, 6], [0; 32]))
+            Op::Push(Node::KVRefValueHash(vec![1, 2, 3], vec![4, 5, 6], [0; 32]))
         );
     }
 
@@ -708,7 +708,7 @@ mod test {
         let op = Op::decode(&bytes[..]).expect("decode failed");
         assert_eq!(
             op,
-            Op::Push(Node::KVValueRefHash(vec![1, 2, 3], vec![4, 5, 6], [0; 32]))
+            Op::Push(Node::KVRefValueHash(vec![1, 2, 3], vec![4, 5, 6], [0; 32]))
         );
     }
 

--- a/merk/src/proofs/mod.rs
+++ b/merk/src/proofs/mod.rs
@@ -60,6 +60,6 @@ pub enum Node {
     /// Represents the key, value and value_hash of a tree node
     KVValueHash(Vec<u8>, Vec<u8>, Hash),
 
-    /// Represents the key, value and value hash of some referenced node
-    KVValueRefHash(Vec<u8>, Vec<u8>, Hash),
+    /// Represents the key, value of some referenced node and value_hash of current tree node
+    KVRefValueHash(Vec<u8>, Vec<u8>, Hash),
 }

--- a/merk/src/proofs/mod.rs
+++ b/merk/src/proofs/mod.rs
@@ -59,4 +59,7 @@ pub enum Node {
 
     /// Represents the key, value and value_hash of a tree node
     KVValueHash(Vec<u8>, Vec<u8>, Hash),
+
+    /// Represents the key, value and value hash of some referenced node
+    KVValueRefHash(Vec<u8>, Vec<u8>, Hash),
 }

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1181,6 +1181,8 @@ pub fn execute_proof(
                             // is lower than the bound
                             Some(Node::KV(..)) => {}
                             Some(Node::KVDigest(..)) => {}
+                            Some(Node::KVValueHash(..)) => {}
+                            Some(Node::KVValueRefHash(..)) => {}
 
                             // cannot verify lower bound - we have an abridged
                             // tree so we cannot tell what the preceding key was
@@ -1205,6 +1207,8 @@ pub fn execute_proof(
                             // is greater than the bound
                             Some(Node::KV(..)) => {}
                             Some(Node::KVDigest(..)) => {}
+                            Some(Node::KVValueHash(..)) => {}
+                            Some(Node::KVValueRefHash(..)) => {}
 
                             // cannot verify upper bound - we have an abridged
                             // tree so we cannot tell what the previous key was
@@ -1290,6 +1294,10 @@ pub fn execute_proof(
             execute_node(key, Some(value))?;
         } else if let Node::KVDigest(key, _) = node {
             execute_node(key, None)?;
+        } else if let Node::KVValueHash(key, value, _) = node {
+            execute_node(key, Some(value))?;
+        } else if let Node::KVValueRefHash(key, value, _) = node {
+            execute_node(key, Some(value))?;
         } else if in_range {
             // we encountered a queried range but the proof was abridged (saw a
             // non-KV push), we are missing some part of the range
@@ -1312,6 +1320,8 @@ pub fn execute_proof(
                 // last node in tree was less than queried item
                 Some(Node::KV(..)) => {}
                 Some(Node::KVDigest(..)) => {}
+                Some(Node::KVValueHash(..)) => {}
+                Some(Node::KVValueRefHash(..)) => {}
 
                 // proof contains abridged data so we cannot verify absence of
                 // remaining query items

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -1182,7 +1182,7 @@ pub fn execute_proof(
                             Some(Node::KV(..)) => {}
                             Some(Node::KVDigest(..)) => {}
                             Some(Node::KVValueHash(..)) => {}
-                            Some(Node::KVValueRefHash(..)) => {}
+                            Some(Node::KVRefValueHash(..)) => {}
 
                             // cannot verify lower bound - we have an abridged
                             // tree so we cannot tell what the preceding key was
@@ -1208,7 +1208,7 @@ pub fn execute_proof(
                             Some(Node::KV(..)) => {}
                             Some(Node::KVDigest(..)) => {}
                             Some(Node::KVValueHash(..)) => {}
-                            Some(Node::KVValueRefHash(..)) => {}
+                            Some(Node::KVRefValueHash(..)) => {}
 
                             // cannot verify upper bound - we have an abridged
                             // tree so we cannot tell what the previous key was
@@ -1296,7 +1296,7 @@ pub fn execute_proof(
             execute_node(key, None)?;
         } else if let Node::KVValueHash(key, value, _) = node {
             execute_node(key, Some(value))?;
-        } else if let Node::KVValueRefHash(key, value, _) = node {
+        } else if let Node::KVRefValueHash(key, value, _) = node {
             execute_node(key, Some(value))?;
         } else if in_range {
             // we encountered a queried range but the proof was abridged (saw a
@@ -1321,7 +1321,7 @@ pub fn execute_proof(
                 Some(Node::KV(..)) => {}
                 Some(Node::KVDigest(..)) => {}
                 Some(Node::KVValueHash(..)) => {}
-                Some(Node::KVValueRefHash(..)) => {}
+                Some(Node::KVRefValueHash(..)) => {}
 
                 // proof contains abridged data so we cannot verify absence of
                 // remaining query items

--- a/merk/src/proofs/tree.rs
+++ b/merk/src/proofs/tree.rs
@@ -169,7 +169,9 @@ impl Tree {
 
     pub(crate) fn key(&self) -> &[u8] {
         match self.node {
-            Node::KV(ref key, _) | Node::KVValueHash(ref key, ..) => key,
+            Node::KV(ref key, _)
+            | Node::KVValueHash(ref key, ..)
+            | Node::KVValueRefHash(ref key, ..) => key,
             _ => panic!("Expected node to be type KV"),
         }
     }
@@ -348,7 +350,10 @@ where
                 stack.push(parent);
             }
             Op::Push(node) => {
-                if let Node::KV(key, _) | Node::KVValueHash(key, ..) = &node {
+                if let Node::KV(key, _)
+                | Node::KVValueHash(key, ..)
+                | Node::KVValueRefHash(key, ..) = &node
+                {
                     // keys should always increase
                     if let Some(last_key) = &maybe_last_key {
                         if key <= last_key {
@@ -365,7 +370,10 @@ where
                 stack.push(tree);
             }
             Op::PushInverted(node) => {
-                if let Node::KV(key, _) | Node::KVValueHash(key, ..) = &node {
+                if let Node::KV(key, _)
+                | Node::KVValueHash(key, ..)
+                | Node::KVValueRefHash(key, ..) = &node
+                {
                     // keys should always increase
                     if let Some(last_key) = &maybe_last_key {
                         if key >= last_key {

--- a/merk/src/tree/hash.rs
+++ b/merk/src/tree/hash.rs
@@ -88,3 +88,18 @@ pub fn node_hash(kv: &Hash, left: &Hash, right: &Hash) -> CostContext<Hash> {
         ..Default::default()
     })
 }
+
+/// Combines two hash values into one
+pub fn combine_hash(hash_one: &Hash, hash_two: &Hash) -> CostContext<Hash> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(hash_one);
+    hasher.update(hash_two);
+
+    let res = hasher.finalize();
+    let mut hash: Hash = Default::default();
+    hash.copy_from_slice(res.as_bytes());
+    hash.wrap_with_cost(OperationCost {
+        hash_node_calls: 1,
+        ..Default::default()
+    })
+}

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -19,7 +19,8 @@ use costs::{
 };
 use ed::{Decode, Encode, Terminated};
 pub use hash::{
-    kv_digest_to_kv_hash, kv_hash, node_hash, value_hash, Hash, HASH_LENGTH, NULL_HASH,
+    combine_hash, kv_digest_to_kv_hash, kv_hash, node_hash, value_hash, Hash, HASH_LENGTH,
+    NULL_HASH,
 };
 use kv::KV;
 pub use link::Link;

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -81,6 +81,23 @@ impl Tree {
         })
     }
 
+    /// Creates a new `Tree` with the given key, value and value hash, and no
+    /// children.
+    /// Sets the tree's value_hash = hash(value, supplied_value_hash)
+    pub fn new_with_combined_value_hash(
+        key: Vec<u8>,
+        value: Vec<u8>,
+        value_hash: Hash,
+    ) -> CostContext<Self> {
+        KV::new_with_combined_value_hash(key, value, value_hash).map(|kv| Self {
+            inner: Box::new(TreeInner {
+                kv,
+                left: None,
+                right: None,
+            }),
+        })
+    }
+
     /// Creates a `Tree` by supplying all the raw struct fields (mainly useful
     /// for testing). The `kv_hash` and `Link`s are not ensured to be correct.
     pub fn from_fields(

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -121,7 +121,7 @@ where
             Put(_) => {
                 Tree::new(mid_key.as_ref().to_vec(), mid_value.to_vec()).unwrap_add_cost(&mut cost)
             }
-            PutReference(_, referenced_value) => Tree::new_with_value_hash(
+            PutReference(_, referenced_value) => Tree::new_with_combined_value_hash(
                 mid_key.as_ref().to_vec(),
                 mid_value.to_vec(),
                 referenced_value.to_owned(),


### PR DESCRIPTION
Before this pr, reference values didn't affect the state root. This means that if a reference points to a value at point A, and then gets updated to point to a duplicate value at point B, the state root doesn't change as the value hash is maintained. 