### PR TITLE
test: remove 4 redundant zero-impact tests from PR #440

### DIFF
--- a/grovedb-element/tests/element_constructors_helpers.rs
+++ b/grovedb-element/tests/element_constructors_helpers.rs
@@ -1,8 +1,5 @@
-use std::panic;
-
 use grovedb_element::{
-    error::ElementError, reference_path::ReferencePathType, CountValue, Element, ElementFlags,
-    SumValue,
+    error::ElementError, reference_path::ReferencePathType, Element, ElementFlags,
 };
 use grovedb_version::version::GroveVersion;
 use integer_encoding::VarInt;
@@ -136,31 +133,6 @@ fn constructors_create_expected_count_and_count_sum_tree_variants() {
             sample_flags()
         ),
         Element::CountSumTree(Some(vec![6]), 2, -3, sample_flags())
-    );
-}
-
-#[test]
-fn constructors_create_expected_item_and_sum_item_variants() {
-    assert_eq!(
-        Element::new_item(vec![1, 2]),
-        Element::Item(vec![1, 2], None)
-    );
-    assert_eq!(
-        Element::new_item_with_flags(vec![1, 2], sample_flags()),
-        Element::Item(vec![1, 2], sample_flags())
-    );
-    assert_eq!(Element::new_sum_item(12), Element::SumItem(12, None));
-    assert_eq!(
-        Element::new_sum_item_with_flags(-12, sample_flags()),
-        Element::SumItem(-12, sample_flags())
-    );
-    assert_eq!(
-        Element::new_item_with_sum_item(vec![1], 44),
-        Element::ItemWithSumItem(vec![1], 44, None)
-    );
-    assert_eq!(
-        Element::new_item_with_sum_item_with_flags(vec![1], -44, sample_flags()),
-        Element::ItemWithSumItem(vec![1], -44, sample_flags())
     );
 }
 
@@ -299,22 +271,6 @@ fn constructors_create_expected_commitment_mmr_bulk_dense_variants() {
         Element::new_dense_tree(13, 9, sample_flags()),
         Element::DenseAppendOnlyFixedSizeTree(13, 9, sample_flags())
     );
-}
-
-#[test]
-fn constructors_enforce_chunk_power_bounds() {
-    let commitment = panic::catch_unwind(|| Element::empty_commitment_tree(32));
-    assert!(commitment.is_err());
-
-    let commitment_flags =
-        panic::catch_unwind(|| Element::empty_commitment_tree_with_flags(255, Some(vec![1])));
-    assert!(commitment_flags.is_err());
-
-    let bulk = panic::catch_unwind(|| Element::empty_bulk_append_tree(100));
-    assert!(bulk.is_err());
-
-    let bulk_flags = panic::catch_unwind(|| Element::empty_bulk_append_tree_with_flags(50, None));
-    assert!(bulk_flags.is_err());
 }
 
 #[test]
@@ -567,10 +523,4 @@ fn convert_if_reference_to_absolute_reference_converts_and_preserves_other_types
         err,
         ElementError::InvalidInput("reference stored path cannot satisfy reference constraints")
     ));
-}
-
-#[test]
-fn tree_and_item_defaults_use_alias_types() {
-    let _sum_value: SumValue = Element::new_sum_item(1).as_sum_item_value().unwrap();
-    let _count_value: CountValue = Element::new_count_tree(Some(vec![1])).count_value_or_default();
 }

--- a/grovedb-element/tests/element_display_and_serialization.rs
+++ b/grovedb-element/tests/element_display_and_serialization.rs
@@ -1,4 +1,4 @@
-use grovedb_element::{error::ElementError, hex_to_ascii, Element, ElementType};
+use grovedb_element::{error::ElementError, Element, ElementType};
 use grovedb_version::version::GroveVersion;
 
 #[test]
@@ -105,12 +105,6 @@ fn element_display_and_type_helpers_cover_all_variants() {
         assert_eq!(element.type_str(), expected_type_str);
         assert_eq!(format!("{element}"), expected_display);
     }
-}
-
-#[test]
-fn hex_to_ascii_covers_ascii_and_binary_inputs() {
-    assert_eq!(hex_to_ascii(b"Alpha_123/-[]@\\"), "Alpha_123/-[]@\\");
-    assert_eq!(hex_to_ascii(&[0, 255, 10]), "0x00ff0a");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Removes 4 tests from PR #440's element crate coverage that add zero unique coverage lines (fully covered by other tests in the same suite)
- Reduces test count from 20 to 16 while preserving all 667 new coverage lines
- Cleaned up unused imports (`hex_to_ascii`, `std::panic`, `CountValue`, `SumValue`)

### Removed tests
| Test | Reason |
|------|--------|
| `constructors_create_expected_item_and_sum_item_variants` | 0 unique lines; all covered by `value_helpers_and_conversion_errors_work` |
| `constructors_enforce_chunk_power_bounds` | 0 unique lines; covered by other constructor tests |
| `tree_and_item_defaults_use_alias_types` | 0 unique lines; covered by other constructor tests |
| `hex_to_ascii_covers_ascii_and_binary_inputs` | 0 unique lines; covered by `element_display_and_type_helpers_cover_all_variants` |

## Test plan
- [x] `cargo test -p grovedb-element --tests` — all 16 remaining tests pass
- [x] `cargo clippy -p grovedb-element --tests -- -D warnings` — clean
- [x] `cargo llvm-cov` confirms 667/667 new coverage lines preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)