### PR TITLE
ci: replace deprecated actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -15,10 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Login to crates.io
         run: cargo login ${{ secrets.CARGO_GROVE_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable` in `release-crates.yml`
- The old action is unmaintained and uses deprecated Node.js 12
- Matches the pattern already used by all other workflows

## Test plan
- [x] Workflow syntax is valid YAML
- [ ] Verify next release workflow run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)