### PR TITLE
chore(ci): speed up security audit with pre-built cargo-audit

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -194,11 +194,8 @@ jobs:
 
   security:
     name: Security Audit
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo generate-lockfile
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: taiki-e/install-action@cargo-audit
+      - run: cargo audit


### PR DESCRIPTION
## Summary

- Replace `rustsec/audit-check` (compiles `cargo-audit` from source — slow) with `taiki-e/install-action@cargo-audit` (downloads pre-built binary — seconds)
- Remove unnecessary `dtolnay/rust-toolchain` install and `cargo generate-lockfile` (Cargo.lock is committed, runner has Rust pre-installed)
- Switch from `ubuntu-22.04` to `ubuntu-latest`

## Test plan

- [ ] Security audit job passes on this PR
- [ ] Job completes significantly faster than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)