### PR TITLE
fix(ci): add sccache to linting job

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -86,9 +86,16 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "false"
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - name: Run clippy
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
         run: cargo clippy --workspace --all-features -- -D warnings
       - name: Check verify feature
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
         run: cargo build --no-default-features --features verify -p grovedb
 
   formatting:


### PR DESCRIPTION
## Summary

The linting job was missing sccache, causing clippy to recompile the entire workspace from scratch (~8 min). Test shards with sccache only take ~2 min.

Added `mozilla-actions/sccache-action` and `RUSTC_WRAPPER=sccache` to both the clippy and verify-feature build steps.

## Test plan

- [ ] Linting job completes in ~2 min instead of ~8 min on cache-warm runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration pipeline with enhanced build caching mechanisms to improve compilation performance and reduce build times.
  * Introduced a dedicated feature verification step in the automated workflow to streamline verification processes and enhance build clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->