### PR TITLE
fix(merk): handle KV, KVValueHash, KVCount nodes in chunk restoration

### DIFF
--- a/merk/src/merk/restore.rs
+++ b/merk/src/merk/restore.rs
@@ -47,11 +47,11 @@ use crate::{
         tree::{execute, Child, Tree as ProofTree},
         Node, Op,
     },
-    tree::{combine_hash, kv::ValueDefinedCostType, RefWalker, TreeNode},
+    tree::{combine_hash, kv::ValueDefinedCostType, value_hash, RefWalker, TreeNode},
     tree_type::TreeType,
     CryptoHash, Error,
     Error::{CostsError, StorageError},
-    Link, Merk,
+    Link, Merk, TreeFeatureType,
 };
 
 /// Restorer handles verification of chunks and replication of Merk trees.
@@ -177,9 +177,15 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
         let mut hash_count = 0;
 
         // build tree from ops
-        // ensure only made of KvValueFeatureType and Hash nodes and count them
+        // ensure only made of KV-like nodes and Hash nodes, and count them
         let tree = execute(chunk.clone().into_iter().map(Ok), false, |node| {
-            if matches!(node, Node::KVValueHashFeatureType(..)) {
+            if matches!(
+                node,
+                Node::KVValueHashFeatureType(..)
+                    | Node::KV(..)
+                    | Node::KVValueHash(..)
+                    | Node::KVCount(..)
+            ) {
                 kv_count += 1;
                 Ok(())
             } else if matches!(node, Node::Hash(..)) {
@@ -187,7 +193,7 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
                 Ok(())
             } else {
                 Err(Error::ChunkRestoringError(ChunkError::InvalidChunkProof(
-                    "expected chunk proof to contain only kvvaluefeaturetype or hash nodes",
+                    "expected chunk proof to contain only kv or hash nodes",
                 )))
             }
         })
@@ -234,12 +240,12 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
             None,
             &mut |proof_node, node_traversal_instruction, parent_key| {
                 match &proof_node.node {
-                    Node::KVValueHashFeatureType(key, value, value_hash, feature_type) => {
+                    Node::KVValueHashFeatureType(key, value, vh, feature_type) => {
                         // build tree from node value
                         let mut tree = TreeNode::new_with_value_hash(
                             key.clone(),
                             value.clone(),
-                            *value_hash,
+                            *vh,
                             *feature_type,
                         )
                         .unwrap();
@@ -251,6 +257,60 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
                         // encode the node and add it to the batch
                         let bytes = tree.encode();
 
+                        batch.put(key, &bytes, None, None).map_err(CostsError)
+                    }
+                    Node::KV(key, value) => {
+                        // Items in normal trees: value_hash = H(value),
+                        // feature_type = BasicMerkNode
+                        let vh = value_hash(value.as_slice()).unwrap();
+                        let mut tree = TreeNode::new_with_value_hash(
+                            key.clone(),
+                            value.clone(),
+                            vh,
+                            TreeFeatureType::BasicMerkNode,
+                        )
+                        .unwrap();
+
+                        *tree.slot_mut(LEFT) = proof_node.left.as_ref().map(Child::as_link);
+                        *tree.slot_mut(RIGHT) = proof_node.right.as_ref().map(Child::as_link);
+
+                        let bytes = tree.encode();
+                        batch.put(key, &bytes, None, None).map_err(CostsError)
+                    }
+                    Node::KVValueHash(key, value, vh) => {
+                        // Subtrees/references in normal trees: value_hash is
+                        // provided (may be a combined hash for subtrees),
+                        // feature_type = BasicMerkNode
+                        let mut tree = TreeNode::new_with_value_hash(
+                            key.clone(),
+                            value.clone(),
+                            *vh,
+                            TreeFeatureType::BasicMerkNode,
+                        )
+                        .unwrap();
+
+                        *tree.slot_mut(LEFT) = proof_node.left.as_ref().map(Child::as_link);
+                        *tree.slot_mut(RIGHT) = proof_node.right.as_ref().map(Child::as_link);
+
+                        let bytes = tree.encode();
+                        batch.put(key, &bytes, None, None).map_err(CostsError)
+                    }
+                    Node::KVCount(key, value, count) => {
+                        // Items in ProvableCountTree: value_hash = H(value),
+                        // feature_type = ProvableCountedMerkNode(count)
+                        let vh = value_hash(value.as_slice()).unwrap();
+                        let mut tree = TreeNode::new_with_value_hash(
+                            key.clone(),
+                            value.clone(),
+                            vh,
+                            TreeFeatureType::ProvableCountedMerkNode(*count),
+                        )
+                        .unwrap();
+
+                        *tree.slot_mut(LEFT) = proof_node.left.as_ref().map(Child::as_link);
+                        *tree.slot_mut(RIGHT) = proof_node.right.as_ref().map(Child::as_link);
+
+                        let bytes = tree.encode();
                         batch.put(key, &bytes, None, None).map_err(CostsError)
                     }
                     Node::Hash(hash) => {
@@ -268,7 +328,7 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
                     _ => {
                         // we do nothing for other node types
                         // technically verify chunk will be called before this
-                        // as such this should be be reached
+                        // as such this should not be reached
                         Ok(())
                     }
                 }
@@ -593,20 +653,50 @@ mod tests {
     }
 
     #[test]
-    fn test_chunk_verification_only_kv_feature_and_hash() {
-        // should not accept kv
-        let invalid_chunk_proof = vec![Op::Push(Node::KV(vec![1], vec![1]))];
-        let verification_result = Restorer::<PrefixedRocksDbTransactionContext>::verify_chunk(
-            invalid_chunk_proof,
-            &[0; 32],
-            &None,
+    fn test_chunk_verification_accepted_and_rejected_node_types() {
+        // KV should be accepted (items in normal trees)
+        let kv_proof = vec![Op::Push(Node::KV(vec![1], vec![1]))];
+        let result =
+            Restorer::<PrefixedRocksDbTransactionContext>::verify_chunk(kv_proof, &[0; 32], &None);
+        // KV is now accepted; it will fail with hash mismatch (not invalid node type)
+        assert!(
+            !matches!(
+                result,
+                Err(ChunkRestoringError(InvalidChunkProof(
+                    "expected chunk proof to contain only kv or hash nodes",
+                )))
+            ),
+            "KV nodes should be accepted by chunk verification"
         );
-        assert!(matches!(
-            verification_result,
-            Err(ChunkRestoringError(InvalidChunkProof(
-                "expected chunk proof to contain only kvvaluefeaturetype or hash nodes",
-            )))
-        ));
+
+        // KVValueHash should be accepted (subtrees in normal trees)
+        let kvvh_proof = vec![Op::Push(Node::KVValueHash(vec![0], vec![0], [0; 32]))];
+        let result = Restorer::<PrefixedRocksDbTransactionContext>::verify_chunk(
+            kvvh_proof, &[0; 32], &None,
+        );
+        assert!(
+            !matches!(
+                result,
+                Err(ChunkRestoringError(InvalidChunkProof(
+                    "expected chunk proof to contain only kv or hash nodes",
+                )))
+            ),
+            "KVValueHash nodes should be accepted by chunk verification"
+        );
+
+        // KVCount should be accepted (items in provable count trees)
+        let kvc_proof = vec![Op::Push(Node::KVCount(vec![0], vec![0], 1))];
+        let result =
+            Restorer::<PrefixedRocksDbTransactionContext>::verify_chunk(kvc_proof, &[0; 32], &None);
+        assert!(
+            !matches!(
+                result,
+                Err(ChunkRestoringError(InvalidChunkProof(
+                    "expected chunk proof to contain only kv or hash nodes",
+                )))
+            ),
+            "KVCount nodes should be accepted by chunk verification"
+        );
 
         // should not accept kvhash
         let invalid_chunk_proof = vec![Op::Push(Node::KVHash([0; 32]))];
@@ -618,7 +708,7 @@ mod tests {
         assert!(matches!(
             verification_result,
             Err(ChunkRestoringError(InvalidChunkProof(
-                "expected chunk proof to contain only kvvaluefeaturetype or hash nodes",
+                "expected chunk proof to contain only kv or hash nodes",
             )))
         ));
 
@@ -632,21 +722,7 @@ mod tests {
         assert!(matches!(
             verification_result,
             Err(ChunkRestoringError(InvalidChunkProof(
-                "expected chunk proof to contain only kvvaluefeaturetype or hash nodes",
-            )))
-        ));
-
-        // should not accept kvvaluehash
-        let invalid_chunk_proof = vec![Op::Push(Node::KVValueHash(vec![0], vec![0], [0; 32]))];
-        let verification_result = Restorer::<PrefixedRocksDbTransactionContext>::verify_chunk(
-            invalid_chunk_proof,
-            &[0; 32],
-            &None,
-        );
-        assert!(matches!(
-            verification_result,
-            Err(ChunkRestoringError(InvalidChunkProof(
-                "expected chunk proof to contain only kvvaluefeaturetype or hash nodes",
+                "expected chunk proof to contain only kv or hash nodes",
             )))
         ));
 
@@ -660,7 +736,7 @@ mod tests {
         assert!(matches!(
             verification_result,
             Err(ChunkRestoringError(InvalidChunkProof(
-                "expected chunk proof to contain only kvvaluefeaturetype or hash nodes",
+                "expected chunk proof to contain only kv or hash nodes",
             )))
         ));
     }


### PR DESCRIPTION
## Summary

- The Merk chunk restorer previously only accepted `KVValueHashFeatureType` nodes, rejecting `KV`, `KVValueHash`, and `KVCount` during `verify_chunk` and `process_chunk`
- This meant replication would fail for normal trees (which produce `KV`/`KVValueHash` proof nodes) and provable count trees (which produce `KVCount` proof nodes)
- Adds match arms for all three node types, deriving the appropriate `value_hash` and `TreeFeatureType` for each
- Updates the existing test to verify the new node types are accepted rather than rejected

## Test plan

- [x] Existing `test_chunk_verification_accepted_and_rejected_node_types` updated to verify KV, KVValueHash, and KVCount are accepted
- [x] KVHash and KVRefValueHash remain correctly rejected
- [x] `cargo test -p merk` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration logic to accept additional node variants during verification and reconstruction, enabling broader data recovery scenarios.

* **Tests**
  * Enhanced test coverage to validate acceptance of multiple node types in restoration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->