### PR TITLE
test(grovedb): add coverage tests for error, visualize, reference_path, and commitment_tree

### DIFF
--- a/grovedb-commitment-tree/src/commitment_tree/mod.rs
+++ b/grovedb-commitment-tree/src/commitment_tree/mod.rs
@@ -277,6 +277,10 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
 
         let bulk_result = match self.bulk_tree.append(&item_value) {
             Ok(r) => r,
+            // codecov:ignore — requires BulkAppendTree::append to fail, which only happens on
+            // storage faults (put/get errors) during dense tree insert or MMR compaction;
+            // MockDataStorageContext always succeeds and FailingDataStorageContext prevents
+            // construction, so this path cannot be reached without a fault-injecting mock
             Err(e) => {
                 return Err(CommitmentTreeError::InvalidData(format!(
                     "bulk append: {}",
@@ -296,6 +300,9 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
                 cost += frontier_cost;
                 root
             }
+            // codecov:ignore — CommitmentFrontier::append can only fail with InvalidFieldElement
+            // (already checked at line 258) or TreeFull (requires 2^32 Sinsemilla appends);
+            // neither case is reachable in practice
             grovedb_costs::CostContext {
                 value: Err(e),
                 cost: frontier_cost,

--- a/grovedb-commitment-tree/src/commitment_tree/tests.rs
+++ b/grovedb-commitment-tree/src/commitment_tree/tests.rs
@@ -926,6 +926,75 @@ mod storage_tests {
     }
 
     #[test]
+    fn test_debug_fmt() {
+        let ctx = MockDataStorageContext::new();
+        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
+            .value
+            .expect("open should succeed");
+
+        // Debug on empty tree
+        let s = format!("{:?}", ct);
+        assert!(s.contains("CommitmentTree"), "should contain struct name");
+        assert!(
+            s.contains("total_count"),
+            "should contain total_count field"
+        );
+        assert!(s.contains("frontier"), "should contain frontier field");
+
+        // Debug after appending
+        ct.append(test_leaf(0), test_rho(0), &test_ciphertext(0))
+            .value
+            .expect("append should succeed");
+        let s = format!("{:?}", ct);
+        assert!(
+            s.contains("CommitmentTree"),
+            "should still contain struct name after append"
+        );
+    }
+
+    #[test]
+    fn test_open_from_state_error_invalid_chunk_power() {
+        let ctx = MockDataStorageContext::new();
+        // chunk_power=0 is invalid (must be 1..=16), causing from_state to fail
+        let result = CommitmentTree::<_, DashMemo>::open(0, 0, ctx);
+        let err = result
+            .value
+            .expect_err("should fail with invalid chunk_power");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("bulk tree from_state"),
+            "error should mention from_state: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_open_frontier_total_count_mismatch() {
+        // 1. Create a tree, append 1 item, save
+        let ctx = MockDataStorageContext::new();
+        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
+            .value
+            .expect("open should succeed");
+        ct.append(test_leaf(0), test_rho(0), &test_ciphertext(0))
+            .value
+            .expect("append should succeed");
+        ct.save().value.expect("save should succeed");
+
+        // 2. Re-open with total_count=0 but the frontier has tree_size=1
+        let storage = ct.bulk_tree.dense_tree.storage;
+        let result = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, storage);
+        let err = result
+            .value
+            .expect_err("should fail with frontier/total_count mismatch");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("frontier tree_size"),
+            "error should mention frontier mismatch: {}",
+            msg
+        );
+    }
+
+    #[test]
     fn test_append_raw_rejects_invalid_cmx() {
         let ctx = MockDataStorageContext::new();
         let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)

--- a/grovedb/src/tests/error_display_tests.rs
+++ b/grovedb/src/tests/error_display_tests.rs
@@ -578,4 +578,511 @@ mod tests {
             "Debug should contain variant name"
         );
     }
+
+    // ---------------------------------------------------------------
+    // add_context noop on non-String variants (wildcard arm, line 197)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_add_context_noop_on_non_string_variants() {
+        // Each of these variants hits the `_ => {}` wildcard arm in add_context.
+        // We verify that calling add_context does not alter the Display output.
+
+        // Unit variants (no payload)
+        {
+            let mut e = Error::Infallible;
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "Infallible should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::CyclicReference;
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "CyclicReference should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::ReferenceLimit;
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "ReferenceLimit should be unchanged by add_context"
+            );
+        }
+
+        // &'static str variants (not in the String match arm)
+        {
+            let mut e = Error::InvalidQuery("original");
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "InvalidQuery should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::MissingParameter("original");
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "MissingParameter should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::InvalidParameter("original");
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "InvalidParameter should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::InvalidCodeExecution("original");
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "InvalidCodeExecution should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::CorruptedCodeExecution("original");
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "CorruptedCodeExecution should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::InvalidBatchOperation("original");
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "InvalidBatchOperation should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::DeletingNonEmptyTree("original");
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "DeletingNonEmptyTree should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::ClearingTreeWithSubtreesNotAllowed("original");
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "ClearingTreeWithSubtreesNotAllowed should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::OverrideNotAllowed("original");
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "OverrideNotAllowed should be unchanged by add_context"
+            );
+        }
+        {
+            let mut e = Error::CyclicError("original");
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "CyclicError should be unchanged by add_context"
+            );
+        }
+
+        // Complex wrapper variants (also hit the wildcard arm)
+        {
+            let ver_err = grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
+                method: "test".to_string(),
+                known_versions: vec![0],
+                received: 1,
+            };
+            let mut e = Error::VersionError(ver_err);
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "VersionError should be unchanged by add_context"
+            );
+        }
+        {
+            let elem_err = grovedb_element::error::ElementError::WrongElementType("expected tree");
+            let mut e = Error::ElementError(elem_err);
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "ElementError should be unchanged by add_context"
+            );
+        }
+        {
+            let query_err = grovedb_query::error::Error::InvalidOperation("bad op");
+            let mut e = Error::QueryError(query_err);
+            let before = e.to_string();
+            e.add_context("extra");
+            let after = e.to_string();
+            assert_eq!(
+                before, after,
+                "QueryError should be unchanged by add_context"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // From<grovedb_merk::Error> — additional wildcard arm coverage
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_from_merk_error_variants() {
+        // Verify each specifically-mapped variant produces the right grovedb Error
+        let e: Error = grovedb_merk::error::Error::PathKeyNotFound("k".to_string()).into();
+        assert!(
+            matches!(e, Error::PathKeyNotFound(ref s) if s == "k"),
+            "PathKeyNotFound should map directly"
+        );
+
+        let e: Error = grovedb_merk::error::Error::PathNotFound("p".to_string()).into();
+        assert!(
+            matches!(e, Error::PathNotFound(ref s) if s == "p"),
+            "PathNotFound should map directly"
+        );
+
+        let e: Error = grovedb_merk::error::Error::PathParentLayerNotFound("pp".to_string()).into();
+        assert!(
+            matches!(e, Error::PathParentLayerNotFound(ref s) if s == "pp"),
+            "PathParentLayerNotFound should map directly"
+        );
+
+        let elem_err = grovedb_element::error::ElementError::CorruptedData("elem".to_string());
+        let e: Error = grovedb_merk::error::Error::ElementError(elem_err).into();
+        assert!(
+            matches!(e, Error::ElementError(_)),
+            "ElementError should map directly"
+        );
+
+        let e: Error = grovedb_merk::error::Error::InvalidInputError("inp").into();
+        assert!(
+            matches!(e, Error::InvalidInput("inp")),
+            "InvalidInputError should map to InvalidInput"
+        );
+
+        // Wildcard: variants not specifically matched become MerkError
+        let e: Error = grovedb_merk::error::Error::CorruptedCodeExecution("merk corrupt").into();
+        assert!(
+            matches!(e, Error::MerkError(_)),
+            "CorruptedCodeExecution should fall through to MerkError"
+        );
+
+        let e: Error = grovedb_merk::error::Error::CorruptedState("bad state").into();
+        assert!(
+            matches!(e, Error::MerkError(_)),
+            "CorruptedState should fall through to MerkError"
+        );
+
+        let e: Error = grovedb_merk::error::Error::DivideByZero("div0").into();
+        assert!(
+            matches!(e, Error::MerkError(_)),
+            "DivideByZero should fall through to MerkError"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // add_context on String variants not already tested above
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_add_context_on_string_variants() {
+        // NotSupported(String)
+        {
+            let mut e = Error::NotSupported("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::NotSupported(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "NotSupported should have context appended"
+                    );
+                }
+                _ => panic!("expected NotSupported"),
+            }
+        }
+
+        // CorruptedStorage(String)
+        {
+            let mut e = Error::CorruptedStorage("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::CorruptedStorage(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "CorruptedStorage should have context appended"
+                    );
+                }
+                _ => panic!("expected CorruptedStorage"),
+            }
+        }
+
+        // PathParentLayerNotFound(String)
+        {
+            let mut e = Error::PathParentLayerNotFound("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::PathParentLayerNotFound(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "PathParentLayerNotFound should have context appended"
+                    );
+                }
+                _ => panic!("expected PathParentLayerNotFound"),
+            }
+        }
+
+        // PathKeyNotFound(String)
+        {
+            let mut e = Error::PathKeyNotFound("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::PathKeyNotFound(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "PathKeyNotFound should have context appended"
+                    );
+                }
+                _ => panic!("expected PathKeyNotFound"),
+            }
+        }
+
+        // CorruptedReferencePathKeyNotFound(String)
+        {
+            let mut e = Error::CorruptedReferencePathKeyNotFound("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::CorruptedReferencePathKeyNotFound(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "CorruptedReferencePathKeyNotFound should have context appended"
+                    );
+                }
+                _ => panic!("expected CorruptedReferencePathKeyNotFound"),
+            }
+        }
+
+        // CorruptedReferencePathNotFound(String)
+        {
+            let mut e = Error::CorruptedReferencePathNotFound("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::CorruptedReferencePathNotFound(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "CorruptedReferencePathNotFound should have context appended"
+                    );
+                }
+                _ => panic!("expected CorruptedReferencePathNotFound"),
+            }
+        }
+
+        // CorruptedReferencePathParentLayerNotFound(String)
+        {
+            let mut e = Error::CorruptedReferencePathParentLayerNotFound("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::CorruptedReferencePathParentLayerNotFound(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "CorruptedReferencePathParentLayerNotFound should have context appended"
+                    );
+                }
+                _ => panic!("expected CorruptedReferencePathParentLayerNotFound"),
+            }
+        }
+
+        // InvalidParentLayerPath(String)
+        {
+            let mut e = Error::InvalidParentLayerPath("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::InvalidParentLayerPath(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "InvalidParentLayerPath should have context appended"
+                    );
+                }
+                _ => panic!("expected InvalidParentLayerPath"),
+            }
+        }
+
+        // InvalidPath(String)
+        {
+            let mut e = Error::InvalidPath("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::InvalidPath(ref s) => {
+                    assert_eq!(s, "base, extra", "InvalidPath should have context appended");
+                }
+                _ => panic!("expected InvalidPath"),
+            }
+        }
+
+        // CorruptedPath(String)
+        {
+            let mut e = Error::CorruptedPath("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::CorruptedPath(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "CorruptedPath should have context appended"
+                    );
+                }
+                _ => panic!("expected CorruptedPath"),
+            }
+        }
+
+        // DeleteUpTreeStopHeightMoreThanInitialPathSize(String)
+        {
+            let mut e = Error::DeleteUpTreeStopHeightMoreThanInitialPathSize("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::DeleteUpTreeStopHeightMoreThanInitialPathSize(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "DeleteUpTreeStopHeightMoreThanInitialPathSize should have context appended"
+                    );
+                }
+                _ => panic!("expected DeleteUpTreeStopHeightMoreThanInitialPathSize"),
+            }
+        }
+
+        // JustInTimeElementFlagsClientError(String)
+        {
+            let mut e = Error::JustInTimeElementFlagsClientError("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::JustInTimeElementFlagsClientError(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "JustInTimeElementFlagsClientError should have context appended"
+                    );
+                }
+                _ => panic!("expected JustInTimeElementFlagsClientError"),
+            }
+        }
+
+        // SplitRemovalBytesClientError(String)
+        {
+            let mut e = Error::SplitRemovalBytesClientError("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::SplitRemovalBytesClientError(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "SplitRemovalBytesClientError should have context appended"
+                    );
+                }
+                _ => panic!("expected SplitRemovalBytesClientError"),
+            }
+        }
+
+        // ClientReturnedNonClientError(String)
+        {
+            let mut e = Error::ClientReturnedNonClientError("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::ClientReturnedNonClientError(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "ClientReturnedNonClientError should have context appended"
+                    );
+                }
+                _ => panic!("expected ClientReturnedNonClientError"),
+            }
+        }
+
+        // PathNotFoundInCacheForEstimatedCosts(String)
+        {
+            let mut e = Error::PathNotFoundInCacheForEstimatedCosts("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::PathNotFoundInCacheForEstimatedCosts(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "PathNotFoundInCacheForEstimatedCosts should have context appended"
+                    );
+                }
+                _ => panic!("expected PathNotFoundInCacheForEstimatedCosts"),
+            }
+        }
+
+        // CommitmentTreeError(String) — verify it works (complementary to
+        // existing test_add_context_appends_to_commitment_tree_error)
+        {
+            let mut e = Error::CommitmentTreeError("base".to_string());
+            e.add_context("extra");
+            match e {
+                Error::CommitmentTreeError(ref s) => {
+                    assert_eq!(
+                        s, "base, extra",
+                        "CommitmentTreeError should have context appended"
+                    );
+                }
+                _ => panic!("expected CommitmentTreeError"),
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Display tests for QueryError (not previously tested)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_display_query_error() {
+        let query_err = grovedb_query::error::Error::NotSupported("unsupported op".to_string());
+        let e = Error::QueryError(query_err);
+        let s = e.to_string();
+        assert!(
+            s.contains("unsupported op"),
+            "expected payload in QueryError display: {}",
+            s
+        );
+        assert!(
+            s.contains("query error"),
+            "expected 'query error' prefix in: {}",
+            s
+        );
+    }
 }

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -32,6 +32,7 @@ mod provable_count_tree_comprehensive_test;
 mod provable_count_tree_structure_test;
 mod provable_count_tree_test;
 mod query_result_type_tests;
+mod reference_path_tests;
 mod replication_session_tests;
 mod replication_utils_tests;
 mod test_compaction_sizes;

--- a/grovedb/src/tests/reference_path_tests.rs
+++ b/grovedb/src/tests/reference_path_tests.rs
@@ -1,0 +1,331 @@
+//! Integration tests for `reference_path.rs` -- covering error paths in
+//! `follow_reference` and `follow_reference_once`.
+
+#[cfg(test)]
+mod tests {
+    use grovedb_merk::{element::insert::ElementInsertToStorageExtensions, tree::NULL_HASH};
+    use grovedb_path::SubtreePath;
+    use grovedb_version::version::GroveVersion;
+
+    use crate::{
+        merk_cache::MerkCache,
+        reference_path::{follow_reference, follow_reference_once, ReferencePathType},
+        tests::{make_test_grovedb, TEST_LEAF},
+        Element, Error,
+    };
+
+    /// Helper: extract the `Err` from a `CostResult` whose `Ok` type does not
+    /// implement `Debug`. Panics with the given message when the result is `Ok`.
+    fn unwrap_cost_err<T>(cost_result: grovedb_costs::CostResult<T, Error>, msg: &str) -> Error {
+        match cost_result.unwrap() {
+            Err(e) => e,
+            Ok(_) => panic!("{}", msg),
+        }
+    }
+
+    /// Two references that form a cycle: ref_a -> ref_b -> ref_a.
+    ///
+    /// We insert both reference elements at the Merk level (bypassing GroveDb
+    /// validation which would reject dangling/cyclic refs) and then call the
+    /// standalone `follow_reference` from `reference_path.rs`.
+    ///
+    /// Covers line 64: `CyclicReference` in `follow_reference`.
+    #[test]
+    fn test_cyclic_reference_detected() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert a subtree to hold our references.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"refs",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert subtree");
+
+        let tx = db.start_transaction();
+
+        // Use MerkCache to insert raw reference elements at the Merk level,
+        // which skips GroveDb-level validation.
+        {
+            let cache = MerkCache::new(&db, &tx, grove_version);
+            let path: SubtreePath<&[u8]> = SubtreePath::from(&[TEST_LEAF, b"refs"] as &[&[u8]]);
+
+            // ref_a points to [TEST_LEAF, "refs", "b"]
+            let ref_a = Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                TEST_LEAF.to_vec(),
+                b"refs".to_vec(),
+                b"b".to_vec(),
+            ]));
+
+            // ref_b points to [TEST_LEAF, "refs", "a"]
+            let ref_b = Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                TEST_LEAF.to_vec(),
+                b"refs".to_vec(),
+                b"a".to_vec(),
+            ]));
+
+            let mut merk = cache
+                .get_merk(path.derive_owned())
+                .unwrap()
+                .expect("should open merk");
+
+            // Insert both references via the low-level Merk insert (no
+            // reference validation). We use insert_reference with NULL_HASH
+            // since the combined value hash is irrelevant for this test.
+            merk.for_merk(|m| {
+                ref_a
+                    .insert_reference(m, b"a", NULL_HASH, None, grove_version)
+                    .unwrap()
+                    .expect("should insert ref_a at merk level");
+            });
+
+            merk.for_merk(|m| {
+                ref_b
+                    .insert_reference(m, b"b", NULL_HASH, None, grove_version)
+                    .unwrap()
+                    .expect("should insert ref_b at merk level");
+            });
+
+            drop(merk);
+
+            // Now call follow_reference starting at key "a" with its ref type.
+            // The chain is: (initial) -> b -> a -> b (cycle detected).
+            let err = unwrap_cost_err(
+                follow_reference(
+                    &cache,
+                    path.derive_owned(),
+                    b"a",
+                    ReferencePathType::AbsolutePathReference(vec![
+                        TEST_LEAF.to_vec(),
+                        b"refs".to_vec(),
+                        b"b".to_vec(),
+                    ]),
+                ),
+                "should detect cyclic reference",
+            );
+
+            assert!(
+                matches!(err, Error::CyclicReference),
+                "expected CyclicReference, got: {:?}",
+                err
+            );
+        }
+    }
+
+    /// Create a chain of references longer than MAX_REFERENCE_HOPS (10).
+    /// ref0 -> ref1 -> ref2 -> ... -> ref10 -> ref11 (11 hops total).
+    ///
+    /// Covers line 107: `ReferenceLimit` in `follow_reference`.
+    #[test]
+    fn test_reference_hop_limit_exceeded() {
+        use crate::operations::get::MAX_REFERENCE_HOPS;
+
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert a subtree to hold our chain.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"chain",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert subtree");
+
+        let tx = db.start_transaction();
+
+        {
+            let cache = MerkCache::new(&db, &tx, grove_version);
+            let path: SubtreePath<&[u8]> = SubtreePath::from(&[TEST_LEAF, b"chain"] as &[&[u8]]);
+
+            let keygen = |i: usize| format!("ref{}", i).into_bytes();
+
+            // Build a chain: ref_i -> ref_{i+1}, for i in 0..=MAX_REFERENCE_HOPS.
+            // That gives MAX_REFERENCE_HOPS + 1 reference elements total, so the
+            // hop count will exceed the limit.
+            //
+            // The last element in the chain also points forward (to a
+            // non-existent key), but the ReferenceLimit error triggers before
+            // the PathKeyNotFound because hops run out first.
+            for i in 0..=MAX_REFERENCE_HOPS {
+                let ref_element =
+                    Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                        TEST_LEAF.to_vec(),
+                        b"chain".to_vec(),
+                        keygen(i + 1),
+                    ]));
+
+                let mut merk = cache
+                    .get_merk(path.derive_owned())
+                    .unwrap()
+                    .expect("should open merk");
+
+                merk.for_merk(|m| {
+                    ref_element
+                        .insert_reference(m, keygen(i), NULL_HASH, None, grove_version)
+                        .unwrap()
+                        .expect("should insert reference at merk level");
+                });
+
+                drop(merk);
+            }
+
+            // follow_reference starts at ref0, which points to ref1 ... ref10
+            // -> ref11. After 10 hops the loop exits and we get ReferenceLimit.
+            let err = unwrap_cost_err(
+                follow_reference(
+                    &cache,
+                    path.derive_owned(),
+                    b"ref0",
+                    ReferencePathType::AbsolutePathReference(vec![
+                        TEST_LEAF.to_vec(),
+                        b"chain".to_vec(),
+                        keygen(1),
+                    ]),
+                ),
+                "should exceed reference hop limit",
+            );
+
+            assert!(
+                matches!(err, Error::ReferenceLimit),
+                "expected ReferenceLimit, got: {:?}",
+                err
+            );
+        }
+    }
+
+    /// Insert nothing at the target location and call `follow_reference` with
+    /// a reference pointing to a key that does not exist.
+    ///
+    /// Covers lines 80-84: `PathKeyNotFound` -> `CorruptedReferencePathKeyNotFound`
+    /// in `follow_reference`.
+    ///
+    /// Also covers lines 151-154: same mapping in `follow_reference_once`.
+    #[test]
+    fn test_reference_to_missing_key() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert a subtree so the path exists, but no key "ghost" inside it.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"container",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert subtree");
+
+        let tx = db.start_transaction();
+
+        {
+            let cache = MerkCache::new(&db, &tx, grove_version);
+            let path: SubtreePath<&[u8]> =
+                SubtreePath::from(&[TEST_LEAF, b"container"] as &[&[u8]]);
+
+            // Test via follow_reference
+            let err = unwrap_cost_err(
+                follow_reference(
+                    &cache,
+                    path.derive_owned(),
+                    b"origin",
+                    ReferencePathType::AbsolutePathReference(vec![
+                        TEST_LEAF.to_vec(),
+                        b"container".to_vec(),
+                        b"ghost".to_vec(),
+                    ]),
+                ),
+                "should fail with missing key via follow_reference",
+            );
+
+            assert!(
+                matches!(err, Error::CorruptedReferencePathKeyNotFound(_)),
+                "expected CorruptedReferencePathKeyNotFound, got: {:?}",
+                err
+            );
+
+            // Test via follow_reference_once (covers lines 151-154)
+            let err_once = unwrap_cost_err(
+                follow_reference_once(
+                    &cache,
+                    path.derive_owned(),
+                    b"origin",
+                    ReferencePathType::AbsolutePathReference(vec![
+                        TEST_LEAF.to_vec(),
+                        b"container".to_vec(),
+                        b"ghost".to_vec(),
+                    ]),
+                ),
+                "should fail with missing key via follow_reference_once",
+            );
+
+            assert!(
+                matches!(err_once, Error::CorruptedReferencePathKeyNotFound(_)),
+                "expected CorruptedReferencePathKeyNotFound from follow_reference_once, got: {:?}",
+                err_once
+            );
+        }
+    }
+
+    /// A reference that points to itself triggers the immediate cycle detection
+    /// in `follow_reference_once`.
+    ///
+    /// Covers lines 139-141: `path == referred_path && key == referred_key`
+    /// returning `CyclicReference` in `follow_reference_once`.
+    #[test]
+    fn test_self_referencing_element() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert a subtree so the path is valid.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"self_ref",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert subtree");
+
+        let tx = db.start_transaction();
+
+        {
+            let cache = MerkCache::new(&db, &tx, grove_version);
+            let path: SubtreePath<&[u8]> = SubtreePath::from(&[TEST_LEAF, b"self_ref"] as &[&[u8]]);
+
+            // Call follow_reference_once with a reference that resolves to the
+            // same (path, key) it originates from.
+            let err = unwrap_cost_err(
+                follow_reference_once(
+                    &cache,
+                    path.derive_owned(),
+                    b"me",
+                    ReferencePathType::AbsolutePathReference(vec![
+                        TEST_LEAF.to_vec(),
+                        b"self_ref".to_vec(),
+                        b"me".to_vec(),
+                    ]),
+                ),
+                "should detect self-reference cycle",
+            );
+
+            assert!(
+                matches!(err, Error::CyclicReference),
+                "expected CyclicReference, got: {:?}",
+                err
+            );
+        }
+    }
+}

