### PR TITLE
docs(grovedb): add docstrings with review fixes

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -3991,6 +3991,7 @@ mod tests {
         );
     }
 
+    /// Tests reference element handling in batch operations, including missing references, in-batch resolution, proof generation, and reference hop limits.
     #[test]
     fn test_references() {
         let grove_version = GroveVersion::latest();

--- a/grovedb/src/operations/get/query.rs
+++ b/grovedb/src/operations/get/query.rs
@@ -156,7 +156,19 @@ where {
         Ok(result).wrap_with_cost(cost)
     }
 
-    /// Prove a path query as either verbose or non-verbose
+    /// Generates a cryptographic proof for a given path query, optionally using provided prove options and transaction context.
+    ///
+    /// Returns a serialized proof as a vector of bytes, which can be used to verify the query result externally. The proof can be generated in verbose or non-verbose mode depending on the prove options.
+    ///
+    /// # Returns
+    /// A cost-tracked result containing the serialized proof bytes or an error if the operation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let proof = grovedb.get_proved_path_query(&path_query, Some(prove_options), transaction, &grove_version)?;
+    /// assert!(!proof.value.is_empty());
+    /// ```
     pub fn get_proved_path_query(
         &self,
         path_query: &PathQuery,
@@ -175,6 +187,21 @@ where {
         self.prove_query(path_query, prove_options, transaction, grove_version)
     }
 
+    /// Resolves an element by following references to their target item, sum, or count elements.
+    ///
+    /// If the provided element is a reference with an absolute path, this method follows the reference and returns the referenced element if it is an item, sum item, sum tree, big sum tree, count tree, or count sum tree. If the element is already one of these types, it is returned as-is. Returns an error if the reference is not absolute, if it does not resolve to a valid item, or if the element is a tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the element is a tree, if a reference is not absolute, or if a reference does not resolve to a valid item.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let element = Element::Reference(ReferencePathType::AbsolutePathReference(vec![b"root".to_vec()]), ..);
+    /// let resolved = grovedb.follow_element(element, true, &mut cost, None, &grove_version)?;
+    /// assert!(resolved.is_any_item());
+    /// ```
     fn follow_element(
         &self,
         element: Element,

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -32,6 +32,15 @@ pub enum OwnedOrBorrowedTransaction<'db> {
 impl<'db> Deref for OwnedOrBorrowedTransaction<'db> {
     type Target = Transaction<'db>;
 
+    /// Returns a reference to the underlying `Transaction`, regardless of whether it is owned or borrowed.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let tx = Transaction::default();
+    /// let owned = OwnedOrBorrowedTransaction::OwnedTransaction(tx);
+    /// let reference: &Transaction = owned.deref();
+    /// ```
     fn deref(&self) -> &Self::Target {
         match self {
             OwnedOrBorrowedTransaction::BorrowedTransaction(borrowed) => borrowed,
@@ -41,9 +50,17 @@ impl<'db> Deref for OwnedOrBorrowedTransaction<'db> {
 }
 
 impl GroveDb {
-    /// Prove one or more path queries.
-    /// If we have more than one path query, we merge into a single path query
-    /// before proving.
+    /// Generates a cryptographic proof for multiple path queries, merging them if necessary.
+    ///
+    /// If more than one query is provided, merges them into a single query before generating the proof. Returns the serialized proof as a byte vector, or an error with operation cost if proof generation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let queries = vec![&path_query1, &path_query2];
+    /// let proof = grovedb.prove_query_many(queries, None, tx_arg, &grove_version)?;
+    /// assert!(!proof.is_empty());
+    /// ```
     pub fn prove_query_many(
         &self,
         query: Vec<&PathQuery>,
@@ -67,10 +84,26 @@ impl GroveDb {
         }
     }
 
-    /// Generate a minimalistic proof for a given path query
-    /// doesn't allow for subset verification
-    /// Proofs generated with this can only be verified by the path query used
-    /// to generate them.
+    /// Generates a serialized cryptographic proof for a single database query.
+    ///
+    /// Produces a minimalistic proof for the provided `PathQuery`, serializes it using big-endian
+    /// encoding, and returns the resulting byte vector. This proof does not allow for subset
+    /// verification — it can only be verified by the exact path query used to generate it.
+    ///
+    /// # Returns
+    /// A byte vector containing the serialized proof, or an error wrapped with operation cost if proof generation or serialization fails.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let proof_bytes = grovedb.prove_query(
+    ///     &path_query,
+    ///     Some(prove_options),
+    ///     transaction_arg,
+    ///     &grove_version,
+    /// )?;
+    /// assert!(!proof_bytes.is_empty());
+    /// ```
     pub fn prove_query(
         &self,
         path_query: &PathQuery,
@@ -102,7 +135,24 @@ impl GroveDb {
         Ok(encoded_proof).wrap_with_cost(cost)
     }
 
-    /// Generates a proof and does not serialize the result
+    /// Generates a cryptographic proof for a single path query without serializing the result.
+    ///
+    /// Validates the query parameters, then constructs a minimalistic proof structure representing the database state for the specified query. The proof includes all necessary information to verify the query result externally. Returns the proof as a `GroveDBProof` variant, or an error if the query parameters are invalid.
+    ///
+    /// # Returns
+    /// A `GroveDBProof` containing the proof structure for the query, or an error if the query is invalid (e.g., non-zero offset or zero limit).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let proof = grovedb.prove_query_non_serialized(
+    ///     &path_query,
+    ///     None,
+    ///     tx_arg,
+    ///     &grove_version,
+    /// );
+    /// assert!(proof.is_ok());
+    /// ```
     pub fn prove_query_non_serialized(
         &self,
         path_query: &PathQuery,
@@ -188,8 +238,35 @@ impl GroveDb {
         .wrap_with_cost(cost)
     }
 
-    /// Perform a pre-order traversal of the tree based on the provided
-    /// subqueries
+    /// Recursively generates a layered cryptographic proof for a path query and its subqueries.
+    ///
+    /// Traverses the GroveDB tree according to the provided `PathQuery`, generating a Merk proof for each relevant subtree and recursively including proofs for subqueries. Handles reference resolution, limit enforcement, and proof composition across multiple tree levels. Returns a `LayerProof` containing the serialized Merk proof for the current layer and any lower-layer proofs.
+    ///
+    /// # Parameters
+    /// - `path`: The current path within the GroveDB tree being traversed.
+    /// - `path_query`: The query specifying which elements and subqueries to prove.
+    /// - `overall_limit`: Mutable reference to the remaining result limit, decremented as results are included in the proof.
+    /// - `prove_options`: Options controlling proof generation behavior, such as limit handling.
+    /// - `tx`: The transaction context for database operations.
+    /// - `grove_version`: The GroveDB version to use for compatibility.
+    ///
+    /// # Returns
+    /// A `LayerProof` containing the serialized Merk proof for the current layer and any lower-layer proofs, wrapped with operation cost and error handling.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let mut limit = Some(10);
+    /// let proof = grovedb.prove_subqueries(
+    ///     vec![b"root"],
+    ///     &path_query,
+    ///     &mut limit,
+    ///     &prove_options,
+    ///     tx,
+    ///     &grove_version,
+    /// );
+    /// assert!(proof.is_ok());
+    /// ```
     fn prove_subqueries(
         &self,
         path: Vec<&[u8]>,

--- a/grovedb/src/query/mod.rs
+++ b/grovedb/src/query/mod.rs
@@ -602,6 +602,7 @@ mod tests {
         Element, GroveDb, PathQuery, SizedQuery,
     };
 
+    /// Tests merging two `PathQuery` instances with the same path but different key queries, verifying that the merged query returns results for both keys.
     #[test]
     fn test_same_path_different_query_merge() {
         let grove_version = GroveVersion::latest();
@@ -650,6 +651,7 @@ mod tests {
         assert_eq!(result_set_tree.len(), 2);
     }
 
+    /// Tests merging of `PathQuery` instances with different but same-length paths and queries, verifying correct merged query structure and result sets.
     #[test]
     fn test_different_same_length_path_with_different_query_merge() {
         let grove_version = GroveVersion::latest();
@@ -936,6 +938,7 @@ mod tests {
         compare_result_tuples(proved_result_set_merged, expected_result_set);
     }
 
+    /// Tests merging of `PathQuery` instances with different path lengths and verifies that the merged query returns the combined results from both original queries.
     #[test]
     fn test_different_length_paths_merge() {
         let grove_version = GroveVersion::latest();
@@ -1087,6 +1090,7 @@ mod tests {
         assert_eq!(result_set.len(), 4);
     }
 
+    /// Tests merging of `PathQuery` instances with equal and nested paths, verifying correct query merging, subquery handling, and result set sizes.
     #[test]
     fn test_equal_path_merge() {
         let grove_version = GroveVersion::latest();

--- a/grovedb/src/tests/count_tree_tests.rs
+++ b/grovedb/src/tests/count_tree_tests.rs
@@ -18,6 +18,7 @@ mod tests {
         Element, GroveDb, PathQuery,
     };
 
+    /// Tests that a count tree behaves like a regular tree in GroveDB.
     #[test]
     fn test_count_tree_behaves_like_regular_tree() {
         let grove_version = GroveVersion::latest();

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -771,6 +771,7 @@ mod tests {
         GroveDb::open(tmp_dir).expect("empty tree is ok");
     }
 
+    /// Tests insertion, retrieval, and proof generation for elements with and without flags in GroveDB.
     #[test]
     fn test_element_with_flags() {
         let grove_version = GroveVersion::latest();
@@ -1426,6 +1427,7 @@ mod tests {
         .expect("should exist");
     }
 
+    /// Tests that generating and verifying a proof for a query with an invalid root key returns an empty result set and the correct root hash.
     #[test]
     fn test_proof_for_invalid_path_root_key() {
         let grove_version = GroveVersion::latest();
@@ -1446,6 +1448,7 @@ mod tests {
         assert_eq!(result_set.len(), 0);
     }
 
+    /// Verifies that proofs for queries with invalid paths return an empty result set.
     #[test]
     fn test_proof_for_invalid_path() {
         let grove_version = GroveVersion::latest();
@@ -1532,6 +1535,7 @@ mod tests {
         assert_eq!(result_set.len(), 0);
     }
 
+    /// Tests that generating and verifying a proof for a query on an empty subtree returns an empty result set.
     #[test]
     fn test_proof_for_non_existent_data() {
         let grove_version = GroveVersion::latest();
@@ -1558,6 +1562,7 @@ mod tests {
         assert_eq!(result_set.len(), 0);
     }
 
+    /// Tests proof generation and verification for a path query that includes references without subqueries.
     #[test]
     fn test_path_query_proofs_without_subquery_with_reference() {
         let grove_version = GroveVersion::latest();
@@ -1745,6 +1750,7 @@ mod tests {
         );
     }
 
+    /// Tests proof generation and verification for path queries without subqueries in GroveDB.
     #[test]
     fn test_path_query_proofs_without_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1945,6 +1951,7 @@ mod tests {
         );
     }
 
+    /// Tests proof generation and verification for path queries with default subqueries in GroveDB.
     #[test]
     fn test_path_query_proofs_with_default_subquery() {
         let grove_version = GroveVersion::latest();
@@ -2118,6 +2125,7 @@ mod tests {
         compare_result_tuples(result_set, expected_result_set);
     }
 
+    /// Tests proof generation and verification for path queries using subquery paths in GroveDB.
     #[test]
     fn test_path_query_proofs_with_subquery_path() {
         let grove_version = GroveVersion::latest();
@@ -2259,6 +2267,7 @@ mod tests {
         assert_eq!(result_set.len(), 0);
     }
 
+    /// Tests proof generation and verification for a path query with a key and a subquery key.
     #[test]
     fn test_path_query_proofs_with_key_and_subquery() {
         let grove_version = GroveVersion::latest();
@@ -2296,6 +2305,7 @@ mod tests {
         compare_result_tuples(result_set, expected_result_set);
     }
 
+    /// Tests proof generation and verification for path queries with conditional and default subqueries.
     #[test]
     fn test_path_query_proofs_with_conditional_subquery() {
         let grove_version = GroveVersion::latest();
@@ -2408,6 +2418,7 @@ mod tests {
         compare_result_tuples(result_set, expected_result_set);
     }
 
+    /// Tests proof generation and verification for a sized query with conditional and default subqueries.
     #[test]
     fn test_path_query_proofs_with_sized_query() {
         let grove_version = GroveVersion::latest();
@@ -2460,6 +2471,7 @@ mod tests {
         compare_result_tuples(result_set, expected_result_set);
     }
 
+    /// Tests proof generation and verification for a path query with a range subquery and a result limit.
     #[test]
     fn test_path_query_proof_with_range_subquery_and_limit() {
         let grove_version = GroveVersion::latest();
@@ -2524,6 +2536,7 @@ mod tests {
         }
     }
 
+    /// Tests proof generation and verification for a path query with a range subquery and a result limit on a tree containing sum trees.
     #[test]
     fn test_path_query_proof_with_range_subquery_and_limit_with_sum_trees() {
         let grove_version = GroveVersion::latest();
@@ -2616,6 +2629,7 @@ mod tests {
         }
     }
 
+    /// Tests proof generation and verification for path queries with direction flags and subqueries.
     #[test]
     fn test_path_query_proofs_with_direction() {
         let grove_version = GroveVersion::latest();
@@ -3946,6 +3960,7 @@ mod tests {
         ));
     }
 
+    /// Tests detection of corrupted references in GroveDB by verifying that proof verification and database integrity checks fail when a referenced value is modified.
     #[test]
     fn test_grovedb_verify_corrupted_reference() {
         // This test is dedicated to a case when references are out of sync, but

--- a/grovedb/src/tests/query_tests.rs
+++ b/grovedb/src/tests/query_tests.rs
@@ -730,6 +730,7 @@ mod tests {
         assert_eq!(elements, vec![vec![4], vec![2], vec![1], vec![5], vec![3]]);
     }
 
+    /// Tests a range query with a non-unique subquery, verifying correct element retrieval and proof verification.
     #[test]
     fn test_get_range_query_with_non_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -775,6 +776,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests a range query with a unique subquery, verifying correct element retrieval and proof verification.
     #[test]
     fn test_get_range_query_with_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -815,6 +817,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests unique range queries on a tree containing references, verifying that the correct elements are returned and that proof generation and verification yield consistent results.
     #[test]
     fn test_get_range_query_with_unique_subquery_on_references() {
         let grove_version = GroveVersion::latest();
@@ -855,6 +858,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests a range query with a unique subquery on a tree containing non-unique null values, verifying correct element retrieval and proof verification.
     #[test]
     fn test_get_range_query_with_unique_subquery_with_non_unique_null_values() {
         let grove_version = GroveVersion::latest();
@@ -904,6 +908,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests that a unique range query with a conditional subquery correctly ignores non-unique null values.
     #[test]
     fn test_get_range_query_with_unique_subquery_ignore_non_unique_null_values() {
         let grove_version = GroveVersion::latest();
@@ -954,6 +959,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests inclusive range queries with non-unique subqueries, verifying that all expected elements are returned in order and that proof verification matches the query results.
     #[test]
     fn test_get_range_inclusive_query_with_non_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1001,6 +1007,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests inclusive range queries with non-unique subqueries on reference trees.
     #[test]
     fn test_get_range_inclusive_query_with_non_unique_subquery_on_references() {
         let grove_version = GroveVersion::latest();
@@ -1051,6 +1058,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests inclusive range queries with a unique subquery, verifying that the correct elements are returned and that proof generation and verification yield consistent results.
     #[test]
     fn test_get_range_inclusive_query_with_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1093,6 +1101,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests a range-from query with a non-unique subquery, verifying correct element retrieval and proof verification.
     #[test]
     fn test_get_range_from_query_with_non_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1138,6 +1147,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests a range-from query with a unique subquery, verifying correct retrieval and proof verification.
     #[test]
     fn test_get_range_from_query_with_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1178,6 +1188,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests a range-to query with a non-unique subquery, verifying correct element retrieval and proof verification.
     #[test]
     fn test_get_range_to_query_with_non_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1223,6 +1234,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests a range-to query with a unique subquery, verifying correct element retrieval and proof verification.
     #[test]
     fn test_get_range_to_query_with_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1263,6 +1275,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests inclusive range-to queries with non-unique subqueries in GroveDB.
     #[test]
     fn test_get_range_to_inclusive_query_with_non_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1308,6 +1321,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests an inclusive range-to query with a non-unique subquery where the upper bound key is out of the populated range.
     #[test]
     fn test_get_range_to_inclusive_query_with_non_unique_subquery_and_key_out_of_bounds() {
         let grove_version = GroveVersion::latest();
@@ -1353,6 +1367,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests inclusive range queries with a unique subquery, verifying that the correct elements are returned and that proof verification matches the query results.
     #[test]
     fn test_get_range_to_inclusive_query_with_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1393,6 +1408,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests a range-after query with a non-unique subquery, verifying correct element retrieval and proof verification.
     #[test]
     fn test_get_range_after_query_with_non_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1438,6 +1454,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests a range-after-to query with a non-unique subquery, verifying correct element retrieval and proof verification.
     #[test]
     fn test_get_range_after_to_query_with_non_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1485,6 +1502,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests inclusive range-after-to queries with non-unique subqueries, verifying that the correct number of elements are returned and that proof verification matches the query results.
     #[test]
     fn test_get_range_after_to_inclusive_query_with_non_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1532,6 +1550,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests an inclusive range-after-to query with a non-unique subquery where the upper bound key is out of range.
     #[test]
     fn test_get_range_after_to_inclusive_query_with_non_unique_subquery_and_key_out_of_bounds() {
         let grove_version = GroveVersion::latest();
@@ -1579,6 +1598,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests inclusive range queries with double non-unique subqueries, verifying correct retrieval and proof verification.
     #[test]
     fn test_get_range_inclusive_query_with_double_non_unique_subquery() {
         let grove_version = GroveVersion::latest();
@@ -1630,6 +1650,7 @@ mod tests {
         compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests range queries with various combinations of limits and offsets, verifying correct ordering, element counts, and proof verification for both non-unique and unique subqueries.
     #[test]
     fn test_get_range_query_with_limit_and_offset() {
         let grove_version = GroveVersion::latest();
@@ -1874,6 +1895,7 @@ mod tests {
         assert_eq!(elements[elements.len() - 1], last_value);
     }
 
+    /// Tests that child root hashes are correctly propagated to parent nodes when multiple levels of trees and references are inserted in the same batch.
     #[test]
     fn test_correct_child_root_hash_propagation_for_parent_in_same_batch() {
         let grove_version = GroveVersion::latest();
@@ -2026,6 +2048,7 @@ mod tests {
         assert_eq!(hash, db.root_hash(None, grove_version).unwrap().unwrap());
     }
 
+    /// Tests mixed-level queries and proof verification involving trees, items, and references with various limits and offsets.
     #[test]
     fn test_mixed_level_proofs() {
         let grove_version = GroveVersion::latest();
@@ -2242,6 +2265,7 @@ mod tests {
         assert_eq!(elements, vec![vec![1]]);
     }
 
+    /// Tests mixed-level queries and proof verification involving both trees and items, including conditional subqueries and query limits.
     #[test]
     fn test_mixed_level_proofs_with_tree() {
         let grove_version = GroveVersion::latest();
@@ -2393,6 +2417,7 @@ mod tests {
         // compare_result_sets(&elements, &result_set);
     }
 
+    /// Tests mixed-level GroveDB queries with subquery paths and verifies proof correctness.
     #[test]
     fn test_mixed_level_proofs_with_subquery_paths() {
         let grove_version = GroveVersion::latest();
@@ -2697,6 +2722,7 @@ mod tests {
         assert_eq!(result_set.len(), 8);
     }
 
+    /// Tests that attempting to generate a proof for a query with a limit of zero results in an error.
     #[test]
     fn test_proof_with_limit_zero() {
         let grove_version = GroveVersion::latest();
@@ -2713,6 +2739,7 @@ mod tests {
             .expect_err("expected error when trying to prove with limit 0");
     }
 
+    /// Tests that result set paths are correctly tracked after proof verification for various query types, including subqueries and subquery paths.
     #[test]
     fn test_result_set_path_after_verification() {
         let grove_version = GroveVersion::latest();
@@ -2873,6 +2900,7 @@ mod tests {
         assert_eq!(result_set[3].key, b"innertree4".to_vec());
     }
 
+    /// Tests that proof verification returns the correct set of (path, key, optional element) tuples for a query over a subtree.
     #[test]
     fn test_verification_with_path_key_optional_element_trio() {
         let grove_version = GroveVersion::latest();
@@ -2916,6 +2944,7 @@ mod tests {
         );
     }
 
+    /// Tests proof generation and verification for absent and present keys in a subtree.
     #[test]
     fn test_absence_proof() {
         let grove_version = GroveVersion::latest();
@@ -2972,6 +3001,7 @@ mod tests {
         assert_eq!(result_set[3].2, None);
     }
 
+    /// Tests that a proof generated for a superset query can be used to verify a subset query, ensuring correct result extraction and root hash consistency.
     #[test]
     fn test_subset_proof_verification() {
         let grove_version = GroveVersion::latest();
@@ -3055,6 +3085,7 @@ mod tests {
             )
         );
     }
+    /// Tests chained path query verification by generating a proof for a nested query, then verifying the proof and chaining additional path queries based on the results.
     #[test]
     fn test_chained_path_query_verification() {
         let grove_version = GroveVersion::latest();
@@ -3201,6 +3232,7 @@ mod tests {
         );
     }
 
+    /// Tests chained query proof generation and verification where the result of one query determines the parameters of the next.
     #[test]
     fn test_query_b_depends_on_query_a() {
         let grove_version = GroveVersion::latest();
@@ -3382,6 +3414,7 @@ mod tests {
         assert_eq!(age_result[1].2, Some(Element::new_item(vec![46])));
     }
 
+    /// Tests that a proof can be generated and verified for the absence of a key in a path containing an intermediate empty tree.
     #[test]
     fn test_prove_absent_path_with_intermediate_emtpy_tree() {
         let grove_version = GroveVersion::latest();
@@ -3410,6 +3443,7 @@ mod tests {
         );
     }
 
+    /// Tests that a path query with a subquery and a limit of 2, ascending from the start, returns the correct elements and verifies the proof.
     #[test]
     fn test_path_query_items_with_subquery_and_limit_2_asc_from_start() {
         // The structure is the following
@@ -3456,6 +3490,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a descending path query with a subquery and a limit of 2 returns the correct elements and verifies the proof.
     #[test]
     fn test_path_query_items_with_subquery_and_limit_2_desc_from_start() {
         // The structure is the following
@@ -3502,6 +3537,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with a subquery and a limit of 2, starting in the middle of a two-by-two hierarchy, returns the correct elements and verifies the proof.
     #[test]
     fn test_path_query_items_with_subquery_and_limit_2_asc_in_middle() {
         // The structure is the following
@@ -3548,6 +3584,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a descending range query with a subquery and a limit of 2 returns the correct elements from the middle of a two-by-two hierarchy tree.
     #[test]
     fn test_path_query_items_with_subquery_and_limit_2_desc_in_middle() {
         // The structure is the following
@@ -3594,6 +3631,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with a subquery and a limit of 2, ascending from the end of the key range, returns the correct elements and verifies the proof.
     #[test]
     fn test_path_query_items_with_subquery_and_limit_2_asc_at_end() {
         // The structure is the following
@@ -3640,6 +3678,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a descending path query with a subquery and a limit of 2 at the end of the key range returns the correct elements and verifies the proof.
     #[test]
     fn test_path_query_items_with_subquery_and_limit_2_desc_at_end() {
         // The structure is the following
@@ -3686,6 +3725,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with an intermediate path translation and a limit of 2 returns the first two elements in ascending order.
     #[test]
     fn test_path_query_items_with_intermediate_path_limit_2_asc_from_start() {
         // The structure is the following
@@ -3734,6 +3774,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with an intermediate path translation and a descending order limit returns the correct elements and proof.
     #[test]
     fn test_path_query_items_with_intermediate_path_limit_2_desc_from_start() {
         // The structure is the following
@@ -3782,6 +3823,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with an intermediate path translation and a limit of 2, ascending from a middle key, returns the correct elements and verifies proof correctness.
     #[test]
     fn test_path_query_items_with_intermediate_path_limit_2_asc_in_middle() {
         // The structure is the following
@@ -3830,6 +3872,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests descending path queries with an intermediate path translation, limit 2, starting from the middle of the key range.
     #[test]
     fn test_path_query_items_with_intermediate_path_limit_2_desc_in_middle() {
         // The structure is the following
@@ -3878,6 +3921,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with an intermediate path and a range excluding middle keys returns the correct two elements in ascending order, and verifies the proof for correctness.
     #[test]
     fn test_path_query_items_with_intermediate_path_limit_2_asc_not_included_in_middle() {
         // The structure is the following
@@ -3926,6 +3970,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests descending path queries with intermediate path translation, a limit of 2, and a range excluding middle keys.
     #[test]
     fn test_path_query_items_with_intermediate_path_limit_2_desc_not_included_in_middle() {
         // The structure is the following
@@ -3974,6 +4019,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with an intermediate path translation and a limit of 2, ascending from the end of the key range, returns the correct elements and verifies the proof.
     #[test]
     fn test_path_query_items_with_intermediate_path_limit_2_asc_at_end() {
         // The structure is the following
@@ -4022,6 +4068,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests descending path queries with an intermediate path translation, limit 2, at the end of the range.
     #[test]
     fn test_path_query_items_with_intermediate_path_limit_2_desc_at_end() {
         // The structure is the following
@@ -4070,6 +4117,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with references and a limit of 2 returns the correct elements in ascending order from the start.
     #[test]
     fn test_path_query_items_with_reference_limit_2_asc_from_start() {
         // The structure is the following
@@ -4121,6 +4169,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests descending path queries with references and a limit of 2 from the start of the range.
     #[test]
     fn test_path_query_items_with_reference_limit_2_desc_from_start() {
         // The structure is the following
@@ -4172,6 +4221,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with references and a limit of 2, ascending from the middle of the key range, returns the correct elements and verifies the proof.
     #[test]
     fn test_path_query_items_with_reference_limit_2_asc_in_middle() {
         // The structure is the following
@@ -4223,6 +4273,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests descending path queries with references, limit 2, starting from the middle of the key range.
     #[test]
     fn test_path_query_items_with_reference_limit_2_desc_in_middle() {
         // The structure is the following
@@ -4274,6 +4325,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests a path query with references, limit 2, ascending order, excluding middle keys.
     #[test]
     fn test_path_query_items_with_reference_limit_2_asc_not_included_in_middle() {
         // The structure is the following
@@ -4325,6 +4377,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests a descending path query with references, limit 2, excluding middle keys.
     #[test]
     fn test_path_query_items_with_reference_limit_2_desc_not_included_in_middle() {
         // The structure is the following
@@ -4376,6 +4429,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with references and a limit of 2, ascending from the end of the key range, returns the correct elements and verifies the proof.
     #[test]
     fn test_path_query_items_with_reference_limit_2_asc_at_end() {
         // The structure is the following
@@ -4427,6 +4481,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests descending path queries with references, limit 2, at the end of the key range.
     #[test]
     fn test_path_query_items_with_reference_limit_2_desc_at_end() {
         // The structure is the following
@@ -4478,6 +4533,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with references in a top-level tree returns the first two elements in ascending order from the start, and verifies the proof for correctness.
     #[test]
     fn test_path_query_items_held_in_top_tree_with_refs_limit_2_asc_from_start() {
         // The structure is the following
@@ -4529,6 +4585,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests descending path queries with references in a top-level tree, using a limit of 2 from the start.
     #[test]
     fn test_path_query_items_held_in_top_tree_with_refs_limit_2_desc_from_start() {
         // The structure is the following
@@ -4580,6 +4637,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with references in a top-level tree, using a limit of 2 and ascending order from a middle key, returns the correct elements and verifies proof correctness.
     #[test]
     fn test_path_query_items_held_in_top_tree_with_refs_limit_2_asc_in_middle() {
         // The structure is the following
@@ -4631,6 +4689,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests descending path queries with references in a top-level tree, using a limit of 2 and a range ending in the middle of the keyspace.
     #[test]
     fn test_path_query_items_held_in_top_tree_with_refs_limit_2_desc_in_middle() {
         // The structure is the following
@@ -4682,6 +4741,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with a limit of 2, ascending order, and a range not including middle keys returns the correct referenced elements from a top-level tree.
     #[test]
     fn test_path_query_items_held_in_top_tree_with_refs_limit_2_asc_not_included_in_middle() {
         // The structure is the following
@@ -4733,6 +4793,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests descending path queries with references in a top-level tree, using a limit of 2 and a range that excludes middle keys.
     #[test]
     fn test_path_query_items_held_in_top_tree_with_refs_limit_2_desc_not_included_in_middle() {
         // The structure is the following
@@ -4800,6 +4861,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests that a path query with references in a top-level tree, limited to 2 elements in ascending order starting at the end of the range, returns the correct elements and verifies the proof.
     #[test]
     fn test_path_query_items_held_in_top_tree_with_refs_limit_2_asc_at_end() {
         // The structure is the following
@@ -4851,6 +4913,7 @@ mod tests {
         assert_eq!(result_set.len(), 2);
     }
 
+    /// Tests descending path queries with a limit of 2 at the end of a top-level tree containing references.
     #[test]
     fn test_path_query_items_held_in_top_tree_with_refs_limit_2_desc_at_end() {
         // The structure is the following

--- a/grovedb/src/tests/sum_tree_tests.rs
+++ b/grovedb/src/tests/sum_tree_tests.rs
@@ -20,6 +20,7 @@ mod tests {
         Element, Error, GroveDb, PathQuery,
     };
 
+    /// Tests that a sum tree behaves like a regular tree for insertion, retrieval, and proof generation.
     #[test]
     fn test_sum_tree_behaves_like_regular_tree() {
         let grove_version = GroveVersion::latest();
@@ -121,6 +122,7 @@ mod tests {
         );
     }
 
+    /// Tests that sum items in a sum tree behave like regular items, supporting insertion, retrieval, proof generation, and correct sum aggregation.
     #[test]
     fn test_sum_item_behaves_like_regular_item() {
         let grove_version = GroveVersion::latest();

--- a/tutorials/src/bin/proofs.rs
+++ b/tutorials/src/bin/proofs.rs
@@ -12,6 +12,16 @@ const INSERT_OPTIONS: Option<InsertOptions> = Some(InsertOptions {
     base_root_storage_is_free: true,
 });
 
+/// Demonstrates querying, proof generation, and verification in GroveDB.
+///
+/// Opens an existing GroveDB instance, populates it with nested subtrees and key-value pairs, performs a range query, generates a cryptographic proof for the query, verifies the proof, and checks if the resulting hash matches the current database root hash.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Run the main function to execute the GroveDB demonstration.
+/// main();
+/// ```
 fn main() {
     // Specify the path to the previously created GroveDB instance
     let path = String::from("../tutorial-storage");

--- a/tutorials/src/bin/replication.rs
+++ b/tutorials/src/bin/replication.rs
@@ -235,6 +235,24 @@ fn generate_random_path(prefix: &str, suffix: &str, len: usize) -> String {
     format!("{}{}{}", prefix, random_string, suffix)
 }
 
+/// Executes a query on the specified path and key, prints the results, and verifies the query proof against the database root hash.
+///
+/// This function constructs a query for a single key at the given path, retrieves and prints the matching elements, generates a cryptographic proof for the query, and verifies the proof against the current root hash of the database. The verification result is printed to the terminal.
+///
+/// # Parameters
+/// - `path`: The path within the database to query, as a slice of byte slices.
+/// - `key`: The key to query for at the specified path.
+/// - `grove_version`: The GroveDb version to use for the query and proof verification.
+///
+/// # Examples
+///
+/// ```ignore
+/// let db = GroveDb::open("some_path").unwrap();
+/// let path = &[b"root", b"subtree"];
+/// let key = b"my_key".to_vec();
+/// let grove_version = GroveVersion::default();
+/// query_db(&db, path, key, &grove_version);
+/// ```
 fn query_db(db: &GroveDb, path: &[&[u8]], key: Vec<u8>, grove_version: &GroveVersion) {
     let path_vec: Vec<Vec<u8>> = path.iter()
         .map(|&slice| slice.to_vec())
@@ -296,4 +314,3 @@ fn sync_db_demo(
 
     Ok(())
 }
-


### PR DESCRIPTION
Supersedes #375 with all review feedback addressed:

1. Removed `# Examples` sections from `#[test]` function docstrings — test fns get concise one-line summaries only
2. Fenced public API examples with ` ```ignore ` — undefined variables would fail as doctests
3. Placed doc comments before `#[test]` attribute (idiomatic Rust)
4. Replaced old doc comments cleanly instead of appending
5. Restored `prove_query`'s "doesn't allow subset verification" caveat that was overwritten

Doc-comment-only changes — no code logic modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation throughout the codebase for improved clarity, including detailed descriptions of proof generation, query operations, and test purposes.

* **Tests**
  * Added comprehensive test cases for PathQuery merging functionality, covering scenarios with identical paths, different path lengths, and nested paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->