### PR TITLE
fix(ci): restore coverage baseline detection in PR diffs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: coverage-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   detect-changes:
@@ -103,7 +103,7 @@ jobs:
       - name: Run coverage diff analysis
         if: github.event_name == 'pull_request'
         env:
-          BASELINE_CACHE_HIT: ${{ steps.baseline.outputs.cache-hit }}
+          BASELINE_CACHE_HIT: ${{ steps.baseline.outputs.cache-matched-key != '' }}
           BASE_REF: ${{ github.base_ref }}
         run: |
           python .github/scripts/coverage-diff.py \


### PR DESCRIPTION
## Summary

- **Fix baseline detection**: The cache restore step uses a `restore-keys` prefix match (intentionally non-matching primary key with `-notexact` suffix). The `cache-hit` output is only `true` for exact primary key matches, so `BASELINE_CACHE_HIT` was always `false`. Changed to `cache-matched-key != ''` which correctly detects successful prefix-match restores.
- **Fix baseline caching**: `cancel-in-progress: true` applied to push events too, meaning rapid merges to develop would cancel earlier coverage runs before the `actions/cache/save` step completed. Changed to `cancel-in-progress: ${{ github.event_name != 'push' }}` so only PR runs get cancelled on concurrent updates.

## Test plan

- [ ] Merge a PR to develop → verify push coverage run completes and saves cache
- [ ] Open a new PR → verify coverage diff report shows baseline data instead of "No baseline coverage data available"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow concurrency to skip cancellation for push events while maintaining cancellation for pull request events.
  * Adjusted baseline cache detection mechanism in coverage workflow for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->