--- a/grovedb/src/tests/visualize_tests.rs
+++ b/grovedb/src/tests/visualize_tests.rs
@@ -186,4 +186,231 @@ mod tests {
             output
         );
     }
+
+    /// Exercises the `uses_non_merk_data_storage()` branch in `draw_subtree`
+    /// (visualize.rs lines 47-51) by inserting an MmrTree element.
+    #[test]
+    fn visualize_with_mmr_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert an MmrTree under TEST_LEAF — MmrTree is a non-Merk tree type.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"my_mmr",
+            Element::empty_mmr_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert mmr tree");
+
+        let output = visualize_to_string(&db);
+
+        assert!(
+            output.contains("my_mmr"),
+            "visualization should contain 'my_mmr', got: {}",
+            output
+        );
+        // The non-Merk branch writes "[non-Merk tree]" before the element.
+        assert!(
+            output.contains("[non-Merk tree]"),
+            "visualization should contain '[non-Merk tree]' for MmrTree, got: {}",
+            output
+        );
+    }
+
+    /// Exercises the `uses_non_merk_data_storage()` branch with a
+    /// BulkAppendTree element.
+    #[test]
+    fn visualize_with_bulk_append_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert a BulkAppendTree under TEST_LEAF.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"my_bulk",
+            Element::empty_bulk_append_tree(3), // chunk_power = 3 (epoch size 8)
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert bulk append tree");
+
+        let output = visualize_to_string(&db);
+
+        assert!(
+            output.contains("my_bulk"),
+            "visualization should contain 'my_bulk', got: {}",
+            output
+        );
+        assert!(
+            output.contains("[non-Merk tree]"),
+            "visualization should contain '[non-Merk tree]' for BulkAppendTree, got: {}",
+            output
+        );
+    }
+
+    /// Exercises the `uses_non_merk_data_storage()` branch with a
+    /// CommitmentTree element.
+    #[test]
+    fn visualize_with_commitment_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert a CommitmentTree under TEST_LEAF.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"my_ct",
+            Element::empty_commitment_tree(4), // chunk_power = 4
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert commitment tree");
+
+        let output = visualize_to_string(&db);
+
+        assert!(
+            output.contains("my_ct"),
+            "visualization should contain 'my_ct', got: {}",
+            output
+        );
+        assert!(
+            output.contains("[non-Merk tree]"),
+            "visualization should contain '[non-Merk tree]' for CommitmentTree, got: {}",
+            output
+        );
+    }
+
+    /// Exercises the leaf element `else` branch (visualize.rs line 63-64)
+    /// with a Reference element. Items are already tested in
+    /// `visualize_with_items`, but References are a distinct leaf type.
+    #[test]
+    fn visualize_with_reference() {
+        use crate::reference_path::ReferencePathType;
+
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert an item that the reference will point to.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"target",
+            Element::new_item(b"target_value".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert target item");
+
+        // Insert a reference to that item.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"my_ref",
+            Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                TEST_LEAF.to_vec(),
+                b"target".to_vec(),
+            ])),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert reference");
+
+        let output = visualize_to_string(&db);
+
+        assert!(
+            output.contains("my_ref"),
+            "visualization should contain 'my_ref', got: {}",
+            output
+        );
+        // The Reference element's Visualize impl writes "ref".
+        assert!(
+            output.contains("ref"),
+            "visualization should contain 'ref' for Reference element, got: {}",
+            output
+        );
+    }
+
+    /// Exercises all three branches of `draw_subtree` in a single tree:
+    /// 1. Non-Merk tree (MmrTree) -> "[non-Merk tree]" branch
+    /// 2. Regular Merk tree (subtree) -> recursive `draw_subtree` branch
+    /// 3. Leaf element (Item) -> `else` branch
+    #[test]
+    fn visualize_mixed_elements() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Branch 1: non-Merk tree element
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"mmr_child",
+            Element::empty_mmr_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert mmr tree");
+
+        // Branch 2: regular Merk subtree
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"sub_tree",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert subtree");
+
+        // Branch 3: leaf item
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"leaf_item",
+            Element::new_item(b"hello".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("should insert leaf item");
+
+        let output = visualize_to_string(&db);
+
+        // Verify all three element types appear in the visualization.
+        assert!(
+            output.contains("mmr_child"),
+            "visualization should contain 'mmr_child', got: {}",
+            output
+        );
+        assert!(
+            output.contains("[non-Merk tree]"),
+            "visualization should contain '[non-Merk tree]', got: {}",
+            output
+        );
+        assert!(
+            output.contains("sub_tree"),
+            "visualization should contain 'sub_tree', got: {}",
+            output
+        );
+        assert!(
+            output.contains("leaf_item"),
+            "visualization should contain 'leaf_item', got: {}",
+            output
+        );
+        assert!(
+            output.contains("item:"),
+            "visualization should contain 'item:' for the leaf Item element, got: {}",
+            output
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- **commitment_tree**: 3 new tests covering `Debug` fmt, `open()` `from_state` error path, and frontier/total_count mismatch; `codecov:ignore` on 2 unreachable error paths (storage fault during bulk append, frontier full at 2^32 appends)
- **error.rs**: Tests for `add_context` noop on non-String variants (wildcard arm), `add_context` on all String variants, `From<merk::Error>` conversions, `QueryError` Display
- **visualize.rs**: Tests for non-Merk tree branch (MmrTree, BulkAppendTree, CommitmentTree), Reference leaf branch, and mixed-element visualization
- **reference_path.rs**: Tests for reference resolution edge cases

## Test plan

- [x] `cargo test -p grovedb-commitment-tree --features storage` — all 45 tests pass
- [x] `cargo test -p grovedb` — all tests pass
- [x] Pre-commit hooks pass (fmt, typos, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit and integration tests covering error handling, debug formatting, and tree operations.
  * Added tests for reference path resolution error scenarios and visualization across different element types.

* **Chores**
  * Enhanced code clarity with inline comments in error-handling paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->