### PR TITLE
feat: enable transaction support for proof queries

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -4043,7 +4043,7 @@ mod tests {
         reference_key_query.insert_key(b"key1".to_vec());
         let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], reference_key_query);
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .expect("should generate proof");
         let verification_result = GroveDb::verify_query_raw(&proof, &path_query, grove_version);

--- a/grovedb/src/operations/get/query.rs
+++ b/grovedb/src/operations/get/query.rs
@@ -172,14 +172,7 @@ where {
                 .query
                 .get_proved_path_query
         );
-        if transaction.is_some() {
-            Err(Error::NotSupported(
-                "transactions are not currently supported".to_string(),
-            ))
-            .wrap_with_cost(Default::default())
-        } else {
-            self.prove_query(path_query, prove_options, grove_version)
-        }
+        self.prove_query(path_query, prove_options, transaction, grove_version)
     }
 
     fn follow_element(

--- a/grovedb/src/query/mod.rs
+++ b/grovedb/src/query/mod.rs
@@ -614,7 +614,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query_one);
 
         let proof = temp_db
-            .prove_query(&path_query_one, None, grove_version)
+            .prove_query(&path_query_one, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_one) =
@@ -628,7 +628,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query_two);
 
         let proof = temp_db
-            .prove_query(&path_query_two, None, grove_version)
+            .prove_query(&path_query_two, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_two) =
@@ -641,7 +641,7 @@ mod tests {
                 .expect("should merge path queries");
 
         let proof = temp_db
-            .prove_query(&merged_path_query, None, grove_version)
+            .prove_query(&merged_path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_tree) =
@@ -664,7 +664,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query_one);
 
         let proof = temp_db
-            .prove_query(&path_query_one, None, grove_version)
+            .prove_query(&path_query_one, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_one) =
@@ -678,7 +678,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree4".to_vec()], query_two);
 
         let proof = temp_db
-            .prove_query(&path_query_two, None, grove_version)
+            .prove_query(&path_query_two, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_two) =
@@ -693,7 +693,7 @@ mod tests {
         assert_eq!(merged_path_query.query.query.items.len(), 2);
 
         let proof = temp_db
-            .prove_query(&merged_path_query, None, grove_version)
+            .prove_query(&merged_path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_merged) =
@@ -720,7 +720,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query_one, None, grove_version)
+            .prove_query(&path_query_one, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_one) =
@@ -741,7 +741,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query_two, None, grove_version)
+            .prove_query(&path_query_two, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_two) =
@@ -762,7 +762,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query_three, None, grove_version)
+            .prove_query(&path_query_three, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_two) =
@@ -905,7 +905,7 @@ mod tests {
         assert_eq!(result_set_merged.len(), 7);
 
         let proof = temp_db
-            .prove_query(&merged_path_query, None, grove_version)
+            .prove_query(&merged_path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, proved_result_set_merged) =
@@ -954,7 +954,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query_one, None, grove_version)
+            .prove_query(&path_query_one, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_one) =
@@ -975,7 +975,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query_two, None, grove_version)
+            .prove_query(&path_query_two, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_two) =
@@ -989,7 +989,7 @@ mod tests {
         assert_eq!(merged_path_query.path, vec![b"deep_leaf".to_vec()]);
 
         let proof = temp_db
-            .prove_query(&merged_path_query, None, grove_version)
+            .prove_query(&merged_path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set_merged) =
@@ -1033,7 +1033,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query_one);
 
         let proof = temp_db
-            .prove_query(&path_query_one, None, grove_version)
+            .prove_query(&path_query_one, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set) =
@@ -1047,7 +1047,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query_two);
 
         let proof = temp_db
-            .prove_query(&path_query_two, None, grove_version)
+            .prove_query(&path_query_two, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set) =
@@ -1063,7 +1063,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query_three, None, grove_version)
+            .prove_query(&path_query_three, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set) =
@@ -1078,7 +1078,7 @@ mod tests {
         .expect("should merge three queries");
 
         let proof = temp_db
-            .prove_query(&merged_path_query, None, grove_version)
+            .prove_query(&merged_path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set) =
@@ -1102,7 +1102,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query_one);
 
         let proof = temp_db
