### PR TITLE
docs: fix translation diacritics and terminology in es/fr/pl/id

### DIFF
--- a/docs/book/translations/es/src/commitment-tree.md
+++ b/docs/book/translations/es/src/commitment-tree.md
@@ -675,7 +675,7 @@ registro almacenado:
    This note can later be spent by proving knowledge of it in ZK
 ```
 
-El paso 5 es la razon por la que `rho` debe almacenarse junto al texto cifrado — sin el,
+El paso 5 es la razon por la que `rho` debe almacenarse junto al texto cifrado — sin él,
 el cliente ligero no puede verificar el enlace de la clave efimera durante el descifrado
 de prueba.
 

--- a/docs/book/translations/fr/src/commitment-tree.md
+++ b/docs/book/translations/fr/src/commitment-tree.md
@@ -401,7 +401,7 @@ des preuves d'autorisation de depense.
 
 ### commitment_tree_get_value
 
-Recupere une valeur stockee (cmx || rho || charge utile) par sa position globale :
+Récupère une valeur stockée (cmx || rho || charge utile) par sa position globale :
 
 ```text
 Step 1: Validate element at path/key is a CommitmentTree

--- a/docs/book/translations/id/src/commitment-tree.md
+++ b/docs/book/translations/id/src/commitment-tree.md
@@ -544,7 +544,7 @@ merupakan payload terenkripsi.
 
 ### Rincian Field Demi Field
 
-**cmx (32 byte)** — Extracted note commitment, elemen base field Pallas.
+**cmx (32 byte)** — Extracted note commitment, elemen medan dasar (base field) Pallas.
 Ini adalah nilai leaf yang ditambahkan ke frontier Sinsemilla. Ia berkomitmen pada
 semua field note (penerima, nilai, keacakan) tanpa mengungkapkannya.
 cmx adalah yang membuat note "dapat ditemukan" di commitment tree.

--- a/docs/book/translations/pl/src/commitment-tree.md
+++ b/docs/book/translations/pl/src/commitment-tree.md
@@ -401,7 +401,7 @@ dowodow autoryzacji wydania.
 
 ### commitment_tree_get_value
 
-Pobiera przechowywana wartosc (cmx || rho || ladunek) po jej globalnej pozycji:
+Pobiera przechowywana wartosc (cmx || rho || ladunek) wedlug globalnej pozycji:
 
 ```text
 Step 1: Validate element at path/key is a CommitmentTree

--- a/docs/book/translations/pl/src/commitment-tree.md
+++ b/docs/book/translations/pl/src/commitment-tree.md
@@ -401,7 +401,7 @@ dowodow autoryzacji wydania.
 
 ### commitment_tree_get_value
 
-Pobiera przechowywana wartosc (cmx || rho || ladunek) wedlug globalnej pozycji:
+Pobiera przechowywana wartosc (cmx || rho || ladunek) według globalnej pozycji:
 
 ```text
 Step 1: Validate element at path/key is a CommitmentTree


### PR DESCRIPTION
Follow-up to #444 — addresses CodeRabbit feedback on translation quality:
- **Spanish**: `sin el` → `sin él` (pronoun accent)
- **French**: `Recupere` → `Récupère`, `stockee` → `stockée` (diacritics)
- **Polish**: `po jej globalnej pozycji` → `wedlug globalnej pozycji` (preposition)
- **Indonesian**: `elemen base field Pallas` → `elemen medan dasar (base field) Pallas` (mixed terminology)

Docs-only, no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated commitment tree documentation translations in Spanish, French, Indonesian, and Polish. Changes include grammar and pronoun corrections in Spanish, accent marks and capitalization improvements in French, localized terminology translations in Indonesian, and refined phrasing in Polish. These updates enhance clarity, consistency, and accuracy across all supported language versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->