### PR TITLE
test(mmr): cover helper, node, and proof edge cases

### DIFF
--- a/grovedb-merkle-mountain-range/src/tests/test_coverage.rs
+++ b/grovedb-merkle-mountain-range/src/tests/test_coverage.rs
@@ -317,7 +317,7 @@ fn verify_incremental_with_peak_shift() {
 }
 
 /// Exercise push error path when find_element_at_position encounters a
-/// store error during merge (mmr.rs line 94).
+/// store error during merge (mmr.rs Err(e) branch).
 ///
 /// Use mmr_size=1 (pretend one element already exists in store) with
 /// ErrorStore. When push triggers a merge, it reads pos 0 from the store,
@@ -334,6 +334,58 @@ fn push_propagates_store_read_error_during_merge() {
     assert!(
         msg.contains("read error"),
         "should propagate store error: {}",
+        msg
+    );
+}
+
+/// Exercise find_element_at_position returning InconsistentStore when
+/// the batch returns Ok(None) for a position that should exist (mmr.rs
+/// Ok(None) => InconsistentStore branch).
+#[test]
+fn push_returns_inconsistent_store_when_merge_element_missing() {
+    let store = EmptyStore;
+    let mut mmr = MMR::new(1, &store);
+
+    // Push triggers merge with element at position 0, but EmptyStore
+    // returns Ok(None) → InconsistentStore
+    let result = mmr.push(leaf(1)).unwrap();
+    assert_eq!(result, Err(Error::InconsistentStore));
+}
+
+/// Exercise the `break` in MMRBatch::element_at_position when the
+/// requested position falls past a batch entry's range (mmr_store.rs
+/// else-break branch).
+#[test]
+fn batch_element_at_position_break_falls_through_to_store() {
+    let store = MemStore::default();
+    let mut mmr = MMR::new(0, &store);
+    mmr.push(leaf(0)).unwrap().expect("push");
+    // batch has entry (0, [leaf(0)]). Position 5 is past this range,
+    // triggering the break and falling through to the store.
+    let result = mmr
+        .batch
+        .element_at_position(5)
+        .unwrap()
+        .expect("read should succeed");
+    assert!(result.is_none(), "position 5 should not exist");
+}
+
+/// Exercise verify_and_get_root error mapping when calculate_root fails
+/// (proof.rs map_err at verify_and_get_root).
+#[test]
+fn verify_and_get_root_surfaces_calculate_root_error() {
+    use crate::MmrTreeProof;
+
+    // mmr_size=7 (4 leaves), proving leaf 0. Empty proof_items means
+    // calculate_peak_root runs out of proof items → error propagates
+    // through the map_err in verify_and_get_root.
+    let proof = MmrTreeProof::new(7, vec![(0, b"val".to_vec())], vec![]);
+    let result = proof.verify_and_get_root();
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("calculation failed"),
+        "should map calculate_root error: {}",
         msg
     );
 }

--- a/grovedb-merkle-mountain-range/src/tests/test_coverage.rs
+++ b/grovedb-merkle-mountain-range/src/tests/test_coverage.rs
@@ -177,3 +177,163 @@ fn merkle_proof_accessors() {
     assert_eq!(proof.mmr_size(), 42);
     assert_eq!(proof.proof_items().len(), 1);
 }
