### PR TITLE
test(visualize): add comprehensive test suite for coverage improvement

### DIFF
--- a/grovedb/src/debugger.rs
+++ b/grovedb/src/debugger.rs
@@ -148,7 +148,7 @@ impl AppState {
     async fn get_checkpointed_grovedb(
         &self,
         id: SessionId,
-    ) -> Result<RwLockReadGuard<GroveDb>, AppError> {
+    ) -> Result<RwLockReadGuard<'_, GroveDb>, AppError> {
         self.verify_running()?;
         let mut lock = self.sessions.write().await;
         if let Some(session) = lock.get_mut(&id) {

--- a/visualize/src/lib.rs
+++ b/visualize/src/lib.rs
@@ -245,7 +245,7 @@ mod tests {
 
     impl Write for FailWriteWriter {
         fn write(&mut self, _data: &[u8]) -> std::io::Result<usize> {
-            Err(Error::new(ErrorKind::Other, "write failure"))
+            Err(Error::other("write failure"))
         }
 
         fn flush(&mut self) -> std::io::Result<()> {
@@ -263,7 +263,7 @@ mod tests {
         }
 
         fn flush(&mut self) -> std::io::Result<()> {
-            Err(Error::new(ErrorKind::Other, "flush failure"))
+            Err(Error::other("flush failure"))
         }
     }
 
@@ -271,7 +271,7 @@ mod tests {
 
     impl Visualize for AlwaysErrVisualize {
         fn visualize<W: Write>(&self, _drawer: Drawer<W>) -> std::io::Result<Drawer<W>> {
-            Err(Error::new(ErrorKind::Other, "visualize failure"))
+            Err(Error::other("visualize failure"))
         }
     }
 


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for the `grovedb-visualize` crate, targeting previously uncovered code paths.

## Tests Added (18 tests)

- `Drawer::{new, down, up, write, flush}` including error propagation
- `to_hex` normal and truncation paths
- `Visualize` implementations for `[u8]`, `Vec<u8>`, `&T`, and `Option<T>`
- `DebugBytes` and `DebugByteVectors` formatting behavior
- `visualize_to_vec`, `visualize_stdout`, and `visualize_stderr` including panic paths

## Validation

- `cargo test -p grovedb-visualize` — all 18 tests pass

Part of the GroveDB coverage improvement initiative (thepastaclaw/tracker#364).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal type annotations to enhance memory safety and stability without changing behavior.

* **Tests**
  * Added extensive tests for visualization utilities, error handling, and drawer output/formatting to increase reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->