### PR TITLE
fix: propagate deserialization errors in proof display instead of hiding them

### DIFF
--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -75,7 +75,7 @@ harness = false
 [features]
 default = ["full", "estimated_costs"]
 proof_debug = ["grovedb-merk/proof_debug"]
-serde = ["dep:serde", "grovedb-merk/serde", "indexmap/serde"]
+serde = ["dep:serde", "grovedb-merk/serde", "grovedb-query/serde", "indexmap/serde"]
 full = ["grovedb-merk/full", "minimal"]
 minimal = [
     "grovedb-merk/minimal",

--- a/grovedb/src/debugger.rs
+++ b/grovedb/src/debugger.rs
@@ -148,7 +148,7 @@ impl AppState {
     async fn get_checkpointed_grovedb(
         &self,
         id: SessionId,
-    ) -> Result<RwLockReadGuard<GroveDb>, AppError> {
+    ) -> Result<RwLockReadGuard<'_, GroveDb>, AppError> {
         self.verify_running()?;
         let mut lock = self.sessions.write().await;
         if let Some(session) = lock.get_mut(&id) {

--- a/grovedb/src/operations/proof/util.rs
+++ b/grovedb/src/operations/proof/util.rs
@@ -51,7 +51,7 @@ impl fmt::Display for ProvedPathKeyOptionalValue {
         writeln!(
             f,
             "  value: {},",
-            optional_element_hex_to_ascii(self.value.as_ref())
+            optional_element_hex_to_ascii(self.value.as_ref())?
         )?;
         writeln!(f, "  proof: {}", hex::encode(self.proof))?;
         write!(f, "}}")
@@ -86,7 +86,11 @@ impl fmt::Display for ProvedPathKeyValue {
                 .join(", ")
         )?;
         writeln!(f, "  key: {},", hex_to_ascii(&self.key))?;
-        writeln!(f, "  value: {},", element_hex_to_ascii(self.value.as_ref()))?;
+        writeln!(
+            f,
+            "  value: {},",
+            element_hex_to_ascii(self.value.as_ref())?
+        )?;
         writeln!(f, "  proof: {}", hex::encode(self.proof))?;
         write!(f, "}}")
     }
@@ -212,19 +216,17 @@ pub fn path_as_slices_hex_to_ascii(path: &[&[u8]]) -> String {
         .collect::<Vec<_>>()
         .join("/")
 }
-pub fn optional_element_hex_to_ascii(hex_value: Option<&Vec<u8>>) -> String {
+pub fn optional_element_hex_to_ascii(hex_value: Option<&Vec<u8>>) -> Result<String, fmt::Error> {
     match hex_value {
-        None => "None".to_string(),
-        Some(hex_value) => Element::deserialize(hex_value, GroveVersion::latest())
-            .map(|e| e.to_string())
-            .unwrap_or_else(|_| hex::encode(hex_value)),
+        None => Ok("None".to_string()),
+        Some(hex_value) => element_hex_to_ascii(hex_value),
     }
 }
 
-pub fn element_hex_to_ascii(hex_value: &[u8]) -> String {
-    Element::deserialize(hex_value, GroveVersion::latest())
-        .map(|e| e.to_string())
-        .unwrap_or_else(|_| hex::encode(hex_value))
+pub fn element_hex_to_ascii(hex_value: &[u8]) -> Result<String, fmt::Error> {
+    let element =
+        Element::deserialize(hex_value, GroveVersion::latest()).map_err(|_| fmt::Error)?;
+    Ok(element.to_string())
 }
 
 #[cfg(test)]

--- a/grovedb/src/operations/proof/util.rs
+++ b/grovedb/src/operations/proof/util.rs
@@ -232,8 +232,12 @@ pub fn element_hex_to_ascii(hex_value: &[u8]) -> Result<String, fmt::Error> {
 #[cfg(test)]
 mod tests {
     use grovedb_merk::proofs::query::ProvedKeyOptionalValue;
+    use grovedb_version::version::GroveVersion;
 
-    use crate::operations::proof::util::ProvedPathKeyOptionalValue;
+    use crate::operations::proof::util::{
+        element_hex_to_ascii, optional_element_hex_to_ascii, ProvedPathKeyOptionalValue,
+    };
+    use crate::Element;
 
     #[test]
     fn test_proved_path_from_single_proved_key_value() {
@@ -324,6 +328,62 @@ mod tests {
                 value: None,
                 proof: [2; 32]
             }
+        );
+    }
+
+    #[test]
+    fn test_element_hex_to_ascii_valid() {
+        let grove_version = GroveVersion::latest();
+        let item = Element::new_item(b"hello".to_vec());
+        let serialized = item
+            .serialize(grove_version)
+            .expect("should serialize item");
+        let result =
+            element_hex_to_ascii(&serialized).expect("should deserialize valid element bytes");
+        assert!(
+            !result.is_empty(),
+            "display string should not be empty for a valid element"
+        );
+    }
+
+    #[test]
+    fn test_element_hex_to_ascii_invalid() {
+        let invalid_bytes = vec![0xFF, 0xFE, 0xFD];
+        let result = element_hex_to_ascii(&invalid_bytes);
+        assert!(
+            result.is_err(),
+            "should return Err for invalid element bytes"
+        );
+    }
+
+    #[test]
+    fn test_optional_element_hex_to_ascii_none() {
+        let result = optional_element_hex_to_ascii(None).expect("None should always succeed");
+        assert_eq!(result, "None");
+    }
+
+    #[test]
+    fn test_optional_element_hex_to_ascii_valid() {
+        let grove_version = GroveVersion::latest();
+        let item = Element::new_item(b"test".to_vec());
+        let serialized = item
+            .serialize(grove_version)
+            .expect("should serialize item");
+        let result = optional_element_hex_to_ascii(Some(&serialized))
+            .expect("should deserialize valid element bytes");
+        assert!(
+            !result.is_empty(),
+            "display string should not be empty for a valid element"
+        );
+    }
+
+    #[test]
+    fn test_optional_element_hex_to_ascii_invalid() {
+        let invalid_bytes = vec![0xFF, 0xFE];
+        let result = optional_element_hex_to_ascii(Some(&invalid_bytes));
+        assert!(
+            result.is_err(),
+            "should return Err for invalid element bytes"
         );
     }
 }


### PR DESCRIPTION
## Summary
- `element_hex_to_ascii` and `optional_element_hex_to_ascii` were silently swallowing `Element` deserialization errors by falling back to hex encoding via `unwrap_or_else`
- Changed both functions to return `Result<String, fmt::Error>` so errors propagate through the `fmt::Display` chain
- Updated all callers in `node_to_string`, `op_to_string`, `decode_merk_proof`, and the `Display` impls for `ProvedPathKeyValue` / `ProvedPathKeyOptionalValue`

Supersedes #363 (which was stale and had merge conflicts with the current codebase).

## Test plan
- [ ] `cargo check -p grovedb` passes
- [ ] Existing proof display tests still pass
- [ ] Deserialization errors in proof formatting now surface as `fmt::Error` instead of being silently replaced with hex

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated serialization feature to enable additional query serde support.

* **Refactor**
  * Improved error handling in proof decoding and formatting for more robust, fail-safe behavior.

* **Bug Fixes**
  * Prevented crashes when decoding/formatting invalid proof or element data; errors are now surfaced cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->