### PR TITLE
test(query): add test suite for coverage improvement

### DIFF
--- a/grovedb-query/tests/query_api_and_serialization.rs
+++ b/grovedb-query/tests/query_api_and_serialization.rs
@@ -11,44 +11,6 @@ fn k(v: u8) -> Vec<u8> {
 }
 
 #[test]
-fn query_constructors_and_iteration_behave_as_expected() {
-    let q = Query::new();
-    assert!(q.is_empty());
-    assert_eq!(q.len(), 0);
-    assert!(q.left_to_right);
-
-    let q_full = Query::new_range_full();
-    assert_eq!(q_full.items, vec![QueryItem::RangeFull(..)]);
-
-    let q_key = Query::new_single_key(k(10));
-    assert_eq!(q_key.items, vec![QueryItem::Key(k(10))]);
-
-    let q_item = Query::new_single_query_item(QueryItem::Range(k(1)..k(3)));
-    assert_eq!(q_item.items, vec![QueryItem::Range(k(1)..k(3))]);
-
-    let q_dir = Query::new_with_direction(false);
-    assert!(!q_dir.left_to_right);
-
-    let q_dir_item = Query::new_single_query_item_with_direction(QueryItem::Key(k(9)), false);
-    assert_eq!(q_dir_item.items, vec![QueryItem::Key(k(9))]);
-    assert!(!q_dir_item.left_to_right);
-
-    let mut q_iter = Query::new();
-    q_iter.insert_key(k(3));
-    q_iter.insert_key(k(1));
-    q_iter.insert_key(k(2));
-
-    let forward: Vec<_> = q_iter.iter().cloned().collect();
-    let reverse: Vec<_> = q_iter.rev_iter().cloned().collect();
-    let directional_forward: Vec<_> = q_iter.directional_iter(true).cloned().collect();
-    let directional_reverse: Vec<_> = q_iter.directional_iter(false).cloned().collect();
-
-    assert_eq!(forward, directional_forward);
-    assert_eq!(reverse, directional_reverse);
-    assert_eq!(forward.into_iter().rev().collect::<Vec<_>>(), reverse);
-}
-
-#[test]
 fn query_subquery_flags_and_conditional_first_match_work() {
     let mut q = Query::new();
     q.insert_key(k(1));

--- a/grovedb-query/tests/query_api_and_serialization.rs
+++ b/grovedb-query/tests/query_api_and_serialization.rs
@@ -1,0 +1,140 @@
+use bincode::{
+    borrow_decode_from_slice, config::standard, decode_from_slice, encode_into_std_write,
+    encode_to_vec,
+};
+use indexmap::IndexMap;
+
+use grovedb_query::{Query, QueryItem, SubqueryBranch};
+
+fn k(v: u8) -> Vec<u8> {
+    vec![v]
+}
+
+#[test]
+fn query_constructors_and_iteration_behave_as_expected() {
+    let q = Query::new();
+    assert!(q.is_empty());
+    assert_eq!(q.len(), 0);
+    assert!(q.left_to_right);
+
+    let q_full = Query::new_range_full();
+    assert_eq!(q_full.items, vec![QueryItem::RangeFull(..)]);
+
+    let q_key = Query::new_single_key(k(10));
+    assert_eq!(q_key.items, vec![QueryItem::Key(k(10))]);
+
+    let q_item = Query::new_single_query_item(QueryItem::Range(k(1)..k(3)));
+    assert_eq!(q_item.items, vec![QueryItem::Range(k(1)..k(3))]);
+
+    let q_dir = Query::new_with_direction(false);
+    assert!(!q_dir.left_to_right);
+
+    let q_dir_item = Query::new_single_query_item_with_direction(QueryItem::Key(k(9)), false);
+    assert_eq!(q_dir_item.items, vec![QueryItem::Key(k(9))]);
+    assert!(!q_dir_item.left_to_right);
+
+    let mut q_iter = Query::new();
+    q_iter.insert_key(k(3));
+    q_iter.insert_key(k(1));
+    q_iter.insert_key(k(2));
+
+    let forward: Vec<_> = q_iter.iter().cloned().collect();
+    let reverse: Vec<_> = q_iter.rev_iter().cloned().collect();
+    let directional_forward: Vec<_> = q_iter.directional_iter(true).cloned().collect();
+    let directional_reverse: Vec<_> = q_iter.directional_iter(false).cloned().collect();
+
+    assert_eq!(forward, directional_forward);
+    assert_eq!(reverse, directional_reverse);
+    assert_eq!(forward.into_iter().rev().collect::<Vec<_>>(), reverse);
+}
+
+#[test]
+fn query_subquery_flags_and_conditional_first_match_work() {
+    let mut q = Query::new();
+    q.insert_key(k(1));
+    assert!(!q.has_subquery());
+    assert!(q.has_only_keys());
+
+    q.set_subquery_key(k(9));
+    assert!(q.has_subquery());
+    assert!(q.has_subquery_or_subquery_path_on_key(&k(1), false));
+    assert!(!q.has_subquery_on_key(&k(1), false));
+
+    let mut nested = Query::new();
+    nested.insert_key(k(7));
+    q.set_subquery(nested);
+    assert!(q.has_subquery_on_key(&k(1), false));
+
+    let mut cond = Query::new();
+    cond.insert_key(k(5));
+    cond.add_conditional_subquery(QueryItem::Range(k(0)..k(10)), None, None);
+    cond.add_conditional_subquery(
+        QueryItem::RangeInclusive(k(4)..=k(6)),
+        None,
+        Some(Query::new_single_key(k(8))),
+    );
+
+    assert!(cond.has_subquery());
+    // First matching conditional branch wins (the first has no subquery).
+    assert!(!cond.has_subquery_on_key(&k(5), false));
+    assert!(cond.has_subquery_or_subquery_path_on_key(&k(5), false));
+    assert!(cond.has_subquery_on_key(&k(99), true));
+}
+
+#[test]
+fn query_encode_decode_and_borrow_decode_round_trip() {
+    let mut q = Query::new_single_key(k(1));
+    q.left_to_right = false;
+    q.add_parent_tree_on_subquery = true;
+    q.set_subquery_path(vec![k(9), k(10)]);
+
+    let mut branch_map = IndexMap::new();
+    branch_map.insert(
+        QueryItem::RangeInclusive(k(2)..=k(3)),
+        SubqueryBranch {
+            subquery_path: Some(vec![k(11)]),
+            subquery: Some(Box::new(Query::new_single_key(k(12)))),
+        },
+    );
+    q.conditional_subquery_branches = Some(branch_map);
+
+    let encoded = encode_to_vec(&q, standard()).expect("encode query");
+
+    let (decoded, consumed): (Query, usize) =
+        decode_from_slice(&encoded, standard()).expect("decode query");
+    assert_eq!(consumed, encoded.len());
+    assert_eq!(decoded, q);
+
+    let (borrow_decoded, borrow_consumed): (Query, usize) =
+        borrow_decode_from_slice(&encoded, standard()).expect("borrow decode query");
+    assert_eq!(borrow_consumed, encoded.len());
+    assert_eq!(borrow_decoded, q);
+}
+
+#[test]
+fn query_decode_rejects_unsupported_version() {
+    let err = decode_from_slice::<Query, _>(&[2_u8], standard()).expect_err("must fail");
+    assert!(err
+        .to_string()
+        .contains("unsupported Query encoding version"));
+}
+
+#[test]
+fn query_decode_rejects_too_many_conditional_branches() {
+    let mut bytes = Vec::new();
+    let cfg = standard();
+
+    encode_into_std_write(1_u8, &mut bytes, cfg).expect("encode version");
+    encode_into_std_write(Vec::<QueryItem>::new(), &mut bytes, cfg).expect("encode items");
+    encode_into_std_write(SubqueryBranch::default(), &mut bytes, cfg)
+        .expect("encode default branch");
+    encode_into_std_write(1_u8, &mut bytes, cfg).expect("encode conditional flag");
+    encode_into_std_write(1025_u64, &mut bytes, cfg).expect("encode oversized len");
+    encode_into_std_write(true, &mut bytes, cfg).expect("encode ltr");
+    encode_into_std_write(false, &mut bytes, cfg).expect("encode add parent");
+
+    let err = decode_from_slice::<Query, _>(&bytes, cfg).expect_err("must fail");
+    assert!(err
+        .to_string()
+        .contains("conditional subquery branches length exceeds maximum"));
+}

--- a/grovedb-query/tests/query_terminal_and_merge.rs
+++ b/grovedb-query/tests/query_terminal_and_merge.rs
@@ -1,0 +1,165 @@
+use grovedb_query::{error::Error, Query, QueryItem, SubqueryBranch};
+
+fn k(v: u8) -> Vec<u8> {
+    vec![v]
+}
+
+fn p(v: &[u8]) -> Vec<u8> {
+    v.to_vec()
+}
+
+#[test]
+fn terminal_keys_plain_and_subquery_path_forms() {
+    let mut plain = Query::new();
+    plain.insert_keys(vec![k(1), k(2)]);
+
+    let mut result = vec![];
+    let added = plain
+        .terminal_keys(vec![k(99)], 10, &mut result)
+        .expect("terminal keys");
+    assert_eq!(added, 2);
+    assert_eq!(result.len(), 2);
+    assert!(result.contains(&(vec![k(99)], k(1))));
+    assert!(result.contains(&(vec![k(99)], k(2))));
+
+    let mut with_path = Query::new_single_key(k(7));
+    with_path.set_subquery_path(vec![k(8), k(9)]);
+
+    let mut result = vec![];
+    let added = with_path
+        .terminal_keys(vec![k(1)], 10, &mut result)
+        .expect("terminal keys");
+    assert_eq!(added, 1);
+    assert_eq!(result, vec![(vec![k(1), k(7), k(8)], k(9))]);
+}
+
+#[test]
+fn terminal_keys_recursive_and_deduplicated() {
+    let mut leaf = Query::new();
+    leaf.insert_key(k(3));
+
+    let mut root = Query::new_single_key(k(1));
+    root.set_subquery_path(vec![k(2)]);
+    root.set_subquery(leaf);
+
+    // Duplicate key in conditional branch must not be added from top-level items twice.
+    root.add_conditional_subquery(
+        QueryItem::Key(k(1)),
+        Some(vec![k(4), k(5)]),
+        Some(Query::new_single_key(k(6))),
+    );
+
+    let mut result = vec![];
+    let added = root
+        .terminal_keys(vec![], 10, &mut result)
+        .expect("terminal keys");
+
+    assert_eq!(added, 1);
+    assert_eq!(result, vec![(vec![k(1), k(4), k(5)], k(6))]);
+}
+
+#[test]
+fn terminal_keys_error_paths_are_reported() {
+    let mut with_unbounded = Query::new();
+    with_unbounded.insert_all();
+    let mut out = vec![];
+    let err = with_unbounded
+        .terminal_keys(vec![], 10, &mut out)
+        .expect_err("must fail on unbounded item");
+    assert!(matches!(err, Error::NotSupported(_)));
+
+    let mut conditional_unbounded = Query::new_single_key(k(1));
+    conditional_unbounded.add_conditional_subquery(QueryItem::RangeFull(..), None, None);
+    let mut out = vec![];
+    let err = conditional_unbounded
+        .terminal_keys(vec![], 10, &mut out)
+        .expect_err("must fail on unbounded conditional item");
+    assert!(matches!(err, Error::NotSupported(_)));
+
+    let mut exceeding = Query::new();
+    exceeding.insert_keys(vec![k(1), k(2)]);
+    let mut out = vec![];
+    let err = exceeding
+        .terminal_keys(vec![], 1, &mut out)
+        .expect_err("must fail on max results");
+    assert!(matches!(err, Error::RequestAmountExceeded(_)));
+
+    let mut corrupted_path = Query::new_single_key(k(1));
+    corrupted_path.set_subquery_path(vec![]);
+    let mut out = vec![];
+    let err = corrupted_path
+        .terminal_keys(vec![], 10, &mut out)
+        .expect_err("must fail on empty subquery path");
+    assert!(matches!(err, Error::CorruptedCodeExecution(_)));
+}
+
+#[test]
+fn merge_apis_cover_default_and_conditional_paths() {
+    let mut base = Query::new();
+    base.insert_key(k(1));
+
+    let mut other = Query::new();
+    other.insert_key(k(2));
+    other.set_subquery_path(vec![k(9)]);
+
+    base.merge_with(other);
+    assert_eq!(base.items.len(), 2);
+    assert!(base.items.contains(&QueryItem::Key(k(1))));
+    assert!(base.items.contains(&QueryItem::Key(k(2))));
+
+    let conditional = base
+        .conditional_subquery_branches
+        .as_ref()
+        .expect("conditional branch should be created");
+    assert!(conditional.contains_key(&QueryItem::Key(k(2))));
+
+    let merged_empty = Query::merge_multiple(vec![]);
+    assert!(merged_empty.items.is_empty());
+
+    let mut left = Query::new_single_key(k(10));
+    left.default_subquery_branch = SubqueryBranch {
+        subquery_path: Some(vec![k(1), k(2)]),
+        subquery: Some(Box::new(Query::new_single_key(k(20)))),
+    };
+
+    left.merge_default_subquery_branch(SubqueryBranch {
+        subquery_path: Some(vec![k(1), k(3)]),
+        subquery: Some(Box::new(Query::new_single_key(k(30)))),
+    });
+
+    assert_eq!(left.default_subquery_branch.subquery_path, Some(vec![k(1)]));
+    let merged_conditionals = left
+        .conditional_subquery_branches
+        .as_ref()
+        .expect("expected merged conditionals from split path");
+    assert!(merged_conditionals.contains_key(&QueryItem::Key(k(2))));
+    assert!(merged_conditionals.contains_key(&QueryItem::Key(k(3))));
+}
+
+#[test]
+fn merge_conditional_subquery_branches_splits_intersections() {
+    use indexmap::IndexMap;
+
+    let mut existing = IndexMap::new();
+    existing.insert(
+        QueryItem::Range(k(1)..k(5)),
+        SubqueryBranch {
+            subquery_path: Some(vec![p(b"a")]),
+            subquery: None,
+        },
+    );
+
+    let merged = Query::merge_conditional_subquery_branches_with_new_at_query_item(
+        Some(existing),
+        QueryItem::Range(k(3)..k(7)),
+        SubqueryBranch {
+            subquery_path: Some(vec![p(b"a")]),
+            subquery: None,
+        },
+    );
+
+    assert_eq!(merged.len(), 3);
+    assert!(merged.contains_key(&QueryItem::Range(k(1)..k(3))));
+    assert!(merged.contains_key(&QueryItem::Range(k(3)..k(5))));
+    assert!(merged.contains_key(&QueryItem::Range(k(5)..k(7))));
+}

--- a/grovedb-query/tests/utilities_and_proof_items.rs
+++ b/grovedb-query/tests/utilities_and_proof_items.rs
@@ -1,32 +1,7 @@
-use grovedb_query::{
-    hex_to_ascii,
-    proofs::{Node, NULL_HASH},
-    ProofItems, ProofStatus, Query, QueryItem, SubqueryBranch,
-};
+use grovedb_query::{ProofItems, QueryItem};
 
 fn k(v: u8) -> Vec<u8> {
     vec![v]
-}
-
-#[test]
-fn hex_to_ascii_returns_ascii_or_hex() {
-    let ascii = b"Abc_-/\\[]@09";
-    assert_eq!(hex_to_ascii(ascii), "Abc_-/\\[]@09");
-
-    let non_ascii = [0_u8, 255_u8];
-    assert_eq!(hex_to_ascii(&non_ascii), "0x00ff");
-}
-
-#[test]
-fn proof_status_limit_update_and_hit_limit() {
-    let status = ProofStatus::new_with_limit(Some(2));
-    assert!(!status.hit_limit());
-
-    let unchanged = status.update_limit(None);
-    assert_eq!(unchanged.limit, Some(2));
-
-    let exhausted = unchanged.update_limit(Some(0));
-    assert!(exhausted.hit_limit());
 }
 
 #[test]
@@ -44,33 +19,4 @@ fn proof_items_partition_and_process_key_with_boundaries() {
     assert!(on_boundary);
     assert!(!left.has_no_query_items());
     assert!(!right.has_no_query_items());
-}
-
-#[test]
-fn subquery_branch_max_depth_and_display_are_stable() {
-    let mut nested = Query::new_single_key(k(1));
-    nested.set_subquery_path(vec![k(2)]);
-
-    let branch = SubqueryBranch {
-        subquery_path: Some(vec![k(9)]),
-        subquery: Some(Box::new(nested)),
-    };
-
-    assert_eq!(SubqueryBranch::default().max_depth(), Some(0));
-    assert_eq!(branch.max_depth(), Some(3));
-
-    let rendered = format!("{}", branch);
-    assert!(rendered.contains("subquery_path"));
-    assert!(rendered.contains("subquery"));
-}
-
-#[test]
-fn display_impls_cover_key_rendering() {
-    let node = Node::KV(b"key".to_vec(), b"value".to_vec());
-    let rendered = format!("{}", node);
-    assert!(rendered.contains("KV(key, value)"));
-
-    // Keep at least one hash-based display path exercised.
-    let hash_rendered = format!("{}", Node::Hash(NULL_HASH));
-    assert!(hash_rendered.contains("Hash(HASH["));
 }

--- a/grovedb-query/tests/utilities_and_proof_items.rs
+++ b/grovedb-query/tests/utilities_and_proof_items.rs
@@ -1,0 +1,76 @@
+use grovedb_query::{
+    hex_to_ascii,
+    proofs::{Node, NULL_HASH},
+    ProofItems, ProofStatus, Query, QueryItem, SubqueryBranch,
+};
+
+fn k(v: u8) -> Vec<u8> {
+    vec![v]
+}
+
+#[test]
+fn hex_to_ascii_returns_ascii_or_hex() {
+    let ascii = b"Abc_-/\\[]@09";
+    assert_eq!(hex_to_ascii(ascii), "Abc_-/\\[]@09");
+
+    let non_ascii = [0_u8, 255_u8];
+    assert_eq!(hex_to_ascii(&non_ascii), "0x00ff");
+}
+
+#[test]
+fn proof_status_limit_update_and_hit_limit() {
+    let status = ProofStatus::new_with_limit(Some(2));
+    assert!(!status.hit_limit());
+
+    let unchanged = status.update_limit(None);
+    assert_eq!(unchanged.limit, Some(2));
+
+    let exhausted = unchanged.update_limit(Some(0));
+    assert!(exhausted.hit_limit());
+}
+
+#[test]
+fn proof_items_partition_and_process_key_with_boundaries() {
+    let query_items = vec![QueryItem::RangeAfter(k(5)..), QueryItem::Range(k(3)..k(7))];
+
+    let (proof_items, params) = ProofItems::new_with_query_items(&query_items, false);
+    assert!(!params.left_to_right);
+    assert!(!proof_items.has_no_query_items());
+
+    let target = k(5);
+    let (present, on_boundary, left, right) = proof_items.process_key(&target);
+
+    assert!(present);
+    assert!(on_boundary);
+    assert!(!left.has_no_query_items());
+    assert!(!right.has_no_query_items());
+}
+
+#[test]
+fn subquery_branch_max_depth_and_display_are_stable() {
+    let mut nested = Query::new_single_key(k(1));
+    nested.set_subquery_path(vec![k(2)]);
+
+    let branch = SubqueryBranch {
+        subquery_path: Some(vec![k(9)]),
+        subquery: Some(Box::new(nested)),
+    };
+
+    assert_eq!(SubqueryBranch::default().max_depth(), Some(0));
+    assert_eq!(branch.max_depth(), Some(3));
+
+    let rendered = format!("{}", branch);
+    assert!(rendered.contains("subquery_path"));
+    assert!(rendered.contains("subquery"));
+}
+
+#[test]
+fn display_impls_cover_key_rendering() {
+    let node = Node::KV(b"key".to_vec(), b"value".to_vec());
+    let rendered = format!("{}", node);
+    assert!(rendered.contains("KV(key, value)"));
+
+    // Keep at least one hash-based display path exercised.
+    let hash_rendered = format!("{}", Node::Hash(NULL_HASH));
+    assert!(hash_rendered.contains("Hash(HASH["));
+}


### PR DESCRIPTION
## Summary
- Tests for encode/decode round-trip and error paths (unsupported version, oversized branches)
- Tests for conditional subquery branch first-match-wins logic
- Tests for terminal_keys recursion, deduplication, and error paths
- Tests for merge APIs including range intersection splitting
- Tests for ProofItems process_key partitioning

Cleaned up from #439 — removed trivial constructor/accessor/Display tests that only inflate coverage numbers without catching real bugs.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Query API serialization, deserialization, and round-trip verification
  * Added test coverage for terminal keys behavior and query merging logic
  * Added test coverage for query item boundary processing and state validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->