### PR TITLE
test(merk): add comprehensive test suite for coverage improvement

### DIFF
--- a/merk/src/estimated_costs/average_case_costs.rs
+++ b/merk/src/estimated_costs/average_case_costs.rs
@@ -773,7 +773,6 @@ fn add_average_case_merk_propagate_v1(
     Ok(())
 }
 
-
 #[cfg(feature = "minimal")]
 /// Add average case cost for propagating a merk
 fn add_average_case_merk_propagate_v0(

--- a/merk/src/estimated_costs/average_case_costs.rs
+++ b/merk/src/estimated_costs/average_case_costs.rs
@@ -773,148 +773,6 @@ fn add_average_case_merk_propagate_v1(
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use grovedb_costs::OperationCost;
-    use grovedb_version::version::GroveVersion;
-
-    use super::*;
-
-    #[test]
-    fn test_estimated_sum_trees_divide_by_zero() {
-        let estimated = EstimatedSumTrees::SomeSumTrees {
-            sum_trees_weight: 0,
-            big_sum_trees_weight: 0,
-            count_trees_weight: 0,
-            count_sum_trees_weight: 0,
-            non_sum_trees_weight: 0,
-        };
-        let err = estimated
-            .estimated_size(GroveVersion::latest())
-            .unwrap_err();
-        assert!(matches!(err, Error::DivideByZero("weights add up to 0")));
-    }
-
-    #[test]
-    fn test_estimated_sum_trees_v0_formula_path() {
-        let estimated = EstimatedSumTrees::SomeSumTrees {
-            sum_trees_weight: 1,
-            big_sum_trees_weight: 0,
-            count_trees_weight: 0,
-            count_sum_trees_weight: 0,
-            non_sum_trees_weight: 3,
-        };
-        let size = estimated.estimated_size(GroveVersion::first()).unwrap();
-        assert_eq!(size, 6);
-    }
-
-    #[test]
-    fn test_layered_flags_size_errors() {
-        let layer = EstimatedLayerSizes::AllItems(4, 10, Some(1));
-        let err = layer.layered_flags_size().unwrap_err();
-        assert!(matches!(
-            err,
-            Error::WrongEstimatedCostsElementTypeForLevel(
-                "this layer does not have costs for trees"
-            )
-        ));
-    }
-
-    #[test]
-    fn test_subtree_with_feature_and_flags_size_mix_missing_subtrees() {
-        let layer = EstimatedLayerSizes::Mix {
-            subtrees_size: None,
-            items_size: Some((4, 10, Some(1), 1)),
-            references_size: None,
-        };
-        let err = layer
-            .subtree_with_feature_and_flags_size(GroveVersion::latest())
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            Error::WrongEstimatedCostsElementTypeForLevel(
-                "this layer is a mix but doesn't have subtrees"
-            )
-        ));
-    }
-
-    #[test]
-    fn test_value_with_feature_and_flags_size_mix_without_weights() {
-        let layer = EstimatedLayerSizes::Mix {
-            subtrees_size: None,
-            items_size: None,
-            references_size: None,
-        };
-        let err = layer
-            .value_with_feature_and_flags_size(GroveVersion::latest())
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            Error::WrongEstimatedCostsElementTypeForLevel(
-                "this layer is a mix and does not have items, refs or trees"
-            )
-        ));
-    }
-
-    #[test]
-    fn test_estimated_layer_count_helpers() {
-        assert!(EstimatedLayerCount::ApproximateElements(0).estimated_to_be_empty());
-        assert_eq!(
-            EstimatedLayerCount::ApproximateElements(7).estimate_levels(),
-            3
-        );
-        assert_eq!(
-            EstimatedLayerCount::PotentiallyAtMaxElements.estimate_levels(),
-            32
-        );
-        assert_eq!(
-            EstimatedLayerCount::EstimatedLevel(5, false).estimate_levels(),
-            5
-        );
-    }
-
-    #[test]
-    fn test_add_average_case_merk_propagate_version_mismatch_error() {
-        let mut custom_version = GroveVersion::latest().clone();
-        custom_version
-            .merk_versions
-            .average_case_costs
-            .add_average_case_merk_propagate = 99;
-
-        let layer_info = EstimatedLayerInformation {
-            tree_type: TreeType::NormalTree,
-            estimated_layer_count: EstimatedLayerCount::EstimatedLevel(1, false),
-            estimated_layer_sizes: EstimatedLayerSizes::AllItems(5, 20, None),
-        };
-
-        let mut cost = OperationCost::default();
-        let err =
-            add_average_case_merk_propagate(&mut cost, &layer_info, &custom_version).unwrap_err();
-        assert!(matches!(
-            err,
-            Error::VersionError(
-                grovedb_version::error::GroveVersionError::UnknownVersionMismatch { .. }
-            )
-        ));
-    }
-
-    #[test]
-    fn test_add_average_case_merk_propagate_all_items_updates_cost() {
-        let layer_info = EstimatedLayerInformation {
-            tree_type: TreeType::NormalTree,
-            estimated_layer_count: EstimatedLayerCount::EstimatedLevel(3, false),
-            estimated_layer_sizes: EstimatedLayerSizes::AllItems(8, 32, Some(2)),
-        };
-
-        let mut cost = OperationCost::default();
-        add_average_case_merk_propagate(&mut cost, &layer_info, GroveVersion::latest()).unwrap();
-
-        assert!(cost.seek_count > 0);
-        assert!(cost.hash_node_calls > 0);
-        assert!(cost.storage_cost.replaced_bytes > 0);
-        assert!(cost.storage_loaded_bytes > 0);
-    }
-}
 
 #[cfg(feature = "minimal")]
 /// Add average case cost for propagating a merk
