### PR TITLE
ci: remove redundant errors job, move verify check into linting

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -139,6 +139,8 @@ jobs:
           cache-on-failure: "false"
       - name: Run clippy
         run: cargo clippy --workspace --all-features -- -D warnings
+      - name: Check verify feature
+        run: cargo build --no-default-features --features verify -p grovedb
 
   formatting:
     name: Formatting
@@ -151,21 +153,6 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --all --check
-
-  errors:
-    name: Compilation Errors
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any-code == 'true'
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: "false"
-      - run: cargo check
-      - name: Check verify feature
-        run: cargo build --no-default-features --features verify -p grovedb
 
   security:
     name: Security Audit


### PR DESCRIPTION
## Summary
- Remove standalone `errors` job (`cargo check` + verify feature build) — `cargo clippy` already performs full compilation checking, making it redundant
- Move the `--features verify` build check into the `linting` job after clippy, since the workspace is already compiled at that point
- Saves ~8 min of redundant parallel compilation per CI run

## Test plan
- [x] Verify clippy job now includes the verify feature check step
- [x] Verify no `errors` / `Compilation Errors` job appears in CI

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined continuous integration workflow to streamline build verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->