### PR TITLE
test(epoch-flags): add comprehensive test suite for coverage improvement

### DIFF
--- a/grovedb-epoch-based-storage-flags/src/error.rs
+++ b/grovedb-epoch-based-storage-flags/src/error.rs
@@ -43,3 +43,26 @@ impl StorageFlagsError {
         self.get_mut_info().push_str(format!(": {}", info).as_str());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::StorageFlagsError;
+
+    #[test]
+    fn add_info_appends_to_all_variants() {
+        let errors = vec![
+            StorageFlagsError::DeserializeUnknownStorageFlagsType("a".to_string()),
+            StorageFlagsError::StorageFlagsWrongSize("b".to_string()),
+            StorageFlagsError::RemovingAtEpochWithNoAssociatedStorage("c".to_string()),
+            StorageFlagsError::StorageFlagsOverflow("d".to_string()),
+            StorageFlagsError::RemovingFlagsError("e".to_string()),
+            StorageFlagsError::MergingStorageFlagsFromDifferentOwners("f".to_string()),
+            StorageFlagsError::MergingStorageFlagsWithDifferentBaseEpoch("g".to_string()),
+        ];
+
+        for mut error in errors {
+            error.add_info("extra");
+            assert!(error.to_string().contains("extra"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for the `grovedb-epoch-based-storage-flags` crate, targeting previously uncovered error paths, edge cases, and operator behavior.

## Tests Added (41 total across 4 files)

- Flag serialization/deserialization round-trips
- Split removal bytes logic with various epoch configurations
- Update element flags across different flag type combinations
- Edge cases in epoch-based storage cost calculations
- Error display formatting
- Removal byte splitting edge cases and operator behavior

## Validation

- `cargo test -p grovedb-epoch-based-storage-flags` — all 41 tests pass

Part of the GroveDB coverage improvement initiative (thepastaclaw/tracker#364).
