### PR TITLE
fix: point codecov badges to develop branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,3 +43,4 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+          override_branch: ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ A high-performance, cryptographically verifiable database that organizes data as
 
 | Branch | Tests | Coverage |
 |--------|-------|----------|
-| master | [![Tests](https://github.com/dashpay/grovedb/actions/workflows/grovedb.yml/badge.svg?branch=master)](https://github.com/dashpay/grovedb/actions) | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/master/graph/badge.svg?token=6Z6A6FT5HV)](https://codecov.io/gh/dashpay/grovedb) |
+| develop | [![Tests](https://github.com/dashpay/grovedb/actions/workflows/grovedb.yml/badge.svg?branch=develop)](https://github.com/dashpay/grovedb/actions) | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/develop/graph/badge.svg?token=6Z6A6FT5HV)](https://codecov.io/gh/dashpay/grovedb) |
 
 <details>
 <summary>Per-Crate Coverage</summary>
 
 | Crate | Coverage |
 |-------|----------|
-| grovedb | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/master/graph/badge.svg?token=6Z6A6FT5HV&component=grovedb-core)](https://codecov.io/gh/dashpay/grovedb/component/grovedb-core) |
-| merk | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/master/graph/badge.svg?token=6Z6A6FT5HV&component=merk)](https://codecov.io/gh/dashpay/grovedb/component/merk) |
-| storage | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/master/graph/badge.svg?token=6Z6A6FT5HV&component=storage)](https://codecov.io/gh/dashpay/grovedb/component/storage) |
-| commitment-tree | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/master/graph/badge.svg?token=6Z6A6FT5HV&component=commitment-tree)](https://codecov.io/gh/dashpay/grovedb/component/commitment-tree) |
-| mmr | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/master/graph/badge.svg?token=6Z6A6FT5HV&component=mmr)](https://codecov.io/gh/dashpay/grovedb/component/mmr) |
-| bulk-append-tree | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/master/graph/badge.svg?token=6Z6A6FT5HV&component=bulk-append-tree)](https://codecov.io/gh/dashpay/grovedb/component/bulk-append-tree) |
-| element | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/master/graph/badge.svg?token=6Z6A6FT5HV&component=element)](https://codecov.io/gh/dashpay/grovedb/component/element) |
+| grovedb | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/develop/graph/badge.svg?token=6Z6A6FT5HV&component=grovedb-core)](https://codecov.io/gh/dashpay/grovedb/component/grovedb-core) |
+| merk | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/develop/graph/badge.svg?token=6Z6A6FT5HV&component=merk)](https://codecov.io/gh/dashpay/grovedb/component/merk) |
+| storage | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/develop/graph/badge.svg?token=6Z6A6FT5HV&component=storage)](https://codecov.io/gh/dashpay/grovedb/component/storage) |
+| commitment-tree | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/develop/graph/badge.svg?token=6Z6A6FT5HV&component=commitment-tree)](https://codecov.io/gh/dashpay/grovedb/component/commitment-tree) |
+| mmr | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/develop/graph/badge.svg?token=6Z6A6FT5HV&component=mmr)](https://codecov.io/gh/dashpay/grovedb/component/mmr) |
+| bulk-append-tree | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/develop/graph/badge.svg?token=6Z6A6FT5HV&component=bulk-append-tree)](https://codecov.io/gh/dashpay/grovedb/component/bulk-append-tree) |
+| element | [![codecov](https://codecov.io/gh/dashpay/grovedb/branch/develop/graph/badge.svg?token=6Z6A6FT5HV&component=element)](https://codecov.io/gh/dashpay/grovedb/component/element) |
 
 </details>
 


### PR DESCRIPTION
## Summary
- All codecov badge URLs pointed to `branch/master`, but codecov's default branch is `develop` and that's where coverage data exists (74% / 75%)
- The first coverage push to master ran with **no token** (secret wasn't set yet), so master never got coverage data on codecov
- Subsequent `workflow_dispatch` runs on master had the token but `CC_BRANCH` was empty (auto-detection doesn't work for workflow_dispatch), so data went to the wrong place
- Switch all badge URLs from `branch/master` to `branch/develop`
- Add `override_branch: ${{ github.ref_name }}` to the codecov upload step so workflow_dispatch and other events correctly report the branch

## Test plan
- [x] Verified `curl` of develop badge returns `75%` instead of `unknown`
- [x] After merge, README badges should show actual coverage percentages

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation badges and links to reference the develop branch instead of master.

* **Chores**
  * Updated CI/CD workflow configuration for coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->