### PR TITLE
test(storage): add comprehensive test suite for coverage improvement

### DIFF
--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -462,7 +462,8 @@ impl RocksDbStorage {
         let mut iter = self.db.raw_iterator_cf(&cf_handle);
         iter.seek_to_first();
         while iter.valid() {
-            self.db.delete(iter.key().expect("should have key"))?;
+            let key = iter.key().expect("should have key").to_vec();
+            self.db.delete_cf(&cf_handle, key)?;
             iter.next()
         }
         Ok(())

--- a/storage/src/rocksdb_storage/tests.rs
+++ b/storage/src/rocksdb_storage/tests.rs
@@ -1248,7 +1248,8 @@ mod storage_management {
     #[test]
     fn test_checkpoint_open_read_only_and_writes_fail() {
         let db_dir = TempDir::new().expect("cannot create db directory");
-        let checkpoint_dir = TempDir::new().expect("cannot create checkpoint directory");
+        let checkpoint_parent = TempDir::new().expect("cannot create checkpoint directory");
+        let checkpoint_dir = checkpoint_parent.path().join("checkpoint");
 
         let storage = RocksDbStorage::default_rocksdb_with_path(db_dir.path())
             .expect("cannot create storage");
@@ -1266,11 +1267,11 @@ mod storage_management {
             .expect("tx commit should succeed");
 
         storage
-            .create_checkpoint(checkpoint_dir.path())
+            .create_checkpoint(&checkpoint_dir)
             .expect("checkpoint should be created");
 
         let checkpoint_storage =
-            RocksDbStorage::checkpoint_rocksdb_with_path(checkpoint_dir.path())
+            RocksDbStorage::checkpoint_rocksdb_with_path(&checkpoint_dir)
                 .expect("checkpoint should open read-only");
         let checkpoint_tx = checkpoint_storage.start_transaction();
         let checkpoint_context = checkpoint_storage


### PR DESCRIPTION
Improves test coverage for the grovedb-storage crate (81.50% baseline). Adds tests for storage operations, batch processing, contexts, and error paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit tests covering storage batch operations (put/delete ordering, merge behavior, iteration order).
  * Added tests for RocksDB storage management: transactional behavior, checkpoints, clears/wipes, and storage cost calculations.

* **Refactor**
  * Optimized deletion handling for RocksDB column families to use explicit column-family deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->