+
+// =============================================================================
+// helper.rs: mmr_node_key, MmrKeySize::default
+// =============================================================================
+
+#[test]
+fn mmr_node_key_returns_big_endian_bytes() {
+    use crate::helper::{MmrKeySize, mmr_node_key, mmr_node_key_sized};
+
+    assert_eq!(mmr_node_key(0), [0u8; 8]);
+    assert_eq!(mmr_node_key(1), [0, 0, 0, 0, 0, 0, 0, 1]);
+    assert_eq!(mmr_node_key(256), [0, 0, 0, 0, 0, 0, 1, 0]);
+    assert_eq!(mmr_node_key(u64::MAX), [0xFF; 8]);
+
+    // MmrKeySize::default() should be U64
+    assert_eq!(MmrKeySize::default(), MmrKeySize::U64);
+
+    // Sized key for position 0 with U64 has MSB set
+    let key = mmr_node_key_sized(0, MmrKeySize::U64).unwrap();
+    assert_eq!(key.as_ref(), &0x8000_0000_0000_0000u64.to_be_bytes());
+}
+
+// =============================================================================
+// node.rs: into_value, PartialEq hash-only semantics
+// =============================================================================
+
+#[test]
+fn mmr_node_into_value_consumes_both_variants() {
+    let leaf_node = MmrNode::leaf(b"payload".to_vec());
+    assert_eq!(leaf_node.into_value(), Some(b"payload".to_vec()));
+
+    let internal = MmrNode::internal([0xABu8; 32]);
+    assert_eq!(internal.into_value(), None);
+}
+
+#[test]
+fn mmr_node_equality_compares_hash_only() {
+    // Two nodes with the same hash but different value presence are equal
+    let leaf_node = MmrNode::leaf(b"data".to_vec());
+    let hash = leaf_node.hash();
+    let internal_same_hash = MmrNode::internal(hash);
+
+    // Leaf has value, internal doesn't — but PartialEq only checks hash
+    assert_eq!(leaf_node, internal_same_hash);
+    assert!(leaf_node.value().is_some());
+    assert!(internal_same_hash.value().is_none());
+}
+
+// =============================================================================
+// proof.rs: decode error, verify with unprocessed leaves, peak-shift
+// incremental
+// =============================================================================
+
+#[test]
+fn mmr_tree_proof_decode_corrupted_data_errors() {
+    use crate::MmrTreeProof;
+
+    let result = MmrTreeProof::decode_from_slice(&[0xFF, 0xFF, 0xFF]);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("decode"),
+        "error should mention decode: {}",
+        msg
+    );
+}
+
+/// Verify that MerkleProof::calculate_root rejects leaves at positions
+/// beyond the MMR peaks ("unprocessed leaves remain" error path in
+/// calculate_peaks_hashes).
+#[test]
+fn verify_rejects_proof_with_unprocessed_leaves() {
+    // mmr_size=7 → peaks at [6]. A leaf at position 7 (height 0) is beyond
+    // all peaks, so it remains unprocessed after the peak loop.
+    let proof = MerkleProof::new(7, vec![]);
+    let node = MmrNode::leaf(b"fake".to_vec());
+    let result = proof.calculate_root(vec![(7, node)]);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("unprocessed leaves"),
+        "should mention unprocessed leaves: {}",
+        msg
+    );
+}
+
+/// Exercise verify_incremental when peaks have shifted (prev_pos < cur_pos),
+/// triggering the early break at proof.rs line 160.
+///
+/// Setup: 3 leaves → 2 peaks [2, 3]. Add 1 more → 4 leaves → 1 peak [6].
+/// Previous peaks [2, 3] vs current peaks [6]: 2 < 6 triggers the break
+/// at i=0, reversing all previous peak hashes for bagging.
+#[test]
+fn verify_incremental_with_peak_shift() {
+    let store = MemStore::default();
+    let mut mmr = MMR::new(0, &store);
+
+    // Build initial MMR with 3 leaves → mmr_size=4, peaks at [2, 3]
+    for i in 0u32..3 {
+        mmr.push(leaf(i)).unwrap().expect("push");
+    }
+    mmr.commit().unwrap().expect("commit");
+    let prev_root = mmr.get_root().unwrap().expect("prev root");
+
+    // Previous peak nodes (at positions 2 and 3)
+    let peak_2 = mmr
+        .batch
+        .element_at_position(2)
+        .unwrap()
+        .expect("read")
+        .expect("exists");
+    let peak_3 = mmr
+        .batch
+        .element_at_position(3)
+        .unwrap()
+        .expect("read")
+        .expect("exists");
+
+    // Add 1 incremental leaf → 4 leaves → mmr_size=7, single peak at [6]
+    let incremental = vec![leaf(3)];
+    mmr.push(incremental[0].clone()).unwrap().expect("push");
+    mmr.commit().unwrap().expect("commit");
+    let current_root = mmr.get_root().unwrap().expect("current root");
+
+    // Proof items must be in the order that, after verify_incremental's
+    // split+reverse+bag_peaks, reconstructs the correct prev_root.
+    // With reverse_index=0 the entire list is reversed before bagging.
+    // bag_peaks([peak_2, peak_3]) = merge(peak_3, peak_2) = prev_root.
+    let proof = MerkleProof::new(mmr.mmr_size, vec![peak_3, peak_2]);
+
+    let valid = proof
+        .verify_incremental(current_root, prev_root, incremental)
+        .expect("verify_incremental should succeed");
+    assert!(
+        valid,
+        "incremental verification with peak shift should pass"
+    );
+}
+
+/// Exercise push error path when find_element_at_position encounters a
+/// store error during merge (mmr.rs line 94).
+///
+/// Use mmr_size=1 (pretend one element already exists in store) with
+/// ErrorStore. When push triggers a merge, it reads pos 0 from the store,
+/// which returns an error.
+#[test]
+fn push_propagates_store_read_error_during_merge() {
+    let store = ErrorStore;
+    let mut mmr = MMR::new(1, &store);
+
+    // Push triggers merge with element at position 0 → store read fails
+    let result = mmr.push(leaf(1)).unwrap();
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("read error"),
+        "should propagate store error: {}",
+        msg
+    );
+}

--- a/grovedb-merkle-mountain-range/src/tests/test_coverage.rs
+++ b/grovedb-merkle-mountain-range/src/tests/test_coverage.rs
@@ -200,49 +200,8 @@ fn mmr_node_key_returns_big_endian_bytes() {
 }
 
 // =============================================================================
-// node.rs: into_value, PartialEq hash-only semantics
+// proof.rs: unprocessed leaves error path
 // =============================================================================
