### PR TITLE
ci: run coverage on push so codecov badges work

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,10 @@ name: Coverage
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
+      - develop
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Summary
- Add `push` trigger (master/develop) to coverage workflow
- Without this, coverage only ran on PRs — no data was uploaded for the branches themselves, so all codecov badges showed "unknown"

## Test plan
- [ ] After merging, verify coverage workflow runs on the push to develop
- [ ] Once develop merges to master, master badges should populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)