-            .prove_query(&path_query_one, None, grove_version)
+            .prove_query(&path_query_one, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set) =
@@ -1116,7 +1116,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query_two);
 
         let proof = temp_db
-            .prove_query(&path_query_two, None, grove_version)
+            .prove_query(&path_query_two, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set) =
@@ -1129,7 +1129,7 @@ mod tests {
                 .expect("should merge three queries");
 
         let proof = temp_db
-            .prove_query(&merged_path_query, None, grove_version)
+            .prove_query(&merged_path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set) =
@@ -1148,7 +1148,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query_one, None, grove_version)
+            .prove_query(&path_query_one, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set) =
@@ -1169,7 +1169,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query_two, None, grove_version)
+            .prove_query(&path_query_two, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set) =
@@ -1258,7 +1258,7 @@ mod tests {
         assert_eq!(result_set_merged.len(), 4);
 
         let proof = temp_db
-            .prove_query(&merged_path_query, None, grove_version)
+            .prove_query(&merged_path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (_, result_set) =

--- a/grovedb/src/reference_path.rs
+++ b/grovedb/src/reference_path.rs
@@ -968,7 +968,7 @@ mod tests {
         );
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .expect("should generate proof");
         let (hash, result) = GroveDb::verify_query_raw(&proof, &path_query, grove_version)

--- a/grovedb/src/tests/count_tree_tests.rs
+++ b/grovedb/src/tests/count_tree_tests.rs
@@ -89,7 +89,7 @@ mod tests {
 
         let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"key".to_vec()], query);
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .expect("should generate proof");
         let (root_hash, result_set) = GroveDb::verify_query_raw(&proof, &path_query, grove_version)

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -913,7 +913,7 @@ mod tests {
             SizedQuery::new(query, None, None),
         );
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .expect("should successfully create proof");
         let (root_hash, result_set) = GroveDb::verify_query_raw(&proof, &path_query, grove_version)
@@ -1435,7 +1435,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![b"invalid_path_key".to_vec()], query);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1456,7 +1456,7 @@ mod tests {
             PathQuery::new_unsized(vec![b"deep_leaf".to_vec(), b"invalid_key".to_vec()], query);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1477,7 +1477,7 @@ mod tests {
         );
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1499,7 +1499,7 @@ mod tests {
         );
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1521,7 +1521,7 @@ mod tests {
         );
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1544,7 +1544,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1709,7 +1709,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -1862,7 +1862,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query);
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -1897,7 +1897,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1922,7 +1922,7 @@ mod tests {
         );
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1960,7 +1960,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2001,7 +2001,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2031,7 +2031,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2068,7 +2068,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2135,7 +2135,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2166,7 +2166,7 @@ mod tests {
 
         let path_query = PathQuery::new_unsized(vec![], query);
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2197,7 +2197,7 @@ mod tests {
         let path_query =
             PathQuery::new_unsized(vec![b"deep_leaf".to_vec(), b"deep_node_1".to_vec()], query);
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2246,7 +2246,7 @@ mod tests {
 
         let path_query = PathQuery::new_unsized(vec![], query);
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2276,7 +2276,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2320,7 +2320,7 @@ mod tests {
 
         let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2371,7 +2371,7 @@ mod tests {
 
         let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2440,7 +2440,7 @@ mod tests {
                                                     * empty proved subtrees */
         );
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2481,7 +2481,7 @@ mod tests {
 
         // Generate proof
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
 
@@ -2507,7 +2507,7 @@ mod tests {
         );
 
         let proof_no_limit = db
-            .prove_query(&path_query_no_limit, None, grove_version)
+            .prove_query(&path_query_no_limit, None, None, grove_version)
             .unwrap()
             .unwrap();
         let verification_result_no_limit =
@@ -2579,7 +2579,7 @@ mod tests {
 
         // Generate proof
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
 
@@ -2599,7 +2599,7 @@ mod tests {
         );
 
         let proof_no_limit = db
-            .prove_query(&path_query_no_limit, None, grove_version)
+            .prove_query(&path_query_no_limit, None, None, grove_version)
             .unwrap()
             .unwrap();
         let verification_result_no_limit =
@@ -2672,7 +2672,7 @@ mod tests {
                                                     * trees in proofs */
         );
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2717,7 +2717,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![DEEP_LEAF.to_vec()], query);
 
         let proof = temp_db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -3992,7 +3992,7 @@ mod tests {
             },
         };
         let proof = db
-            .prove_query(&query, None, grove_version)
+            .prove_query(&query, None, None, grove_version)
             .unwrap()
             .unwrap();
 
@@ -4012,7 +4012,7 @@ mod tests {
         .unwrap();
 
         let proof = db
-            .prove_query(&query, None, grove_version)
+            .prove_query(&query, None, None, grove_version)
             .unwrap()
             .unwrap();
 

--- a/grovedb/src/tests/query_tests.rs
+++ b/grovedb/src/tests/query_tests.rs
@@ -765,7 +765,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -805,7 +805,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -845,7 +845,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -894,7 +894,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -944,7 +944,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -991,7 +991,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1041,7 +1041,7 @@ mod tests {
         assert!(elements.contains(&last_value));
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1083,7 +1083,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1128,7 +1128,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1168,7 +1168,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1213,7 +1213,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1253,7 +1253,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1298,7 +1298,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1343,7 +1343,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1383,7 +1383,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1428,7 +1428,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1475,7 +1475,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1522,7 +1522,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1569,7 +1569,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1620,7 +1620,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1666,7 +1666,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1701,7 +1701,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1738,7 +1738,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -1841,7 +1841,7 @@ mod tests {
         assert_eq!(elements.len(), 250);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2018,7 +2018,7 @@ mod tests {
         );
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .expect("expected successful proving");
         let (hash, _result_set) =
@@ -2129,7 +2129,7 @@ mod tests {
         assert_eq!(elements, vec![vec![2], vec![3], vec![4], vec![1], vec![1]]);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2157,7 +2157,7 @@ mod tests {
         assert_eq!(elements, vec![vec![2], vec![3], vec![4], vec![1], vec![1]]);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2179,7 +2179,7 @@ mod tests {
         assert_eq!(elements, vec![vec![2]]);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2201,7 +2201,7 @@ mod tests {
         assert_eq!(elements, vec![vec![2], vec![3], vec![4]]);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2223,7 +2223,7 @@ mod tests {
         assert_eq!(elements, vec![vec![2], vec![3], vec![4], vec![1]]);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2344,7 +2344,7 @@ mod tests {
         assert_eq!(elements.len(), 5);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2382,7 +2382,7 @@ mod tests {
         assert_eq!(elements.len(), 1);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2571,7 +2571,7 @@ mod tests {
         );
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2639,7 +2639,7 @@ mod tests {
         );
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2660,7 +2660,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(path, query.clone());
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2688,7 +2688,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(path, query.clone());
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2708,7 +2708,7 @@ mod tests {
             SizedQuery::new(query, Some(0), Some(0)),
         );
 
-        db.prove_query(&path_query, None, grove_version)
+        db.prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .expect_err("expected error when trying to prove with limit 0");
     }
@@ -2723,7 +2723,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2758,7 +2758,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2798,7 +2798,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![], query);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2845,7 +2845,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2883,7 +2883,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree".to_vec()], query);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) = GroveDb::verify_query(&proof, &path_query, grove_version).unwrap();
@@ -2936,7 +2936,7 @@ mod tests {
         );
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -2987,7 +2987,7 @@ mod tests {
         let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) = GroveDb::verify_query(&proof, &path_query, grove_version).unwrap();
@@ -3074,7 +3074,7 @@ mod tests {
 
         // first prove non verbose
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) = GroveDb::verify_query(&proof, &path_query, grove_version).unwrap();
@@ -3310,7 +3310,7 @@ mod tests {
 
         // first we show that this returns the correct output
         let proof = db
-            .prove_query(&path_query_one, None, grove_version)
+            .prove_query(&path_query_one, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -3326,7 +3326,7 @@ mod tests {
 
         // show that we get the correct output
         let proof = db
-            .prove_query(&path_query_two, None, grove_version)
+            .prove_query(&path_query_two, None, None, grove_version)
             .unwrap()
             .unwrap();
         let (hash, result_set) =
@@ -3341,7 +3341,7 @@ mod tests {
             PathQuery::merge(vec![&path_query_one, &path_query_two], grove_version).unwrap();
         merged_path_queries.query.limit = Some(3);
         let proof = db
-            .prove_query(&merged_path_queries, None, grove_version)
+            .prove_query(&merged_path_queries, None, None, grove_version)
             .unwrap()
             .unwrap();
 
@@ -3396,7 +3396,7 @@ mod tests {
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"invalid".to_vec()], query);
 
         let proof = grovedb
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .expect("should generate proofs");
 
@@ -3447,7 +3447,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3493,7 +3493,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3539,7 +3539,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3585,7 +3585,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3631,7 +3631,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3677,7 +3677,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3725,7 +3725,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3773,7 +3773,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3821,7 +3821,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3869,7 +3869,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3917,7 +3917,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -3965,7 +3965,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4013,7 +4013,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4061,7 +4061,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4112,7 +4112,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4163,7 +4163,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4214,7 +4214,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4265,7 +4265,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4316,7 +4316,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4367,7 +4367,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4418,7 +4418,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4469,7 +4469,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4520,7 +4520,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4571,7 +4571,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4622,7 +4622,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4673,7 +4673,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4724,7 +4724,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4781,7 +4781,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4842,7 +4842,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 
@@ -4893,7 +4893,7 @@ mod tests {
         assert_eq!(elements.len(), 2);
 
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .value
             .expect("expected successful get_path_query");
 

--- a/grovedb/src/tests/sum_tree_tests.rs
+++ b/grovedb/src/tests/sum_tree_tests.rs
@@ -91,7 +91,7 @@ mod tests {
 
         let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"key".to_vec()], query);
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .expect("should generate proof");
         let (root_hash, result_set) = GroveDb::verify_query_raw(&proof, &path_query, grove_version)
@@ -180,7 +180,7 @@ mod tests {
         let path_query =
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"sumkey".to_vec()], query);
         let proof = db
-            .prove_query(&path_query, None, grove_version)
+            .prove_query(&path_query, None, None, grove_version)
             .unwrap()
             .expect("should generate proof");
         let (root_hash, result_set) = GroveDb::verify_query_raw(&proof, &path_query, grove_version)

--- a/tutorials/src/bin/proofs.rs
+++ b/tutorials/src/bin/proofs.rs
@@ -37,7 +37,7 @@ fn main() {
         .expect("expected successful get_path_query");
 
     // Generate proof.
-    let proof = db.prove_query(&path_query, None, grove_version).unwrap().unwrap();
+    let proof = db.prove_query(&path_query, None, None, grove_version).unwrap().unwrap();
 
     // Get hash from query proof and print to terminal along with GroveDB root hash.
     let (hash, _result_set) = GroveDb::verify_query(&proof, &path_query, grove_version).unwrap();

--- a/tutorials/src/bin/replication.rs
+++ b/tutorials/src/bin/replication.rs
@@ -253,7 +253,7 @@ fn query_db(db: &GroveDb, path: &[&[u8]], key: Vec<u8>, grove_version: &GroveVer
         println!(">> {:?}", e);
     }
 
-    let proof = db.prove_query(&path_query, None, grove_version).unwrap().unwrap();
+    let proof = db.prove_query(&path_query, None, None, grove_version).unwrap().unwrap();
     // Get hash from query proof and print to terminal along with GroveDB root hash.
     let (verify_hash, _) = GroveDb::verify_query(&proof, &path_query, grove_version).unwrap();
     println!("verify_hash: {:?}", hex::encode(verify_hash));


### PR DESCRIPTION
This update allows transactions to be used in proof queries by modifying the `prove_query` method to accept a transaction argument. The changes include:

- Updated the `prove_query` method signature to include a transaction parameter.
- Adjusted the logic in various locations where `prove_query` is called to pass the transaction argument.
- Updated tests and examples to reflect the new method signature, ensuring that proof generation works correctly with transactions.

These changes enhance the flexibility of the proof querying system, enabling users to perform operations within transactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Proof generation methods now support executing within a transaction, providing improved consistency and control during proof operations.

- **Bug Fixes**
  - Removed previous restrictions on using transactions with proof queries, allowing for broader use cases.

- **Documentation**
  - Updated tutorial code examples to reflect the new proof generation method signatures.

- **Tests**
  - Updated all relevant test cases to align with the new proof query method signature, ensuring continued test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->