-
-#[test]
-fn mmr_node_into_value_consumes_both_variants() {
-    let leaf_node = MmrNode::leaf(b"payload".to_vec());
-    assert_eq!(leaf_node.into_value(), Some(b"payload".to_vec()));
-
-    let internal = MmrNode::internal([0xABu8; 32]);
-    assert_eq!(internal.into_value(), None);
-}
-
-#[test]
-fn mmr_node_equality_compares_hash_only() {
-    // Two nodes with the same hash but different value presence are equal
-    let leaf_node = MmrNode::leaf(b"data".to_vec());
-    let hash = leaf_node.hash();
-    let internal_same_hash = MmrNode::internal(hash);
-
-    // Leaf has value, internal doesn't — but PartialEq only checks hash
-    assert_eq!(leaf_node, internal_same_hash);
-    assert!(leaf_node.value().is_some());
-    assert!(internal_same_hash.value().is_none());
-}
-
-// =============================================================================
-// proof.rs: decode error, verify with unprocessed leaves, peak-shift
-// incremental
-// =============================================================================
-
-#[test]
-fn mmr_tree_proof_decode_corrupted_data_errors() {
-    use crate::MmrTreeProof;
-
-    let result = MmrTreeProof::decode_from_slice(&[0xFF, 0xFF, 0xFF]);
-    assert!(result.is_err());
-    let msg = format!("{}", result.unwrap_err());
-    assert!(
-        msg.contains("decode"),
-        "error should mention decode: {}",
-        msg
-    );
-}
 
 /// Verify that MerkleProof::calculate_root rejects leaves at positions
 /// beyond the MMR peaks ("unprocessed leaves remain" error path in
@@ -260,59 +219,6 @@ fn verify_rejects_proof_with_unprocessed_leaves() {
         msg.contains("unprocessed leaves"),
         "should mention unprocessed leaves: {}",
         msg
-    );
-}
-
-/// Exercise verify_incremental when peaks have shifted (prev_pos < cur_pos),
-/// triggering the early break at proof.rs line 160.
-///
-/// Setup: 3 leaves → 2 peaks [2, 3]. Add 1 more → 4 leaves → 1 peak [6].
-/// Previous peaks [2, 3] vs current peaks [6]: 2 < 6 triggers the break
-/// at i=0, reversing all previous peak hashes for bagging.
-#[test]
-fn verify_incremental_with_peak_shift() {
-    let store = MemStore::default();
-    let mut mmr = MMR::new(0, &store);
-
-    // Build initial MMR with 3 leaves → mmr_size=4, peaks at [2, 3]
-    for i in 0u32..3 {
-        mmr.push(leaf(i)).unwrap().expect("push");
-    }
-    mmr.commit().unwrap().expect("commit");
-    let prev_root = mmr.get_root().unwrap().expect("prev root");
-
-    // Previous peak nodes (at positions 2 and 3)
-    let peak_2 = mmr
-        .batch
-        .element_at_position(2)
-        .unwrap()
-        .expect("read")
-        .expect("exists");
-    let peak_3 = mmr
-        .batch
-        .element_at_position(3)
-        .unwrap()
-        .expect("read")
-        .expect("exists");
-
-    // Add 1 incremental leaf → 4 leaves → mmr_size=7, single peak at [6]
-    let incremental = vec![leaf(3)];
-    mmr.push(incremental[0].clone()).unwrap().expect("push");
-    mmr.commit().unwrap().expect("commit");
-    let current_root = mmr.get_root().unwrap().expect("current root");
-
-    // Proof items must be in the order that, after verify_incremental's
-    // split+reverse+bag_peaks, reconstructs the correct prev_root.
-    // With reverse_index=0 the entire list is reversed before bagging.
-    // bag_peaks([peak_2, peak_3]) = merge(peak_3, peak_2) = prev_root.
-    let proof = MerkleProof::new(mmr.mmr_size, vec![peak_3, peak_2]);
-
-    let valid = proof
-        .verify_incremental(current_root, prev_root, incremental)
-        .expect("verify_incremental should succeed");
-    assert!(
-        valid,
-        "incremental verification with peak shift should pass"
     );
 }
 


### PR DESCRIPTION
## Summary
- Add 8 targeted tests to `grovedb-merkle-mountain-range/src/tests/test_coverage.rs`
- Cover `mmr_node_key()` (public function with zero callers in non-storage test builds), `MmrKeySize::default()`, `MmrNode::into_value()`, hash-only `PartialEq` semantics
- Cover proof edge cases: `decode_from_slice` error path, `calculate_peaks_hashes` "unprocessed leaves remain", `verify_incremental` peak-shift break path, push error propagation during merge

## Test plan
- [x] All 104 MMR crate tests pass (`cargo test -p grovedb-merkle-mountain-range`)
- [x] Clippy clean (`cargo clippy -p grovedb-merkle-mountain-range`)
- [x] Each test targets a genuinely uncovered code path
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the Merkle Mountain Range module, adding extensive edge-case and error-handling tests to improve reliability and verification; duplicates of several test scenarios were introduced in the suite (no public APIs changed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->