@@ -1185,4 +1043,147 @@ fn add_average_case_merk_propagate_v0(
         }
     } as u64;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use grovedb_costs::OperationCost;
+    use grovedb_version::version::GroveVersion;
+
+    use super::*;
+
+    #[test]
+    fn test_estimated_sum_trees_divide_by_zero() {
+        let estimated = EstimatedSumTrees::SomeSumTrees {
+            sum_trees_weight: 0,
+            big_sum_trees_weight: 0,
+            count_trees_weight: 0,
+            count_sum_trees_weight: 0,
+            non_sum_trees_weight: 0,
+        };
+        let err = estimated
+            .estimated_size(GroveVersion::latest())
+            .unwrap_err();
+        assert!(matches!(err, Error::DivideByZero("weights add up to 0")));
+    }
+
+    #[test]
+    fn test_estimated_sum_trees_v0_formula_path() {
+        let estimated = EstimatedSumTrees::SomeSumTrees {
+            sum_trees_weight: 1,
+            big_sum_trees_weight: 0,
+            count_trees_weight: 0,
+            count_sum_trees_weight: 0,
+            non_sum_trees_weight: 3,
+        };
+        let size = estimated.estimated_size(GroveVersion::first()).unwrap();
+        assert_eq!(size, 6);
+    }
+
+    #[test]
+    fn test_layered_flags_size_errors() {
+        let layer = EstimatedLayerSizes::AllItems(4, 10, Some(1));
+        let err = layer.layered_flags_size().unwrap_err();
+        assert!(matches!(
+            err,
+            Error::WrongEstimatedCostsElementTypeForLevel(
+                "this layer does not have costs for trees"
+            )
+        ));
+    }
+
+    #[test]
+    fn test_subtree_with_feature_and_flags_size_mix_missing_subtrees() {
+        let layer = EstimatedLayerSizes::Mix {
+            subtrees_size: None,
+            items_size: Some((4, 10, Some(1), 1)),
+            references_size: None,
+        };
+        let err = layer
+            .subtree_with_feature_and_flags_size(GroveVersion::latest())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Error::WrongEstimatedCostsElementTypeForLevel(
+                "this layer is a mix but doesn't have subtrees"
+            )
+        ));
+    }
+
+    #[test]
+    fn test_value_with_feature_and_flags_size_mix_without_weights() {
+        let layer = EstimatedLayerSizes::Mix {
+            subtrees_size: None,
+            items_size: None,
+            references_size: None,
+        };
+        let err = layer
+            .value_with_feature_and_flags_size(GroveVersion::latest())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Error::WrongEstimatedCostsElementTypeForLevel(
+                "this layer is a mix and does not have items, refs or trees"
+            )
+        ));
+    }
+
+    #[test]
+    fn test_estimated_layer_count_helpers() {
+        assert!(EstimatedLayerCount::ApproximateElements(0).estimated_to_be_empty());
+        assert_eq!(
+            EstimatedLayerCount::ApproximateElements(7).estimate_levels(),
+            3
+        );
+        assert_eq!(
+            EstimatedLayerCount::PotentiallyAtMaxElements.estimate_levels(),
+            32
+        );
+        assert_eq!(
+            EstimatedLayerCount::EstimatedLevel(5, false).estimate_levels(),
+            5
+        );
+    }
+
+    #[test]
+    fn test_add_average_case_merk_propagate_version_mismatch_error() {
+        let mut custom_version = GroveVersion::latest().clone();
+        custom_version
+            .merk_versions
+            .average_case_costs
+            .add_average_case_merk_propagate = 99;
+
+        let layer_info = EstimatedLayerInformation {
+            tree_type: TreeType::NormalTree,
+            estimated_layer_count: EstimatedLayerCount::EstimatedLevel(1, false),
+            estimated_layer_sizes: EstimatedLayerSizes::AllItems(5, 20, None),
+        };
+
+        let mut cost = OperationCost::default();
+        let err =
+            add_average_case_merk_propagate(&mut cost, &layer_info, &custom_version).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::VersionError(
+                grovedb_version::error::GroveVersionError::UnknownVersionMismatch { .. }
+            )
+        ));
+    }
+
+    #[test]
+    fn test_add_average_case_merk_propagate_all_items_updates_cost() {
+        let layer_info = EstimatedLayerInformation {
+            tree_type: TreeType::NormalTree,
+            estimated_layer_count: EstimatedLayerCount::EstimatedLevel(3, false),
+            estimated_layer_sizes: EstimatedLayerSizes::AllItems(8, 32, Some(2)),
+        };
+
+        let mut cost = OperationCost::default();
+        add_average_case_merk_propagate(&mut cost, &layer_info, GroveVersion::latest()).unwrap();
+
+        assert!(cost.seek_count > 0);
+        assert!(cost.hash_node_calls > 0);
+        assert!(cost.storage_cost.replaced_bytes > 0);
+        assert!(cost.storage_loaded_bytes > 0);
+    }
 }

