### PR TITLE
pref(rocksdb): enable async io for iterators

### DIFF
--- a/storage/src/rocksdb_storage/storage_context/context_immediate.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_immediate.rs
@@ -33,7 +33,7 @@ use grovedb_costs::{
     storage_cost::key_value_cost::KeyValueStorageCost, ChildrenSizesWithIsSumTree, CostResult,
     CostsExt,
 };
-use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, WriteBatchWithTransaction};
+use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, ReadOptions, WriteBatchWithTransaction};
 
 use super::{make_prefixed_key, PrefixedRocksDbBatch, PrefixedRocksDbRawIterator};
 use crate::{
@@ -232,9 +232,12 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
     }
 
     fn raw_iter(&self) -> Self::RawIterator {
+        let mut opts = ReadOptions::default();
+        opts.set_async_io(true);
+
         PrefixedRocksDbRawIterator {
             prefix: self.prefix,
-            raw_iterator: self.transaction.raw_iterator(),
+            raw_iterator: self.transaction.raw_iterator_opt(opts),
         }
     }
 }

--- a/storage/src/rocksdb_storage/storage_context/context_no_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_no_tx.rs
@@ -33,7 +33,7 @@ use grovedb_costs::{
     storage_cost::key_value_cost::KeyValueStorageCost, ChildrenSizesWithIsSumTree, CostResult,
     CostsExt, OperationCost,
 };
-use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode};
+use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, ReadOptions};
 
 use super::{batch::PrefixedMultiContextBatchPart, make_prefixed_key, PrefixedRocksDbRawIterator};
 use crate::{
@@ -278,9 +278,12 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbStorageContext<'db> {
     }
 
     fn raw_iter(&self) -> Self::RawIterator {
+        let mut opts = ReadOptions::default();
+        opts.set_async_io(true);
+
         PrefixedRocksDbRawIterator {
             prefix: self.prefix,
-            raw_iterator: self.storage.raw_iterator(),
+            raw_iterator: self.storage.raw_iterator_opt(opts),
         }
     }
 }

--- a/storage/src/rocksdb_storage/storage_context/context_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_tx.rs
@@ -33,7 +33,7 @@ use grovedb_costs::{
     cost_return_on_error, storage_cost::key_value_cost::KeyValueStorageCost,
     ChildrenSizesWithIsSumTree, CostResult, CostsExt, OperationCost,
 };
-use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode};
+use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, ReadOptions};
 
 use super::{batch::PrefixedMultiContextBatchPart, make_prefixed_key, PrefixedRocksDbRawIterator};
 use crate::{
@@ -310,9 +310,12 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
     }
 
     fn raw_iter(&self) -> Self::RawIterator {
+        let mut opts = ReadOptions::default();
+        opts.set_async_io(true);
+
         PrefixedRocksDbRawIterator {
             prefix: self.prefix,
-            raw_iterator: self.transaction.raw_iterator(),
+            raw_iterator: self.transaction.raw_iterator_opt(opts),
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Writes are not blocking in RocksDB but reads are blocking. There is an asynchronous IO provided for multi-gets and iterators.  That should speed up query operations in Drive which are utilizing iterators. It should increase CPU consumption though.

More details:
- https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html
- https://docs.rs/rocksdb/latest/rocksdb/struct.ReadOptions.html#method.set_async_io

## What was done?
<!--- Describe your changes in detail -->
- [x] Enabled async io for RocksDB iterators
- [ ] Benchmarks to prove that this option speeds up Drive's queries.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
