### PR TITLE
chore: drop nightly-only rustfmt options

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,17 +1,2 @@
-unstable_features = true
-
-blank_lines_lower_bound = 0
-condense_wildcard_suffixes = true
-error_on_line_overflow = true
-error_on_unformatted = true
-format_code_in_doc_comments = true
-format_macro_matchers = true
-format_strings = true
-imports_granularity = "Crate"
-normalize_comments = true
-normalize_doc_attributes = true
-reorder_impl_items = true
-group_imports = "StdExternalCrate"
 use_field_init_shorthand = true
 use_try_shorthand = true
-wrap_comments = true


### PR DESCRIPTION
## Summary

- Remove 15 nightly-only options from `.rustfmt.toml`, keeping only the 2 stable options (`use_field_init_shorthand`, `use_try_shorthand`)
- `cargo fmt` now works on stable without warnings — no need for `cargo +nightly fmt`
- No code changes needed since the codebase is already formatted with these rules

## Test plan

- [x] `cargo fmt --check` passes cleanly on stable toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified code formatting configuration by removing customized options and reverting to default formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->