--- a/merk/src/estimated_costs/average_case_costs.rs
+++ b/merk/src/estimated_costs/average_case_costs.rs
@@ -773,6 +773,149 @@ fn add_average_case_merk_propagate_v1(
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use grovedb_costs::OperationCost;
+    use grovedb_version::version::GroveVersion;
+
+    use super::*;
+
+    #[test]
+    fn test_estimated_sum_trees_divide_by_zero() {
+        let estimated = EstimatedSumTrees::SomeSumTrees {
+            sum_trees_weight: 0,
+            big_sum_trees_weight: 0,
+            count_trees_weight: 0,
+            count_sum_trees_weight: 0,
+            non_sum_trees_weight: 0,
+        };
+        let err = estimated
+            .estimated_size(GroveVersion::latest())
+            .unwrap_err();
+        assert!(matches!(err, Error::DivideByZero("weights add up to 0")));
+    }
+
+    #[test]
+    fn test_estimated_sum_trees_v0_formula_path() {
+        let estimated = EstimatedSumTrees::SomeSumTrees {
+            sum_trees_weight: 1,
+            big_sum_trees_weight: 0,
+            count_trees_weight: 0,
+            count_sum_trees_weight: 0,
+            non_sum_trees_weight: 3,
+        };
+        let size = estimated.estimated_size(GroveVersion::first()).unwrap();
+        assert_eq!(size, 6);
+    }
+
+    #[test]
+    fn test_layered_flags_size_errors() {
+        let layer = EstimatedLayerSizes::AllItems(4, 10, Some(1));
+        let err = layer.layered_flags_size().unwrap_err();
+        assert!(matches!(
+            err,
+            Error::WrongEstimatedCostsElementTypeForLevel(
+                "this layer does not have costs for trees"
+            )
+        ));
+    }
+
+    #[test]
+    fn test_subtree_with_feature_and_flags_size_mix_missing_subtrees() {
+        let layer = EstimatedLayerSizes::Mix {
+            subtrees_size: None,
+            items_size: Some((4, 10, Some(1), 1)),
+            references_size: None,
+        };
+        let err = layer
+            .subtree_with_feature_and_flags_size(GroveVersion::latest())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Error::WrongEstimatedCostsElementTypeForLevel(
+                "this layer is a mix but doesn't have subtrees"
+            )
+        ));
+    }
+
+    #[test]
+    fn test_value_with_feature_and_flags_size_mix_without_weights() {
+        let layer = EstimatedLayerSizes::Mix {
+            subtrees_size: None,
+            items_size: None,
+            references_size: None,
+        };
+        let err = layer
+            .value_with_feature_and_flags_size(GroveVersion::latest())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Error::WrongEstimatedCostsElementTypeForLevel(
+                "this layer is a mix and does not have items, refs or trees"
+            )
+        ));
+    }
+
+    #[test]
+    fn test_estimated_layer_count_helpers() {
+        assert!(EstimatedLayerCount::ApproximateElements(0).estimated_to_be_empty());
+        assert_eq!(
+            EstimatedLayerCount::ApproximateElements(7).estimate_levels(),
+            3
+        );
+        assert_eq!(
+            EstimatedLayerCount::PotentiallyAtMaxElements.estimate_levels(),
+            32
+        );
+        assert_eq!(
+            EstimatedLayerCount::EstimatedLevel(5, false).estimate_levels(),
+            5
+        );
+    }
+
+    #[test]
+    fn test_add_average_case_merk_propagate_version_mismatch_error() {
+        let mut custom_version = GroveVersion::latest().clone();
+        custom_version
+            .merk_versions
+            .average_case_costs
+            .add_average_case_merk_propagate = 99;
+
+        let layer_info = EstimatedLayerInformation {
+            tree_type: TreeType::NormalTree,
+            estimated_layer_count: EstimatedLayerCount::EstimatedLevel(1, false),
+            estimated_layer_sizes: EstimatedLayerSizes::AllItems(5, 20, None),
+        };
+
+        let mut cost = OperationCost::default();
+        let err =
+            add_average_case_merk_propagate(&mut cost, &layer_info, &custom_version).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::VersionError(
+                grovedb_version::error::GroveVersionError::UnknownVersionMismatch { .. }
+            )
+        ));
+    }
+
+    #[test]
+    fn test_add_average_case_merk_propagate_all_items_updates_cost() {
+        let layer_info = EstimatedLayerInformation {
+            tree_type: TreeType::NormalTree,
+            estimated_layer_count: EstimatedLayerCount::EstimatedLevel(3, false),
+            estimated_layer_sizes: EstimatedLayerSizes::AllItems(8, 32, Some(2)),
+        };
+
+        let mut cost = OperationCost::default();
+        add_average_case_merk_propagate(&mut cost, &layer_info, GroveVersion::latest()).unwrap();
+
+        assert!(cost.seek_count > 0);
+        assert!(cost.hash_node_calls > 0);
+        assert!(cost.storage_cost.replaced_bytes > 0);
+        assert!(cost.storage_loaded_bytes > 0);
+    }
+}
+
 #[cfg(feature = "minimal")]
 /// Add average case cost for propagating a merk
 fn add_average_case_merk_propagate_v0(

--- a/merk/src/proofs/chunk/chunk_op.rs
+++ b/merk/src/proofs/chunk/chunk_op.rs
@@ -166,4 +166,20 @@ mod test {
             ])
         );
     }
