### PR TITLE
fix(ci): restore cross-crate coverage with sharded workspace tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,7 +19,7 @@ coverage:
         target: 80%
 
 comment:
-  layout: "condensed_header, diff, flags, components, condensed_files"
+  layout: "condensed_header, diff, components, condensed_files"
   behavior: default
   require_changes: true
 
@@ -53,29 +53,3 @@ component_management:
       name: element
       paths:
         - grovedb-element/
-
-flag_management:
-  default_rules:
-    carryforward: true
-  individual_flags:
-    - name: core
-      paths:
-        - costs/
-        - path/
-        - visualize/
-        - grovedb-version/
-        - grovedbg-types/
-        - storage/
-        - grovedb-epoch-based-storage-flags/
-        - grovedb-element/
-        - merk/
-        - grovedb-query/
-    - name: trees
-      paths:
-        - grovedb-merkle-mountain-range/
-        - grovedb-dense-fixed-sized-merkle-tree/
-        - grovedb-bulk-append-tree/
-        - grovedb-commitment-tree/
-    - name: grovedb
-      paths:
-        - grovedb/

--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -19,10 +19,6 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      core: ${{ steps.filter.outputs.core }}
-      merk: ${{ steps.filter.outputs.merk }}
-      trees: ${{ steps.filter.outputs.trees }}
-      grovedb: ${{ steps.filter.outputs.grovedb }}
       any-code: ${{ steps.filter.outputs.any-code }}
     steps:
       - uses: actions/checkout@v4
@@ -30,68 +26,15 @@ jobs:
         id: filter
         with:
           filters: |
-            core:
-              - 'costs/**'
-              - 'path/**'
-              - 'visualize/**'
-              - 'grovedb-version/**'
-              - 'grovedbg-types/**'
-              - 'storage/**'
-              - 'grovedb-epoch-based-storage-flags/**'
-              - 'grovedb-element/**'
-              - 'grovedb-query/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-            merk:
-              - 'merk/**'
-              - 'costs/**'
-              - 'path/**'
-              - 'visualize/**'
-              - 'grovedb-version/**'
-              - 'storage/**'
-              - 'grovedb-element/**'
-              - 'grovedb-query/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-            trees:
-              - 'costs/**'
-              - 'path/**'
-              - 'visualize/**'
-              - 'storage/**'
-              - 'grovedb-query/**'
-              - 'grovedb-merkle-mountain-range/**'
-              - 'grovedb-dense-fixed-sized-merkle-tree/**'
-              - 'grovedb-bulk-append-tree/**'
-              - 'grovedb-commitment-tree/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-            grovedb:
-              - 'grovedb/**'
-              - 'costs/**'
-              - 'path/**'
-              - 'visualize/**'
-              - 'grovedb-version/**'
-              - 'grovedbg-types/**'
-              - 'storage/**'
-              - 'grovedb-epoch-based-storage-flags/**'
-              - 'grovedb-element/**'
-              - 'merk/**'
-              - 'grovedb-query/**'
-              - 'grovedb-merkle-mountain-range/**'
-              - 'grovedb-dense-fixed-sized-merkle-tree/**'
-              - 'grovedb-bulk-append-tree/**'
-              - 'grovedb-commitment-tree/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
             any-code:
               - '**/*.rs'
               - '**/Cargo.toml'
               - 'Cargo.lock'
 
-  test-core:
-    name: Test Core
+  build:
+    name: Build
     needs: detect-changes
-    if: needs.detect-changes.outputs.core == 'true'
+    if: needs.detect-changes.outputs.any-code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -103,111 +46,27 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "false"
+          shared-key: coverage-build
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Run core crate tests
+      - uses: taiki-e/install-action@cargo-nextest
+      - name: Build and archive tests
         env:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: sccache
