### PR TITLE
test(grovedb-element): improve code coverage for element Display, proof_node_type, and display_path

### DIFF
--- a/grovedb-element/src/element_type.rs
+++ b/grovedb-element/src/element_type.rs
@@ -466,6 +466,31 @@ mod tests {
     }
 
     #[test]
+    fn test_proof_node_type_provable_count_sum_tree() {
+        use super::ProofNodeType;
+
+        let pcst = Some(ElementType::ProvableCountSumTree);
+
+        // Items use KvCount in ProvableCountSumTree (same as ProvableCountTree)
+        assert_eq!(
+            ElementType::Item.proof_node_type(pcst),
+            ProofNodeType::KvCount
+        );
+
+        // References use KvRefValueHashCount
+        assert_eq!(
+            ElementType::Reference.proof_node_type(pcst),
+            ProofNodeType::KvRefValueHashCount
+        );
+
+        // Subtrees use KvValueHashFeatureType
+        assert_eq!(
+            ElementType::Tree.proof_node_type(pcst),
+            ProofNodeType::KvValueHashFeatureType
+        );
+    }
+
+    #[test]
     fn test_from_serialized_value() {
         // Test with valid first bytes
         assert_eq!(

--- a/grovedb-element/tests/element_display_and_serialization.rs
+++ b/grovedb-element/tests/element_display_and_serialization.rs
@@ -183,3 +183,69 @@ fn serialize_deserialize_round_trip_all_element_types_and_errors() {
         ElementError::CorruptedData(msg) if msg.contains("unable to deserialize element")
     ));
 }
+
+/// Covers the `None` flags branch in Display for all 15 variants,
+/// the `None` max_hop branch for Reference, and the `None` root_key
+/// branch for tree-type variants.
+#[test]
+fn element_display_without_flags_covers_none_branches() {
+    use grovedb_element::reference_path::ReferencePathType;
+
+    let values: Vec<(Element, &str)> = vec![
+        // Uses non-allowed bytes to cover hex_to_ascii's else (hex) branch
+        (Element::Item(vec![0x00, 0x01], None), "Item(0x0001)"),
+        (
+            Element::Reference(
+                ReferencePathType::SiblingReference(b"k".to_vec()),
+                None,
+                None,
+            ),
+            "Reference(SiblingReference(6b), max_hop: None)",
+        ),
+        (Element::Tree(None, None), "Tree(None)"),
+        (Element::SumItem(-1, None), "SumItem(-1)"),
+        (Element::SumTree(None, 2, None), "SumTree(None, 2)"),
+        (Element::BigSumTree(None, 3, None), "BigSumTree(None, 3)"),
+        (Element::CountTree(None, 4, None), "CountTree(None, 4)"),
+        (
+            Element::CountSumTree(None, 5, 6, None),
+            "CountSumTree(None, 5, 6)",
+        ),
+        (
+            Element::ProvableCountTree(None, 7, None),
+            "ProvableCountTree(None, 7)",
+        ),
+        (
+            Element::ItemWithSumItem(b"xyz".to_vec(), 8, None),
+            "ItemWithSumItem(xyz , 8)",
+        ),
+        (
+            Element::ProvableCountSumTree(None, 9, 10, None),
+            "ProvableCountSumTree(None, 9, 10)",
+        ),
+        (
+            Element::CommitmentTree(11, 12, None),
+            "CommitmentTree(count: 11, chunk_power: 12)",
+        ),
+        (Element::MmrTree(13, None), "MmrTree(mmr_size: 13)"),
+        (
+            Element::BulkAppendTree(14, 15, None),
+            "BulkAppendTree(total_count: 14, chunk_power: 15)",
+        ),
+        (
+            Element::DenseAppendOnlyFixedSizeTree(17, 18, None),
+            "DenseAppendOnlyFixedSizeTree(count: 17, height: 18)",
+        ),
+    ];
+
+    for (element, expected_display) in values {
+        let display = format!("{element}");
+        assert_eq!(display, expected_display);
+        assert!(
+            !display.contains("flags:"),
+            "Display for {:?} should not contain 'flags:' when flags is None, got: {}",
+            element.type_str(),
+            display
+        );
+    }
+}

--- a/grovedb-element/tests/reference_path_edge_cases.rs
+++ b/grovedb-element/tests/reference_path_edge_cases.rs
@@ -212,6 +212,14 @@ fn serialized_size_display_and_util_helpers_are_covered() {
         ),
         "AbsolutePathReference(616263(abc))"
     );
+    // Valid UTF-8 with non-alphanumeric chars: display_path shows hex only (no parenthetical)
+    assert_eq!(
+        format!(
+            "{}",
+            ReferencePathType::AbsolutePathReference(vec![b"a b".to_vec()])
+        ),
+        "AbsolutePathReference(612062)"
+    );
     assert_eq!(
         format!(
             "{}",


### PR DESCRIPTION
## Summary
- Cover `None` flags/max_hop/root_key branches in Element Display for all 15 variants
- Cover `hex_to_ascii` non-allowed-chars else branch
- Cover `proof_node_type` with `ProvableCountSumTree` parent (previously only `ProvableCountTree` was tested)
- Cover `display_path` valid-UTF-8-but-non-alphanumeric branch

## Test plan
- [x] All 46 grovedb-element tests pass locally
- [x] Each new test targets a genuinely uncovered code path (no redundant tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test coverage for proof node type mappings across different element types.
  * Enhanced element display formatting tests, including edge cases for paths with non-alphanumeric characters.
  * Extended reference path formatting tests to verify consistent display representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->