+
+    #[test]
+    fn test_chunk_op_decoding_unexpected_marker() {
+        let err = ChunkOp::decode([9u8].as_slice()).unwrap_err();
+        assert!(matches!(err, ed::Error::UnexpectedByte(9)));
+    }
+
+    #[test]
+    fn test_chunk_op_decoding_non_binary_chunk_id_values() {
+        let encoded_chunk_op = vec![0, 4, 1, 2, 0, 255];
+        let decoded_chunk_op = ChunkOp::decode(encoded_chunk_op.as_slice()).unwrap();
+        assert_eq!(
+            decoded_chunk_op,
+            ChunkOp::ChunkId(vec![true, false, false, false])
+        );
+    }
 }

--- a/merk/src/proofs/chunk/error.rs
+++ b/merk/src/proofs/chunk/error.rs
@@ -77,3 +77,36 @@ pub enum ChunkError {
     #[error("internal error {0}")]
     InternalError(&'static str),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ChunkError;
+
+    #[test]
+    fn test_chunk_error_messages() {
+        assert_eq!(
+            ChunkError::LimitTooSmall("x").to_string(),
+            "overflow error x"
+        );
+        assert_eq!(
+            ChunkError::OutOfBounds("x").to_string(),
+            "chunk index out of bounds: x"
+        );
+        assert_eq!(
+            ChunkError::BadTraversalInstruction("x").to_string(),
+            "traversal instruction invalid x"
+        );
+        assert_eq!(
+            ChunkError::InvalidChunkProof("x").to_string(),
+            "invalid chunk proof: x"
+        );
+        assert_eq!(
+            ChunkError::InvalidMultiChunk("x").to_string(),
+            "invalid multi chunk: x"
+        );
+        assert_eq!(
+            ChunkError::RestorationNotComplete.to_string(),
+            "called finalize too early still expecting chunks"
+        );
+    }
+}


### PR DESCRIPTION
Improves test coverage for the grovedb-merk crate (82.03% baseline). Adds tests for proof operations, tree balancing, encoding/decoding, and error paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for error handling, cost estimation algorithms, and proof verification operations to enhance code quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->