### PR TITLE
test(merk): add missing ChunkError variant coverage

### DIFF
--- a/merk/src/proofs/chunk/error.rs
+++ b/merk/src/proofs/chunk/error.rs
@@ -108,5 +108,25 @@ mod tests {
             ChunkError::RestorationNotComplete.to_string(),
             "called finalize too early still expecting chunks"
         );
+        assert_eq!(
+            ChunkError::EmptyTree("x").to_string(),
+            "chunk from empty tree: x"
+        );
+        assert_eq!(
+            ChunkError::ExpectedChunkId.to_string(),
+            "expected chunk id when parsing chunk op"
+        );
+        assert_eq!(
+            ChunkError::ExpectedChunk.to_string(),
+            "expected chunk when parsing chunk op"
+        );
+        assert_eq!(
+            ChunkError::UnexpectedChunk.to_string(),
+            "unexpected chunk: cannot verify chunk because verification hash is not in memory"
+        );
+        assert_eq!(
+            ChunkError::InternalError("x").to_string(),
+            "internal error x"
+        );
     }
 }


### PR DESCRIPTION
## Issue Being Fixed

Addresses CodeRabbit feedback on #442 — missing test coverage for 5 `ChunkError` variants.

## What Was Done

Added assertions for `EmptyTree`, `ExpectedChunkId`, `ExpectedChunk`, `UnexpectedChunk`, and `InternalError` in the existing `test_chunk_error_messages` test.

## Tests

```
cargo test -p grovedb-merk --lib proofs::chunk::error::tests::test_chunk_error_messages
```

1 test passed ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for error message validation across multiple error scenarios to ensure robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->