### PR TITLE
fix(merk): add runtime key length validation (RUST-044)

### DIFF
--- a/merk/src/tree/kv.rs
+++ b/merk/src/tree/kv.rs
@@ -451,7 +451,7 @@ impl KV {
 
     #[inline]
     fn encoding_cost(&self) -> usize {
-        debug_assert!(self.key().len() < 256, "Key length must be less than 256");
+        assert!(self.key().len() < 256, "Key length must be less than 256");
         HASH_LENGTH_X2 + self.value.len() + self.feature_type.encoding_cost()
     }
 }
@@ -470,7 +470,12 @@ impl Encode for KV {
 
     #[inline]
     fn encoding_length(&self) -> Result<usize> {
-        debug_assert!(self.key().len() < 256, "Key length must be less than 256");
+        if self.key().len() >= 256 {
+            return Err(ed::Error::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Key length must be less than 256",
+            )));
+        }
         Ok(HASH_LENGTH + HASH_LENGTH + self.value.len() + self.feature_type.encoding_length()?)
     }
 }

--- a/merk/src/tree/link.rs
+++ b/merk/src/tree/link.rs
@@ -843,6 +843,54 @@ mod test {
         link.encode_into(&mut bytes).unwrap();
     }
 
+    /// Demonstrates RUST-044: key length truncation via `key.len() as u8`.
+    ///
+    /// In release builds, `debug_assert!` is stripped, so a 300-byte key
+    /// gets its length silently truncated to `300 % 256 = 44`. This test
+    /// manually constructs the bytes that `encode_into` would produce in
+    /// release mode and shows that decode yields a corrupted key.
+    #[test]
+    fn attack_key_length_truncation_corrupts_decode() {
+        let original_key = vec![0xAB; 300]; // 300-byte key
+
+        // Simulate what encode_into does in release mode (debug_assert stripped):
+        //   out.write_all(&[key.len() as u8])?;  // 300 as u8 = 44
+        //   out.write_all(key)?;                  // all 300 bytes
+        //   out.write_all(hash)?;                 // 32 bytes
+        //   out.write_all(&[left_h, right_h])?;   // 2 bytes
+        //   out.write_all(&[0])?;                 // aggregate_data tag
+        let truncated_len: u8 = original_key.len() as u8; // 44
+        assert_eq!(truncated_len, 44, "300 as u8 should truncate to 44");
+
+        let hash = [0x55u8; 32];
+        let mut encoded = Vec::new();
+        encoded.push(truncated_len); // truncated length byte
+        encoded.extend_from_slice(&original_key); // full 300-byte key
+        encoded.extend_from_slice(&hash);
+        encoded.extend_from_slice(&[10, 11]); // child_heights
+        encoded.push(0); // NoAggregateData
+
+        // Decode: reads 44 bytes for key, then interprets bytes 44..76 as hash,
+        // bytes 76..78 as child_heights, byte 78 as aggregate_data tag.
+        // Everything is shifted and wrong.
+        let decoded = Link::decode(encoded.as_slice());
+
+        match decoded {
+            Ok(link) => {
+                // The decoded key is only the first 44 bytes, not the original 300
+                assert_eq!(link.key().len(), 44);
+                assert_ne!(link.key().len(), original_key.len());
+                // The hash is also corrupted (read from key bytes, not from actual hash)
+                assert_ne!(link.hash(), &hash);
+            }
+            Err(_) => {
+                // Alternatively the decode may fail outright due to misaligned
+                // fields (e.g. invalid aggregate_data tag from shifted bytes).
+                // Either way, data corruption is demonstrated.
+            }
+        }
+    }
+
     #[test]
     fn decode_link() {
         let bytes = vec![

--- a/merk/src/tree/link.rs
+++ b/merk/src/tree/link.rs
@@ -271,7 +271,12 @@ impl Link {
     /// The encoding cost is always 8 bytes for the sum instead of a varint
     #[inline]
     pub fn encoding_cost(&self) -> Result<usize> {
-        debug_assert!(self.key().len() < 256, "Key length must be less than 256");
+        if self.key().len() >= 256 {
+            return Err(ed::Error::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Key length must be less than 256",
+            )));
+        }
 
         Ok(match self {
             Link::Reference {
@@ -361,7 +366,12 @@ impl Encode for Link {
             Link::Modified { .. } => panic!("No encoding for Link::Modified"),
         };
 
-        debug_assert!(key.len() < 256, "Key length must be less than 256");
+        if key.len() >= 256 {
+            return Err(ed::Error::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Key length must be less than 256",
+            )));
+        }
 
         out.write_all(&[key.len() as u8])?;
         out.write_all(key)?;
@@ -407,7 +417,12 @@ impl Encode for Link {
 
     #[inline]
     fn encoding_length(&self) -> Result<usize> {
-        debug_assert!(self.key().len() < 256, "Key length must be less than 256");
+        if self.key().len() >= 256 {
+            return Err(ed::Error::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Key length must be less than 256",
+            )));
+        }
 
         Ok(match self {
             Link::Reference {
@@ -831,8 +846,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn encode_link_long_key() {
+    fn encode_link_long_key_returns_error() {
         let link = Link::Reference {
             key: vec![123; 300],
             aggregate_data: AggregateData::NoAggregateData,
@@ -840,7 +854,14 @@ mod test {
             hash: [55; 32],
         };
         let mut bytes = vec![];
-        link.encode_into(&mut bytes).unwrap();
+        let result = link.encode_into(&mut bytes);
+        assert!(result.is_err(), "Should return error for key >= 256 bytes");
+
+        let result = link.encoding_length();
+        assert!(result.is_err(), "encoding_length should also return error");
+
+        let result = link.encoding_cost();
+        assert!(result.is_err(), "encoding_cost should also return error");
     }
 
     /// Demonstrates RUST-044: key length truncation via `key.len() as u8`.


### PR DESCRIPTION
## Summary
- Replace `debug_assert!` with runtime errors for key length >= 256 bytes in Link and KV encoding methods
- In release builds, `debug_assert!` is stripped, so `key.len() as u8` silently truncates keys >= 256 bytes, causing data corruption on encode and misaligned fields on decode
- Added attack test demonstrating the corruption: a 300-byte key gets truncated to 44 bytes (300 % 256)

## Changes
- `link.rs`: `encoding_cost()`, `encode_into()`, `encoding_length()` — return `ed::Error::IOError` instead of `debug_assert!`
- `kv.rs`: `encoding_cost()` — upgraded to `assert!`; `encoding_length()` — return `ed::Error::IOError`
- Updated existing `encode_link_long_key` test from `#[should_panic]` to verify error return

## Test plan
- [x] `attack_key_length_truncation_corrupts_decode` — demonstrates the data corruption
- [x] `encode_link_long_key_returns_error` — verifies all three methods return errors
- [x] Full merk test suite passes (323 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for key size limits. The system now returns proper error messages for oversized keys instead of crashing, providing better reliability and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->