-        run: >
-          cargo llvm-cov
-          -p grovedb-costs
-          -p grovedb-path
-          -p grovedb-visualize
-          -p grovedb-version
-          -p grovedbg-types
-          -p grovedb-storage
-          -p grovedb-epoch-based-storage-flags
-          -p grovedb-element
-          -p grovedb-query
-          --all-features
-          --lcov --output-path lcov.info
-      - name: Upload coverage
-        if: always()
-        uses: codecov/codecov-action@v5
+        run: |
+          source <(cargo llvm-cov show-env --export-prefix)
+          cargo llvm-cov clean --workspace
+          cargo nextest archive --workspace --all-features --archive-file tests.tar.zst
+      - uses: actions/upload-artifact@v4
         with:
-          files: lcov.info
-          flags: core
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          name: nextest-archive
+          path: tests.tar.zst
+          retention-days: 1
 
-  test-merk:
-    name: Test Merk
-    needs: detect-changes
-    if: needs.detect-changes.outputs.merk == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: "false"
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Run merk tests
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: sccache
-        run: >
-          cargo llvm-cov
-          -p grovedb-merk
-          --all-features
-          --lcov --output-path lcov.info
-      - name: Upload coverage
-        if: always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
-          flags: merk
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-
-  test-trees:
-    name: Test Trees
-    needs: detect-changes
-    if: needs.detect-changes.outputs.trees == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: "false"
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Run tree crate tests
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: sccache
-        run: >
-          cargo llvm-cov
-          -p grovedb-merkle-mountain-range
-          -p grovedb-dense-fixed-sized-merkle-tree
-          -p grovedb-bulk-append-tree
-          -p grovedb-commitment-tree
-          --all-features
-          --lcov --output-path lcov.info
-      - name: Upload coverage
-        if: always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
-          flags: trees
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-
-  test-grovedb:
-    name: Test GroveDB (${{ matrix.partition }}/3)
-    needs: detect-changes
-    if: needs.detect-changes.outputs.grovedb == 'true'
+  test:
+    name: Test (${{ matrix.partition }}/3)
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -223,24 +82,23 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "false"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+          shared-key: coverage-build
+          save-if: "false"
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@cargo-nextest
-      - name: Run grovedb tests (shard ${{ matrix.partition }}/3)
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: sccache
-        run: >
-          cargo llvm-cov nextest
-          -p grovedb
-          --partition count:${{ matrix.partition }}/3
-          --lcov --output-path lcov.info
+      - uses: actions/download-artifact@v4
+        with:
+          name: nextest-archive
+      - name: Run tests (shard ${{ matrix.partition }}/3)
+        run: |
+          source <(cargo llvm-cov show-env --export-prefix)
+          cargo nextest run --archive-file tests.tar.zst --partition count:${{ matrix.partition }}/3
+          cargo llvm-cov report --lcov --output-path lcov.info
       - name: Upload coverage
         if: always()
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info
-          flags: grovedb
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 


### PR DESCRIPTION
## Summary

PR #469 split coverage into 3 per-crate jobs (`-p grovedb`, `-p grovedb-merk`, etc.), but this only instruments the specified crate — losing cross-crate coverage. For example, grovedb's integration tests exercise merk/storage code, but that coverage wasn't collected. This caused overall coverage to drop from **88% to 83%**.

The old workflow used `cargo llvm-cov --workspace` in a single job, which captured everything but couldn't be parallelized.

**Fix:** Replace the 3 separate test jobs with **3 sharded workspace coverage jobs** using `cargo-nextest` partitioning:

```
cargo llvm-cov nextest --workspace --all-features --partition count:N/3
```

Each shard:
- Instruments **all** workspace crates (`--workspace`)
- Runs ~752 of the 2257 total tests (`--partition count:N/3`)
- Uploads coverage to Codecov (which merges all shard uploads)

Also:
- Replaced `flag_management` with `component_management` in `.codecov.yml` to fix the "unknown" per-crate README badges
- Simplified change detection (single `any-code` filter since all shards test the whole workspace)

## Test plan

- [ ] All 3 shards pass
- [ ] Codecov reports ~88% coverage (restored from 83%)
- [ ] Per-crate badges show coverage instead of "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD testing infrastructure to use parallelized test partitions for improved efficiency.
  * Reorganized code coverage configuration from flag-based to component-based management structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->