### PR TITLE
chore: upgrade rand to 0.10 with workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ members = [
     "grovedb-commitment-tree",
     "grovedb-query",
 ]
+
+[workspace.dependencies]
+rand = "0.10"

--- a/grovedb-commitment-tree/Cargo.toml
+++ b/grovedb-commitment-tree/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "2.0"
 [dev-dependencies]
 tempfile = "3"
 criterion = "0.4"
-rand = "0.8"
+rand = { workspace = true }
 
 [[bench]]
 name = "verification"

--- a/grovedb-merkle-mountain-range/Cargo.toml
+++ b/grovedb-merkle-mountain-range/Cargo.toml
@@ -26,7 +26,7 @@ grovedb-storage = { version = "4.0.0", path = "../storage", optional = true }
 [dev-dependencies]
 faster-hex = "0.10.0"
 criterion = "0.8.2"
-rand = "0.8.5"
+rand = { workspace = true }
 proptest = "1.10.0"
 lazy_static = "1.5.0"
 

--- a/grovedb-merkle-mountain-range/benches/helper_benchmark.rs
+++ b/grovedb-merkle-mountain-range/benches/helper_benchmark.rs
@@ -2,21 +2,21 @@
 extern crate criterion;
 use criterion::Criterion;
 use grovedb_merkle_mountain_range::{leaf_index_to_mmr_size, leaf_index_to_pos};
