### PR TITLE
fix(grovedb): correct empty CommitmentTree and MmrTree hash/proof handling

### DIFF
--- a/grovedb-commitment-tree/src/lib.rs
+++ b/grovedb-commitment-tree/src/lib.rs
@@ -31,6 +31,18 @@ pub use client::ClientPersistentCommitmentTree;
 #[cfg(feature = "sqlite")]
 pub use client::{SqliteShardStore, SqliteShardStoreError};
 pub use commitment_frontier::*;
+
+/// Pre-computed state root for an empty CommitmentTree.
+///
+/// `blake3("ct_state" || EMPTY_SINSEMILLA_ROOT || blake3("bulk_state" || [0;32] || [0;32]))`
+///
+/// This avoids re-hashing at runtime every time we need the empty root (e.g.
+/// during batch insertion and verification).
+pub const EMPTY_COMMITMENT_TREE_STATE_ROOT: [u8; 32] = [
+    0xe8, 0x1f, 0x97, 0x6c, 0xfc, 0x6e, 0xaf, 0x83, 0x69, 0xe8, 0x56, 0xa4, 0x69, 0x04, 0x75, 0x69,
+    0x89, 0xa4, 0x85, 0x26, 0x1b, 0xaf, 0xb6, 0x78, 0xec, 0x8f, 0xac, 0x63, 0x70, 0xa6, 0x11, 0x97,
+];
+
 /// Compute the combined CommitmentTree state root that binds the Sinsemilla
 /// anchor to the BulkAppendTree data root.
 ///
@@ -127,3 +139,27 @@ pub use orchard::{
 };
 #[cfg(feature = "sqlite")]
 pub use rusqlite;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_commitment_tree_state_root_constant() {
+        let null = [0u8; 32];
+        // Inline the bulk-append-tree empty state root computation
+        // (blake3("bulk_state" || [0;32] || [0;32])) to avoid an optional dep.
+        let empty_bulk_root = {
+            let mut h = blake3::Hasher::new();
+            h.update(b"bulk_state");
+            h.update(&null);
+            h.update(&null);
+            *h.finalize().as_bytes()
+        };
+        let computed = compute_commitment_tree_state_root(&EMPTY_SINSEMILLA_ROOT, &empty_bulk_root);
+        assert_eq!(
+            computed, EMPTY_COMMITMENT_TREE_STATE_ROOT,
+            "EMPTY_COMMITMENT_TREE_STATE_ROOT constant does not match runtime computation"
+        );
+    }
+}

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1714,19 +1714,11 @@ where
                                 .get_feature_type(in_tree_type)
                                 .wrap_with_cost(OperationCost::default())
                         );
