### PR TITLE
fix(ci): add Codecov component definitions for per-crate badges

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,6 +23,37 @@ comment:
   behavior: default
   require_changes: true
 
+component_management:
+  individual_components:
+    - component_id: grovedb-core
+      name: grovedb-core
+      paths:
+        - grovedb/
+    - component_id: merk
+      name: merk
+      paths:
+        - merk/
+    - component_id: storage
+      name: storage
+      paths:
+        - storage/
+    - component_id: commitment-tree
+      name: commitment-tree
+      paths:
+        - grovedb-commitment-tree/
+    - component_id: mmr
+      name: mmr
+      paths:
+        - grovedb-merkle-mountain-range/
+    - component_id: bulk-append-tree
+      name: bulk-append-tree
+      paths:
+        - grovedb-bulk-append-tree/
+    - component_id: element
+      name: element
+      paths:
+        - grovedb-element/
+
 flag_management:
   default_rules:
     carryforward: true


### PR DESCRIPTION
## Summary

- README badges use Codecov **components** (`?component=merk`, etc.) but `.codecov.yml` only defined **flags** — these are separate features in Codecov
- Added `component_management` section mapping each badge to its source directory:
  - `grovedb-core` → `grovedb/`
  - `merk` → `merk/`
  - `storage` → `storage/`
  - `commitment-tree` → `grovedb-commitment-tree/`
  - `mmr` → `grovedb-merkle-mountain-range/`
  - `bulk-append-tree` → `grovedb-bulk-append-tree/`
  - `element` → `grovedb-element/`

Fixes the "unknown" per-crate coverage badges introduced in #469.

## Test plan

- [ ] After merging to develop, per-crate badges in README show coverage percentages instead of "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)