-use rand::{thread_rng, Rng};
+use rand::RngExt;
 
 fn bench(c: &mut Criterion) {
     c.bench_function("leaf_index_to_pos", |b| {
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         b.iter(|| {
-            let leaf_index = rng.gen_range(50_000_000_000..70_000_000_000);
+            let leaf_index = rng.random_range(50_000_000_000..70_000_000_000);
             leaf_index_to_pos(leaf_index);
         });
     });
 
     c.bench_function("leaf_index_to_mmr_size", |b| {
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         b.iter(|| {
-            let leaf_index = rng.gen_range(50_000_000_000..70_000_000_000);
+            let leaf_index = rng.random_range(50_000_000_000..70_000_000_000);
             leaf_index_to_mmr_size(leaf_index);
         });
     });

--- a/grovedb-merkle-mountain-range/benches/mmr_benchmark.rs
+++ b/grovedb-merkle-mountain-range/benches/mmr_benchmark.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 
 use criterion::{BenchmarkId, Criterion};
 use grovedb_merkle_mountain_range::{MMRStoreReadOps, MemStore, MmrNode, MMR};
-use rand::{seq::SliceRandom, thread_rng};
+use rand::seq::SliceRandom;
 
 /// Create an MmrNode leaf from an integer (for benchmarking).
 fn leaf_from_u32(i: u32) -> MmrNode {
@@ -35,7 +35,7 @@ fn bench(c: &mut Criterion) {
     c.bench_function("MMR gen proof", |b| {
         let (mmr_size, store, positions) = prepare_mmr(100_0000);
         let mmr = MMR::new(mmr_size, &store);
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         b.iter(|| {
             mmr.gen_proof(vec![*positions.choose(&mut rng).unwrap()])
                 .unwrap()
@@ -45,7 +45,7 @@ fn bench(c: &mut Criterion) {
     c.bench_function("MMR verify", |b| {
         let (mmr_size, store, positions) = prepare_mmr(100_0000);
         let mmr = MMR::new(mmr_size, &store);
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         let root = mmr.get_root().unwrap().expect("get root");
         let proofs: Vec<_> = (0..10_000)
             .map(|_| {

--- a/grovedb-merkle-mountain-range/src/tests/test_mmr.rs
+++ b/grovedb-merkle-mountain-range/src/tests/test_mmr.rs
@@ -1,6 +1,6 @@
 use faster_hex::hex_string;
 use proptest::prelude::*;
-use rand::{seq::SliceRandom, thread_rng, Rng};
+use rand::{seq::SliceRandom, RngExt};
 
 use crate::{
     helper::pos_height_in_tree, leaf_index_to_mmr_size, mem_store::MemStore, Error,
@@ -601,9 +601,9 @@ proptest! {
     #[test]
     fn test_random_mmr(count in 10u32..500u32) {
         let mut leaves: Vec<u32> = (0..count).collect();
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         leaves.shuffle(&mut rng);
-        let leaves_count = rng.gen_range(1..count - 1);
+        let leaves_count = rng.random_range(1..count - 1);
         leaves.truncate(leaves_count as usize);
         test_mmr(count, leaves);
     }

--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -55,8 +55,8 @@ grovedb-epoch-based-storage-flags = { version = "4.0.0", path = "../grovedb-epoc
 criterion = "0.5.1"
 hex = "0.4.3"
 pretty_assertions = "1.4.0"
-rand = "0.9.0"
-rand_distr = "0.5"
+rand = { workspace = true }
+rand_distr = "0.6"
 assert_matches = "1.5.0"
 tokio = { version = "1.48.0", features = ["rt-multi-thread", "time", "sync"] }
 

--- a/grovedb/src/tests/chunk_branch_proof_tests.rs
+++ b/grovedb/src/tests/chunk_branch_proof_tests.rs
@@ -7,7 +7,7 @@ mod tests {
         calculate_chunk_depths, calculate_max_tree_depth_from_count,
     };
     use grovedb_version::version::GroveVersion;
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rand::{rngs::StdRng, RngExt, SeedableRng};
 
     use crate::{
         query::PathTrunkChunkQuery,

--- a/grovedb/src/tests/test_compaction_sizes.rs
+++ b/grovedb/src/tests/test_compaction_sizes.rs
@@ -10,7 +10,7 @@ mod tests {
 
     use grovedb_element::Element;
     use grovedb_version::version::GroveVersion;
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rand::{rngs::StdRng, RngExt, SeedableRng};
     use tempfile::TempDir;
 
     use crate::{tests::common::EMPTY_PATH, GroveDb};

--- a/grovedb/src/tests/trunk_proof_tests.rs
+++ b/grovedb/src/tests/trunk_proof_tests.rs
@@ -7,7 +7,7 @@ mod tests {
         branch::depth::calculate_max_tree_depth_from_count, Decoder, Node, Op,
     };
     use grovedb_version::version::GroveVersion;
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rand::{rngs::StdRng, RngExt, SeedableRng};
 
     use crate::{
         operations::proof::GroveDBProof,

--- a/merk/Cargo.toml
+++ b/merk/Cargo.toml
@@ -31,7 +31,7 @@ indexmap = "2.2.6"
 integer-encoding = "4.1.0"
 thiserror = "2.0.17"
 serde = { version = "1.0.219", features = ["derive"], optional = true }
-rand = { version = "0.8.5", features = ["small_rng"], optional = true }
+rand = { workspace = true, optional = true }
 byteorder = { version = "1.5.0" }
 blake3 = { version = "1.8.1", optional = true }
 ed = { version = "0.2.2", optional = true }

--- a/merk/benches/merk.rs
+++ b/merk/benches/merk.rs
@@ -338,12 +338,12 @@ pub fn chunkproducer_rand_1m_1_rand(c: &mut Criterion) {
         apply_batch_default(&mut merk, &batch, grove_version);
     }
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let chunk_count = merk.chunks().unwrap().len();
 
     c.bench_function("chunkproducer_rand_1m_1_rand", |b| {
         b.iter_with_large_drop(|| {
-            let index = rng.gen_range(1..=chunk_count);
+            let index = rng.random_range(1..=chunk_count);
             let _chunk = merk
                 .chunks()
                 .unwrap()

--- a/merk/src/test_utils/mod.rs
+++ b/merk/src/test_utils/mod.rs
@@ -223,7 +223,7 @@ pub fn make_batch_rand(size: u64, seed: u64) -> Vec<BatchEntry<Vec<u8>>> {
     let mut rng: SmallRng = SeedableRng::seed_from_u64(seed);
     let mut batch = Vec::with_capacity(size.try_into().unwrap());
     for _ in 0..size {
-        let n = rng.r#gen::<u64>();
+        let n = rng.random::<u64>();
         batch.push(put_entry(n));
     }
     batch.sort_by(|a, b| a.0.cmp(&b.0));
@@ -235,7 +235,7 @@ pub fn make_del_batch_rand(size: u64, seed: u64) -> Vec<BatchEntry<Vec<u8>>> {
     let mut rng: SmallRng = SeedableRng::seed_from_u64(seed);
     let mut batch = Vec::with_capacity(size.try_into().unwrap());
     for _ in 0..size {
-        let n = rng.r#gen::<u64>();
+        let n = rng.random::<u64>();
         batch.push(del_entry(n));
     }
     batch.sort_by(|a, b| a.0.cmp(&b.0));

--- a/merk/src/tree/fuzz_tests.rs
+++ b/merk/src/tree/fuzz_tests.rs
@@ -19,10 +19,10 @@ type Map = BTreeMap<Vec<u8>, Vec<u8>>;
 #[cfg(feature = "minimal")]
 #[test]
 fn fuzz() {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     for _ in 0..ITERATIONS {
-        let seed = rng.r#gen::<u64>();
+        let seed = rng.random::<u64>();
         fuzz_case(seed);
     }
 }
@@ -42,7 +42,7 @@ fn fuzz_396148930387069749() {
 #[cfg(feature = "minimal")]
 fn fuzz_case(seed: u64, using_sum_trees: bool) {
     let mut rng: SmallRng = SeedableRng::seed_from_u64(seed);
-    let initial_size = (rng.r#gen::<u64>() % 10) + 1;
+    let initial_size = (rng.random::<u64>() % 10) + 1;
     let tree = make_tree_rand(
         initial_size,
         initial_size,
@@ -57,8 +57,8 @@ fn fuzz_case(seed: u64, using_sum_trees: bool) {
     println!("{:?}", maybe_tree.as_ref().unwrap());
 
     for j in 0..3 {
-        let batch_size = (rng.r#gen::<u64>() % 3) + 1;
-        let batch = make_batch(maybe_tree.as_ref(), batch_size, rng.r#gen::<u64>());
+        let batch_size = (rng.random::<u64>() % 3) + 1;
+        let batch = make_batch(maybe_tree.as_ref(), batch_size, rng.random::<u64>());
         println!("BATCH {}", j);
         println!("{:?}", batch);
         maybe_tree = apply_to_memonly(maybe_tree, &batch, using_sum_trees, grove_version);
@@ -80,7 +80,7 @@ fn make_batch(maybe_tree: Option<&TreeNode>, size: u64, seed: u64) -> Vec<BatchE
     let get_random_key = || {
         let tree = maybe_tree.as_ref().unwrap();
         let entries: Vec<_> = tree.iter().collect();
-        let index = rng.borrow_mut().r#gen::<u64>() as usize % entries.len();
+        let index = rng.borrow_mut().random::<u64>() as usize % entries.len();
         entries[index].0.clone()
     };
 
@@ -102,7 +102,7 @@ fn make_batch(maybe_tree: Option<&TreeNode>, size: u64, seed: u64) -> Vec<BatchE
 
     for _ in 0..size {
         let entry = if maybe_tree.is_some() {
-            let kind = rng.borrow_mut().r#gen::<u64>() % 3;
+            let kind = rng.borrow_mut().random::<u64>() % 3;
             if kind == 0 {
                 insert()
             } else if kind == 1 {


### PR DESCRIPTION
## Summary
- Centralize `rand` on **0.10** via `[workspace.dependencies]` in the root `Cargo.toml`
- Switch all 4 member crates (`grovedb`, `merk`, `grovedb-commitment-tree`, `grovedb-merkle-mountain-range`) to `rand = { workspace = true }`
- Drop the `small_rng` feature from merk's rand dep (default in 0.10)
- Bump `rand_distr` from 0.5 to 0.6 (required for rand 0.10 compat)
- Migrate API call sites: `thread_rng()` → `rand::rng()`, `.gen()` → `.random()`, `.gen_range()` → `.random_range()`, `Rng` → `RngExt`

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test -p grovedb -p grovedb-merk -p grovedb-commitment-tree -p grovedb-merkle-mountain-range` — all tests pass
- [x] `cargo clippy -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace-level dependency management for the rand crate across multiple packages.
  * Modernized internal random number generation API calls to align with updated dependency versions, affecting test suites and benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->