### PR TITLE
test(commitment-tree): cover deserialization error paths and client append validation

### DIFF
--- a/grovedb-commitment-tree/src/client/sqlite_client_tests.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_client_tests.rs
@@ -172,6 +172,19 @@ mod tests {
     }
 
     #[test]
+    fn test_append_invalid_field_element() {
+        let mut tree = memory_tree();
+        // All 0xFF bytes is not a valid Pallas field element
+        let result = tree.append([0xFF; 32], Retention::Marked);
+        assert!(result.is_err(), "should reject invalid field element");
+        let msg = format!("{}", result.expect_err("should be error"));
+        assert!(
+            msg.contains("invalid Pallas field element"),
+            "error should mention field element: {msg}"
+        );
+    }
+
+    #[test]
     fn test_shared_connection_append_and_anchor() {
         let conn = Connection::open_in_memory().expect("open sqlite");
         let arc = Arc::new(Mutex::new(conn));

--- a/grovedb-commitment-tree/src/client/sqlite_store/tree_serialization.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_store/tree_serialization.rs
@@ -189,4 +189,138 @@ mod tests {
             "error should mention depth limit: {msg}"
         );
     }
+
+    #[test]
+    fn test_deserialize_empty_data() {
+        let mut pos = 0;
+        let result = deserialize_tree(&[], &mut pos);
+        assert!(result.is_err());
+        let msg = format!("{}", result.expect_err("should be error"));
+        assert!(
+            msg.contains("unexpected end of data"),
+            "error should mention end of data: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_unknown_tag() {
+        let data = [0x99];
+        let mut pos = 0;
+        let result = deserialize_tree(&data, &mut pos);
+        assert!(result.is_err());
+        let msg = format!("{}", result.expect_err("should be error"));
+        assert!(
+            msg.contains("unknown tree node tag: 0x99"),
+            "error should mention unknown tag: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_truncated_leaf() {
+        // TAG_LEAF followed by only 10 bytes (needs 33: 32 hash + 1 flags)
+        let mut data = vec![TAG_LEAF];
+        data.extend_from_slice(&[0u8; 10]);
+        let mut pos = 0;
+        let result = deserialize_tree(&data, &mut pos);
+        assert!(result.is_err());
+        let msg = format!("{}", result.expect_err("should be error"));
+        assert!(
+            msg.contains("truncated leaf data"),
+            "error should mention truncated leaf: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_invalid_leaf_field_element() {
+        // TAG_LEAF + 32 bytes of 0xFF (not a valid Pallas element) + flags
+        let mut data = vec![TAG_LEAF];
+        data.extend_from_slice(&[0xFF; 32]);
+        data.push(0x00); // flags
+        let mut pos = 0;
+        let result = deserialize_tree(&data, &mut pos);
+        assert!(result.is_err());
+        let msg = format!("{}", result.expect_err("should be error"));
+        assert!(
+            msg.contains("invalid Pallas field element in leaf"),
+            "error should mention invalid leaf: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_invalid_retention_flags() {
+        // TAG_LEAF + valid hash + invalid flags byte (0xFF has undefined bits)
+        let valid_hash = crate::commitment_frontier::merkle_hash_from_bytes(&[0u8; 32])
+            .expect("zero is valid Pallas element");
+        let mut data = vec![TAG_LEAF];
+        data.extend_from_slice(&valid_hash.to_bytes());
+        data.push(0xFF); // invalid flags (only low 3 bits are defined)
+        let mut pos = 0;
+        let result = deserialize_tree(&data, &mut pos);
+        assert!(result.is_err());
+        let msg = format!("{}", result.expect_err("should be error"));
+        assert!(
+            msg.contains("invalid retention flags: 0xff"),
+            "error should mention invalid flags: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_truncated_parent_annotation_flag() {
+        // TAG_PARENT but no annotation flag byte follows
+        let data = [TAG_PARENT];
+        let mut pos = 0;
+        let result = deserialize_tree(&data, &mut pos);
+        assert!(result.is_err());
+        let msg = format!("{}", result.expect_err("should be error"));
+        assert!(
+            msg.contains("truncated parent annotation flag"),
+            "error should mention truncated annotation flag: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_truncated_parent_annotation_hash() {
+        // TAG_PARENT + has_ann=0x01 but only 10 bytes of hash (needs 32)
+        let mut data = vec![TAG_PARENT, 0x01];
+        data.extend_from_slice(&[0u8; 10]);
+        let mut pos = 0;
+        let result = deserialize_tree(&data, &mut pos);
+        assert!(result.is_err());
+        let msg = format!("{}", result.expect_err("should be error"));
+        assert!(
+            msg.contains("truncated parent annotation"),
+            "error should mention truncated annotation: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_invalid_annotation_field_element() {
+        // TAG_PARENT + has_ann=0x01 + 32 bytes of 0xFF (invalid) + left=Nil + right=Nil
+        let mut data = vec![TAG_PARENT, 0x01];
+        data.extend_from_slice(&[0xFF; 32]);
+        data.push(TAG_NIL);
+        data.push(TAG_NIL);
+        let mut pos = 0;
+        let result = deserialize_tree(&data, &mut pos);
+        assert!(result.is_err());
+        let msg = format!("{}", result.expect_err("should be error"));
+        assert!(
+            msg.contains("invalid Pallas field element in annotation"),
+            "error should mention invalid annotation: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_invalid_annotation_flag() {
+        // TAG_PARENT + has_ann=0x42 (neither 0x00 nor 0x01)
+        let data = [TAG_PARENT, 0x42];
+        let mut pos = 0;
+        let result = deserialize_tree(&data, &mut pos);
+        assert!(result.is_err());
+        let msg = format!("{}", result.expect_err("should be error"));
+        assert!(
+            msg.contains("invalid parent annotation flag: 0x42"),
+            "error should mention invalid flag: {msg}"
+        );
+    }
 }

--- a/grovedb-commitment-tree/src/client/sqlite_store_tests.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_store_tests.rs
@@ -444,4 +444,55 @@ mod tests {
             .expect("for_each");
         assert_eq!(ids, vec![5, 4, 3]);
     }
+
+    #[test]
+    fn test_with_checkpoints() {
+        let mut store = test_store();
+        for i in 1..=5u32 {
+            store
+                .add_checkpoint(i, Checkpoint::at_position(Position::from(i as u64)))
+                .expect("add");
+        }
+
+        let mut ids = Vec::new();
+        store
+            .with_checkpoints(2, |id, _| {
+                ids.push(*id);
+                Ok(())
+            })
+            .expect("with_checkpoints");
+        assert_eq!(ids, vec![5, 4]);
+    }
+
+    #[test]
+    fn test_update_checkpoint_with_replacement() {
+        let mut store = test_store();
+        let cp = Checkpoint::at_position(Position::from(10));
+        store.add_checkpoint(1, cp).expect("add");
+
+        // Replace checkpoint entirely with new state + marks
+        let mut marks = BTreeSet::new();
+        marks.insert(Position::from(42));
+        marks.insert(Position::from(99));
+        let updated = store
+            .update_checkpoint_with(&1, |cp| {
+                *cp = Checkpoint::from_parts(
+                    TreeState::AtPosition(Position::from(20)),
+                    marks.clone(),
+                );
+                Ok(())
+            })
+            .expect("update with replacement");
+        assert!(updated);
+
+        // Verify the replacement was persisted
+        let loaded = store.get_checkpoint(&1).expect("get").expect("exists");
+        assert_eq!(
+            loaded.tree_state(),
+            TreeState::AtPosition(Position::from(20))
+        );
+        assert_eq!(loaded.marks_removed().len(), 2);
+        assert!(loaded.marks_removed().contains(&Position::from(42)));
+        assert!(loaded.marks_removed().contains(&Position::from(99)));
+    }
 }

--- a/grovedb-commitment-tree/src/client/tests.rs
+++ b/grovedb-commitment-tree/src/client/tests.rs
@@ -199,6 +199,19 @@ fn test_unique_checkpoint_ids_allow_witness_for_all_notes() {
     }
 }
 
+#[test]
+fn test_append_invalid_field_element() {
+    let mut tree = ClientMemoryCommitmentTree::new(10);
+    // All 0xFF bytes is not a valid Pallas field element
+    let result = tree.append([0xFF; 32], Retention::Marked);
+    assert!(result.is_err(), "should reject invalid field element");
+    let msg = format!("{}", result.expect_err("should be error"));
+    assert!(
+        msg.contains("invalid Pallas field element"),
+        "error should mention field element: {msg}"
+    );
+}
+
 /// Verifies that witness anchors from both syncs match when using
 /// unique checkpoint IDs, and that the anchor at checkpoint depth 1
 /// differs from depth 0 (since the tree grew between checkpoints).


### PR DESCRIPTION
## Summary
- Add 13 tests covering previously-uncovered code paths in the `grovedb-commitment-tree` crate
- 9 tests for `tree_serialization.rs` deserialization error branches (empty data, unknown tag, truncated leaf/parent, invalid Pallas field elements, invalid retention flags, invalid annotation flag)
- 2 tests for `sqlite_store` ShardStore trait methods (`with_checkpoints`, `update_checkpoint_with` marks insertion loop)
- 2 tests for client tree `append()` invalid field element error paths (memory and persistent variants)

## Test plan
- [x] `cargo test -p grovedb-commitment-tree --all-features` — all 100 tests pass
- [ ] CI coverage report shows improvement for `grovedb-commitment-tree/src/client/sqlite_store/tree_serialization.rs` and `sqlite_store/mod.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for invalid Pallas field element validation during append operations
  * Added comprehensive error-handling tests for tree deserialization across multiple edge cases and error scenarios
  * Added tests for checkpoint management including iteration, updates, and replacement with state verification
  * Added verification tests for witness anchor consistency across multiple synchronization cycles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->