-                        // Combined empty state root: sinsemilla + bulk
-                        let empty_bulk_root =
-                            grovedb_bulk_append_tree::compute_state_root(&NULL_HASH, &NULL_HASH);
-                        let empty_state_root =
-                            grovedb_commitment_tree::compute_commitment_tree_state_root(
-                                &grovedb_commitment_tree::EMPTY_SINSEMILLA_ROOT,
-                                &empty_bulk_root,
-                            );
                         cost_return_on_error_into!(
                             &mut cost,
                             element.insert_subtree_into_batch_operations(
                                 key_info.get_key_clone(),
-                                empty_state_root,
+                                grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT,
                                 false,
                                 &mut batch_operations,
                                 merk_feature_type,

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -1069,7 +1069,7 @@ impl GroveDb {
         match element {
             Element::CommitmentTree(total_count, chunk_power, _) => {
                 if *total_count == 0 {
-                    return merk_root_hash;
+                    return grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT;
                 }
                 let storage_ctx = self
                     .db

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -292,18 +292,12 @@ impl GroveDb {
             // hash must include the empty sinsemilla root so V1 proof
             // verification works even before the first append.
             Element::CommitmentTree(..) => {
-                let empty_bulk_root =
-                    grovedb_bulk_append_tree::compute_state_root(&NULL_HASH, &NULL_HASH);
-                let empty_state_root = grovedb_commitment_tree::compute_commitment_tree_state_root(
-                    &grovedb_commitment_tree::EMPTY_SINSEMILLA_ROOT,
-                    &empty_bulk_root,
-                );
                 cost_return_on_error_into!(
                     &mut cost,
                     element.insert_subtree(
                         &mut subtree_to_insert_into,
                         key,
-                        empty_state_root,
+                        grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT,
                         Some(options.as_merk_options()),
                         grove_version
                     )

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -1191,6 +1191,24 @@ impl GroveDb {
             Self::query_items_to_leaf_indices(&sub_query.items, mmr_size)
         );
 
+        // Empty leaf_indices means the MMR has no matching leaves (e.g. empty
+        // tree).  Return an empty proof directly instead of calling
+        // MmrTreeProof::generate which rejects empty indices.
+        if leaf_indices.is_empty() {
+            let empty_proof = MmrTreeProof::new(mmr_size, vec![], vec![]);
+            let proof_bytes = cost_return_on_error_no_add!(
+                cost,
+                empty_proof
+                    .encode_to_vec()
+                    .map_err(|e| Error::CorruptedData(format!("{}", e)))
+            );
+            return Ok(LayerProof {
+                merk_proof: ProofBytes::MMR(proof_bytes),
+                lower_layers: BTreeMap::new(),
+            })
+            .wrap_with_cost(cost);
+        }
+
         // Open aux storage at the subtree path
         let path_vec: Vec<Vec<u8>> = subtree_path.iter().map(|s| s.to_vec()).collect();
         let path_refs: Vec<&[u8]> = path_vec.iter().map(|v| v.as_slice()).collect();

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -1191,16 +1191,19 @@ impl GroveDb {
             Self::query_items_to_leaf_indices(&sub_query.items, mmr_size)
         );
 
-        // Empty leaf_indices means the MMR has no matching leaves (e.g. empty
-        // tree).  Return an empty proof directly instead of calling
-        // MmrTreeProof::generate which rejects empty indices.
-        if leaf_indices.is_empty() {
+        // An empty MMR (mmr_size == 0) has no nodes to prove. Return an empty
+        // proof directly instead of calling MmrTreeProof::generate which
+        // rejects empty leaf_indices.
+        if mmr_size == 0 {
             let empty_proof = MmrTreeProof::new(mmr_size, vec![], vec![]);
             let proof_bytes = cost_return_on_error_no_add!(
                 cost,
                 empty_proof
                     .encode_to_vec()
-                    .map_err(|e| Error::CorruptedData(format!("{}", e)))
+                    .map_err(|e| Error::CorruptedData(format!(
+                        "failed to encode MmrTreeProof: {}",
+                        e
+                    )))
             );
             return Ok(LayerProof {
                 merk_proof: ProofBytes::MMR(proof_bytes),

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -669,10 +669,19 @@ impl GroveDb {
             ));
         }
 
-        // Empty proof means no matching leaves (e.g. empty MMR tree).
+        // An empty MMR (mmr_size == 0) has no leaves to verify.
         // Return the empty-MMR root hash ([0u8; 32]) directly.
         if mmr_proof.leaves().is_empty() {
-            return Ok([0u8; 32]);
+            if element_mmr_size == 0 {
+                return Ok([0u8; 32]);
+            }
+            return Err(Error::InvalidProof(
+                query.clone(),
+                format!(
+                    "MMR proof contains no leaves but element mmr_size is {} (expected 0)",
+                    element_mmr_size
+                ),
+            ));
         }
 
         // Compute root from the proof — the Merk child hash mechanism

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -669,6 +669,12 @@ impl GroveDb {
             ));
         }
 
+        // Empty proof means no matching leaves (e.g. empty MMR tree).
+        // Return the empty-MMR root hash ([0u8; 32]) directly.
+        if mmr_proof.leaves().is_empty() {
+            return Ok([0u8; 32]);
+        }
+
         // Compute root from the proof — the Merk child hash mechanism
         // authenticates this root via combine_hash(value_hash || mmr_root)
         let (mmr_root, verified_leaves) = mmr_proof

--- a/grovedb/src/tests/commitment_tree_tests.rs
+++ b/grovedb/src/tests/commitment_tree_tests.rs
@@ -2040,12 +2040,9 @@ fn test_commitment_tree_persistence_across_reopen() {
 // verify_grovedb empty tree test
 // ===========================================================================
 
-/// An empty CommitmentTree (no inserts) currently has a hash mismatch in
-/// verify_grovedb: the initial insert stores NULL_HASH ([0; 32]) as the
-/// child hash in Merk, but verify_grovedb computes the actual state root
-/// (which includes the non-zero sinsemilla empty tree root). This test
-/// documents that known behavior. After the first insert, verify_grovedb
-/// passes cleanly (see `test_verify_grovedb_commitment_tree_valid`).
+/// An empty CommitmentTree (no inserts) should pass verify_grovedb cleanly.
+/// Both batch insertion and verification now use the same pre-computed
+/// EMPTY_COMMITMENT_TREE_STATE_ROOT constant.
 #[test]
 fn test_verify_grovedb_commitment_tree_empty() {
     let grove_version = GroveVersion::latest();
@@ -2063,20 +2060,12 @@ fn test_verify_grovedb_commitment_tree_empty() {
     .unwrap()
     .expect("insert empty commitment tree");
 
-    // An empty CommitmentTree currently reports a hash mismatch because the
-    // initial child hash is NULL_HASH but the computed state root includes
-    // the non-zero sinsemilla empty tree root.
     let issues = db
         .verify_grovedb(None, true, false, grove_version)
         .expect("verify should not fail");
     assert!(
-        !issues.is_empty(),
-        "empty commitment tree should report hash mismatch (NULL_HASH vs sinsemilla empty root)"
-    );
-    // Exactly one issue for the path [b"ct"]
-    assert_eq!(
-        issues.len(),
-        1,
-        "should have exactly one issue for the empty commitment tree path"
+        issues.is_empty(),
+        "empty commitment tree should verify cleanly, got: {:?}",
+        issues
     );
 }

--- a/grovedb/src/tests/mmr_tree_tests.rs
+++ b/grovedb/src/tests/mmr_tree_tests.rs
@@ -14,7 +14,7 @@ use crate::{
     batch::QualifiedGroveDbOp,
     operations::delete::DeleteOptions,
     tests::{common::EMPTY_PATH, make_empty_grovedb},
-    Element, Error,
+    Element, Error, GroveDb,
 };
 
 /// In-memory MMR store for test helpers.
@@ -1620,32 +1620,25 @@ fn test_mmr_tree_v1_proof_empty() {
         },
     };
 
-    // Empty MmrTree proof generation currently errors because
-    // MmrTreeProof::generate rejects empty leaf_indices.
-    let result = db.prove_query_v1(&path_query, None, grove_version).unwrap();
+    // Proving an empty MmrTree should succeed with an empty result set.
+    let proof = db
+        .prove_query_v1(&path_query, None, grove_version)
+        .unwrap()
+        .expect("prove_query_v1 should succeed for empty MmrTree");
 
-    match result {
-        Err(Error::CorruptedData(msg)) => {
-            assert!(
-                msg.contains("leaf_indices must not be empty"),
-                "error should mention empty leaf_indices, got: {}",
-                msg
-            );
-        }
-        Err(other) => {
-            panic!(
-                "expected CorruptedData error about empty leaf_indices, got: {:?}",
-                other
-            );
-        }
-        Ok(_) => {
-            // If a future fix makes this succeed, verify the result is correct
-            panic!(
-                "prove_query_v1 succeeded for empty MmrTree; if this is intentional, update this \
-                 test to verify the proof produces an empty result set"
-            );
-        }
-    }
+    // Verify the proof and confirm an empty result set.
+    let (root_hash, results) = GroveDb::verify_query_raw(&proof, &path_query, grove_version)
+        .expect("proof verification should succeed for empty MmrTree");
+
+    assert!(
+        results.is_empty(),
+        "expected empty result set for empty MmrTree, got {} results",
+        results.len()
+    );
+
+    // Root hash should match the current GroveDB root.
+    let expected_root = db.root_hash(None, grove_version).unwrap().unwrap();
+    assert_eq!(root_hash, expected_root);
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

- **Empty CommitmentTree hash mismatch**: Insertions stored `NULL_HASH` as the child hash, but `verify_grovedb` computed the actual state root (including the non-zero sinsemilla empty tree root). Extracted a pre-computed `EMPTY_COMMITMENT_TREE_STATE_ROOT` constant and use it consistently in batch insertion, direct insertion, and verification.
- **Empty MmrTree proof crash**: `prove_query_v1` on an empty MmrTree crashed with `"leaf_indices must not be empty"` because `generate_mmr_layer_proof` passed an empty vec to `MmrTreeProof::generate`. Added early returns in both generator and verifier when the query produces no matching leaf indices, returning an empty proof with the correct root hash.

## Test plan

- [x] `cargo test -p grovedb -- mmr_tree` — all 48 tests pass including updated `test_mmr_tree_v1_proof_empty`
- [x] `cargo test -p grovedb -- commitment_tree` — `test_verify_grovedb_commitment_tree_empty` now asserts clean verification
- [x] `cargo clippy -p grovedb --all-features --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed empty commitment tree verification to handle empty state roots correctly
  * Empty MMR proof generation and verification now complete successfully

* **Performance Improvements**
  * Eliminated redundant hash computations by introducing a pre-computed constant for empty commitment tree state roots

* **Tests**
  * Updated test expectations for empty commitment tree and MMR proof scenarios to reflect corrected behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->