### PR TITLE
ci: skip coverage on non-code PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,8 +13,26 @@ on:
       - 'v[0-9]*.[0-9]*-dev'
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      any-code: ${{ steps.filter.outputs.any-code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            any-code:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+
   coverage:
     name: Code Coverage
+    needs: detect-changes
+    if: needs.detect-changes.outputs.any-code == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `dorny/paths-filter` to the coverage workflow so it only runs when Rust source (`**/*.rs`) or Cargo files (`**/Cargo.toml`, `Cargo.lock`) change
- PRs that only touch CI config, docs, or markdown no longer trigger the ~13 min coverage job

## Test plan
- [ ] This PR itself only touches `.yml` — coverage job should be skipped
- [ ] A future PR touching `.rs` files should still run coverage normally

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration efficiency by running code coverage analysis only when relevant changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->