### PR TITLE
chore: enforce deny(missing_docs) across all crates

### DIFF
--- a/grovedb-commitment-tree/src/lib.rs
+++ b/grovedb-commitment-tree/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 //! Orchard-style commitment tree integration for GroveDB.
 //!
 //! This crate provides a lightweight frontier-based Sinsemilla Merkle tree

--- a/grovedb-dense-fixed-sized-merkle-tree/src/lib.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! Nodes without children use `[0; 32]` for both child hashes.
 
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 
 mod error;
 pub(crate) mod hash;

--- a/grovedb-merkle-mountain-range/src/lib.rs
+++ b/grovedb-merkle-mountain-range/src/lib.rs
@@ -18,7 +18,7 @@
 //! - [`MmrStore`] — GroveDB `StorageContext` adapter (requires `storage`
 //!   feature).
 
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 
 mod error;
 /// MMR helper functions for position arithmetic, storage keys, and cost

--- a/grovedb-query/src/lib.rs
+++ b/grovedb-query/src/lib.rs
@@ -4,7 +4,7 @@
 //! used throughout GroveDB for specifying which keys and ranges to include in
 //! proofs and query results.
 
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 
 /// Error types for query operations.
 pub mod error;

--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -21,6 +21,7 @@ use crate::{
     ElementFlags, Error,
 };
 
+/// Mapping from path to operations keyed by key info.
 #[cfg(feature = "minimal")]
 pub type OpsByPath = BTreeMap<KeyInfoPath, BTreeMap<KeyInfo, GroveOp>>;
 /// Level, path, key, op

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -13,6 +13,7 @@ mod multi_insert_cost_tests;
 
 #[cfg(test)]
 mod just_in_time_cost_tests;
+/// Just-in-time reference update handling for batch operations.
 pub mod just_in_time_reference_update;
 mod options;
 #[cfg(test)]
@@ -248,9 +249,13 @@ pub enum GroveOp {
     /// disk before write If it is false, the provided information is only
     /// used for average case and worse case costs
     RefreshReference {
+        /// The type of reference path to use.
         reference_path_type: ReferencePathType,
+        /// Maximum number of hops allowed when resolving the reference.
         max_reference_hop: MaxReferenceHop,
+        /// Optional element flags for the reference.
         flags: Option<ElementFlags>,
+        /// If true, skip verifying the element on disk before writing.
         trust_refresh_reference: bool,
     },
     /// Delete

--- a/grovedb/src/element/aggregate_sum_query/mod.rs
+++ b/grovedb/src/element/aggregate_sum_query/mod.rs
@@ -104,17 +104,29 @@ pub struct AggregateSumPathQueryPushArgs<'db, 'ctx, 'a>
 where
     'db: 'ctx,
 {
+    /// The RocksDB storage instance.
     pub storage: &'db RocksDbStorage,
+    /// The optional transaction context for transactional reads.
     pub transaction: TransactionArg<'db, 'ctx>,
+    /// The key of the current element being processed, if any.
     pub key: Option<&'a [u8]>,
+    /// The element to process and potentially add to results.
     pub element: Element,
+    /// The path segments leading to the current subtree.
     pub path: &'a [&'a [u8]],
+    /// Whether to iterate from left to right (ascending order).
     pub left_to_right: bool,
+    /// Options controlling query behavior (caching, error handling, etc.).
     pub query_options: AggregateSumQueryOptions,
+    /// Accumulator for the query result key-sum pairs.
     pub results: &'a mut Vec<KeySumValuePair>,
+    /// Remaining item count limit; decremented as results are added.
     pub limit: &'a mut Option<u16>,
+    /// Remaining sum budget; decremented by each element's sum value.
     pub sum_limit_left: &'a mut SumValue,
+    /// Counter of elements scanned so far.
     pub elements_scanned: &'a mut u16,
+    /// Hard cap on total elements that may be scanned.
     pub max_elements_scanned: u16,
 }
 
@@ -160,7 +172,9 @@ where
 }
 
 #[cfg(feature = "minimal")]
+/// Extension trait providing aggregate sum query operations on `Element`.
 pub trait ElementAggregateSumQueryExtensions {
+    /// Executes an aggregate sum path query and returns matching key-sum pairs.
     fn get_aggregate_sum_query(
         storage: &RocksDbStorage,
         aggregate_sum_path_query: &AggregateSumPathQuery,
@@ -168,6 +182,7 @@ pub trait ElementAggregateSumQueryExtensions {
         transaction: TransactionArg,
         grove_version: &GroveVersion,
     ) -> CostResult<AggregateSumQueryResult, Error>;
+    /// Executes an aggregate sum query using a custom element-processing function.
     fn get_aggregate_sum_query_apply_function(
         storage: &RocksDbStorage,
         path: &[&[u8]],
@@ -180,10 +195,12 @@ pub trait ElementAggregateSumQueryExtensions {
         ) -> CostResult<(), Error>,
         grove_version: &GroveVersion,
     ) -> CostResult<AggregateSumQueryResult, Error>;
+    /// Processes a single element and pushes it to the aggregate sum query results.
     fn aggregate_sum_path_query_push(
         args: AggregateSumPathQueryPushArgs,
         grove_version: &GroveVersion,
     ) -> CostResult<(), Error>;
+    /// Processes a single query item (key or range) within an aggregate sum query.
     fn aggregate_sum_query_item(
         storage: &RocksDbStorage,
         item: &QueryItem,
@@ -202,6 +219,7 @@ pub trait ElementAggregateSumQueryExtensions {
         max_elements_scanned: u16,
         grove_version: &GroveVersion,
     ) -> CostResult<(), Error>;
+    /// Extracts the sum value from an element and appends it to the results.
     fn basic_aggregate_sum_push(
         args: AggregateSumPathQueryPushArgs,
         grove_version: &GroveVersion,

--- a/grovedb/src/element/elements_iterator.rs
+++ b/grovedb/src/element/elements_iterator.rs
@@ -8,7 +8,9 @@ use grovedb_version::version::GroveVersion;
 
 use crate::{query_result_type::KeyElementPair, Error};
 
+/// Extension trait providing an iterator constructor on `Element`.
 pub trait ElementIteratorExtensions {
+    /// Creates a new `ElementsIterator` positioned at the first entry.
     fn iterator<I: RawIterator>(raw_iter: I) -> CostContext<ElementsIterator<I>>;
 }
 
@@ -21,15 +23,19 @@ impl ElementIteratorExtensions for Element {
     }
 }
 
+/// An iterator over stored elements, wrapping a low-level storage iterator.
 pub struct ElementsIterator<I: RawIterator> {
+    /// The underlying raw storage iterator.
     raw_iter: I,
 }
 
 impl<I: RawIterator> ElementsIterator<I> {
+    /// Creates a new `ElementsIterator` from the given raw iterator.
     pub fn new(raw_iter: I) -> Self {
         ElementsIterator { raw_iter }
     }
 
+    /// Advances the iterator and returns the next key-element pair, or `None` if exhausted.
     pub fn next_element(
         &mut self,
         grove_version: &GroveVersion,

--- a/grovedb/src/element/mod.rs
+++ b/grovedb/src/element/mod.rs
@@ -5,11 +5,14 @@
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub mod aggregate_sum_query;
 #[cfg(feature = "minimal")]
+/// Iterator utilities for traversing stored elements.
 pub mod elements_iterator;
 #[cfg(feature = "minimal")]
 mod path_query_push_args;
 #[cfg(feature = "minimal")]
+/// Query execution logic for elements, including path queries and sized queries.
 pub mod query;
+/// Options for controlling query behavior.
 pub mod query_options;
 
 pub use grovedb_element::*;

--- a/grovedb/src/element/query.rs
+++ b/grovedb/src/element/query.rs
@@ -27,7 +27,9 @@ use crate::{
     Error, PathQuery, SizedQuery, TransactionArg,
 };
 
+/// Extension trait providing query operations on `Element`.
 pub trait ElementQueryExtensions {
+    /// Executes a query against a subtree and returns matching elements.
     fn get_query(
         storage: &RocksDbStorage,
         merk_path: &[&[u8]],
@@ -37,6 +39,7 @@ pub trait ElementQueryExtensions {
         transaction: TransactionArg,
         grove_version: &GroveVersion,
     ) -> CostResult<QueryResultElements, Error>;
+    /// Executes a query and returns only the element values (no keys or paths).
     fn get_query_values(
         storage: &RocksDbStorage,
         merk_path: &[&[u8]],
@@ -45,6 +48,7 @@ pub trait ElementQueryExtensions {
         transaction: TransactionArg,
         grove_version: &GroveVersion,
     ) -> CostResult<Vec<Element>, Error>;
+    /// Executes a sized query using a custom element-processing function.
     fn get_query_apply_function(
         storage: &RocksDbStorage,
         path: &[&[u8]],
@@ -55,6 +59,7 @@ pub trait ElementQueryExtensions {
         add_element_function: fn(PathQueryPushArgs, &GroveVersion) -> CostResult<(), Error>,
         grove_version: &GroveVersion,
     ) -> CostResult<(QueryResultElements, u16), Error>;
+    /// Executes a path query, resolving the path and running the sized query within it.
     fn get_path_query(
         storage: &RocksDbStorage,
         path_query: &PathQuery,
@@ -106,6 +111,7 @@ pub trait ElementQueryExtensions {
         add_element_function: fn(PathQueryPushArgs, &GroveVersion) -> CostResult<(), Error>,
         grove_version: &GroveVersion,
     ) -> CostResult<(), Error>;
+    /// Default push function that adds an element to the query results.
     fn basic_push(args: PathQueryPushArgs, grove_version: &GroveVersion) -> Result<(), Error>;
 }
 

--- a/grovedb/src/element/query_options.rs
+++ b/grovedb/src/element/query_options.rs
@@ -1,8 +1,11 @@
 use std::fmt;
 
+/// Options controlling how an element query is executed.
 #[derive(Copy, Clone, Debug)]
 pub struct QueryOptions {
+    /// If true, allows fetching raw (unprocessed) elements.
     pub allow_get_raw: bool,
+    /// If true, allows reading from cache instead of forcing fresh disk reads.
     pub allow_cache: bool,
     /// Should we decrease the limit of elements found when we have no
     /// subelements in the subquery? This should generally be set to true,
@@ -11,6 +14,9 @@ pub struct QueryOptions {
     /// sub elements have no matches, hence the limit would not decrease and
     /// hence we would continue on the increasingly expensive query.
     pub decrease_limit_on_range_with_no_sub_elements: bool,
+    /// If true (default), returns an error when an intermediate path tree does
+    /// not exist. When false, a missing intermediate tree is silently treated
+    /// as empty.
     pub error_if_intermediate_path_tree_not_present: bool,
 }
 

--- a/grovedb/src/error.rs
+++ b/grovedb/src/error.rs
@@ -172,6 +172,7 @@ pub enum Error {
 }
 
 impl Error {
+    /// Appends additional context to the error message.
     pub fn add_context(&mut self, append: impl AsRef<str>) {
         match self {
             Self::MissingReference(s)
@@ -203,7 +204,9 @@ impl Error {
     }
 }
 
+/// Extension trait for adding context to GroveDB error results.
 pub trait GroveDbErrorExt {
+    /// Appends additional context to the error within this result.
     fn add_context(self, append: impl AsRef<str>) -> Self;
 }
 

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -126,6 +126,7 @@
 //! [Tutorial](https://www.grovedb.org/tutorials.html)
 
 // Pre-existing patterns throughout the crate; fix incrementally.
+#![deny(missing_docs)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::result_large_err)]
@@ -156,6 +157,7 @@ pub mod query_result_type;
 #[allow(dead_code)] // WIP module, will be used in future batch rework
 pub mod reference_path;
 #[cfg(feature = "minimal")]
+/// State replication and synchronization support.
 pub mod replication;
 #[cfg(all(test, feature = "minimal"))]
 mod tests;

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -305,8 +305,8 @@ impl GroveDb {
         Ok(GroveDb { db })
     }
 
+    /// Starts a visualizer server for the GroveDB instance.
     #[cfg(feature = "grovedbg")]
-    // Start visualizer server for the GroveDB instance
     pub fn start_visualizer<A>(self: &Arc<Self>, addr: A)
     where
         A: ToSocketAddrs + Send + 'static,

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "minimal")]
 mod generate;
+/// Utility functions for proof display and conversion.
 pub mod util;
 mod verify;
 
@@ -26,6 +27,7 @@ use crate::{
     Error, GroveDb, PathQuery,
 };
 
+/// Options controlling proof generation behavior.
 #[derive(Debug, Clone, Copy, Encode, Decode)]
 pub struct ProveOptions {
     /// This tells the proof system to decrease the available limit of the query
@@ -60,32 +62,46 @@ impl Default for ProveOptions {
     }
 }
 
+/// A single layer of a legacy (v0) GroveDB proof containing only merk proofs.
 #[derive(Encode, Decode)]
 pub struct MerkOnlyLayerProof {
+    /// Encoded merk proof bytes for this layer.
     pub merk_proof: Vec<u8>,
+    /// Proofs for child subtrees keyed by their key in the parent tree.
     pub lower_layers: BTreeMap<Key, MerkOnlyLayerProof>,
 }
 
+/// Encoded proof bytes for different tree backing store types.
 #[derive(Encode, Decode)]
 pub enum ProofBytes {
+    /// Merk (Merkle AVL) tree proof bytes.
     Merk(Vec<u8>),
+    /// Merkle Mountain Range tree proof bytes.
     MMR(Vec<u8>),
+    /// Bulk-append tree proof bytes.
     BulkAppendTree(Vec<u8>),
+    /// Dense fixed-size Merkle tree proof bytes.
     DenseTree(Vec<u8>),
     /// CommitmentTree proof: `sinsemilla_root (32 bytes) || bulk_append_proof`.
     /// Binds the Orchard anchor to the GroveDB root hash.
     CommitmentTree(Vec<u8>),
 }
 
+/// A single layer of a v1 GroveDB proof supporting multiple tree types.
 #[derive(Encode, Decode)]
 pub struct LayerProof {
+    /// Proof bytes for this layer (may be any supported tree type).
     pub merk_proof: ProofBytes,
+    /// Proofs for child subtrees keyed by their key in the parent tree.
     pub lower_layers: BTreeMap<Key, LayerProof>,
 }
 
+/// A versioned GroveDB proof that can be verified against a path query.
 #[derive(Encode, Decode)]
 pub enum GroveDBProof {
+    /// Legacy proof format using only merk proofs.
     V0(GroveDBProofV0),
+    /// Current proof format supporting multiple tree backing store types.
     V1(GroveDBProofV1),
 }
 
@@ -203,15 +219,21 @@ impl GroveDBProof {
     }
 }
 
+/// Legacy (v0) GroveDB proof containing only merk layer proofs.
 #[derive(Encode, Decode)]
 pub struct GroveDBProofV0 {
+    /// The root layer proof for the top-level tree.
     pub root_layer: MerkOnlyLayerProof,
+    /// Options that were used when generating this proof.
     pub prove_options: ProveOptions,
 }
 
+/// Current (v1) GroveDB proof supporting multiple tree backing store types.
 #[derive(Encode, Decode)]
 pub struct GroveDBProofV1 {
+    /// The root layer proof for the top-level tree.
     pub root_layer: LayerProof,
+    /// Options that were used when generating this proof.
     pub prove_options: ProveOptions,
 }
 

--- a/grovedb/src/operations/proof/util.rs
+++ b/grovedb/src/operations/proof/util.rs
@@ -8,15 +8,19 @@ use grovedb_version::version::GroveVersion;
 
 use crate::Element;
 
+/// A collection of proved key-value pairs.
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub type ProvedKeyValues = Vec<ProvedKeyValue>;
 
+/// A collection of proved key-value pairs where values are optional.
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub type ProvedKeyOptionalValues = Vec<ProvedKeyOptionalValue>;
 
+/// A collection of proved path-key-value triples.
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub type ProvedPathKeyValues = Vec<ProvedPathKeyValue>;
 
+/// A collection of proved path-key-value triples where values are optional.
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub type ProvedPathKeyOptionalValues = Vec<ProvedPathKeyOptionalValue>;
 
@@ -186,6 +190,7 @@ impl ProvedPathKeyOptionalValue {
     }
 }
 
+/// Converts a byte slice to an ASCII string if all bytes are printable, otherwise hex-encodes it.
 pub fn hex_to_ascii(hex_value: &[u8]) -> String {
     // Define the set of allowed characters
     const ALLOWED_CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
@@ -203,6 +208,7 @@ pub fn hex_to_ascii(hex_value: &[u8]) -> String {
     }
 }
 
+/// Converts a path (vector of byte vectors) to a human-readable slash-separated string.
 pub fn path_hex_to_ascii(path: &Path) -> String {
     path.iter()
         .map(|e| hex_to_ascii(e.as_slice()))
@@ -210,12 +216,14 @@ pub fn path_hex_to_ascii(path: &Path) -> String {
         .join("/")
 }
 
+/// Converts a path of byte slices to a human-readable slash-separated string.
 pub fn path_as_slices_hex_to_ascii(path: &[&[u8]]) -> String {
     path.iter()
         .map(|e| hex_to_ascii(e))
         .collect::<Vec<_>>()
         .join("/")
 }
+/// Converts optional serialized element bytes to a display string, returning "None" if absent.
 pub fn optional_element_hex_to_ascii(hex_value: Option<&Vec<u8>>) -> Result<String, fmt::Error> {
     match hex_value {
         None => Ok("None".to_string()),
@@ -223,6 +231,7 @@ pub fn optional_element_hex_to_ascii(hex_value: Option<&Vec<u8>>) -> Result<Stri
     }
 }
 
+/// Deserializes element bytes and returns the element's display string.
 pub fn element_hex_to_ascii(hex_value: &[u8]) -> Result<String, fmt::Error> {
     let element =
         Element::deserialize(hex_value, GroveVersion::latest()).map_err(|_| fmt::Error)?;

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -31,6 +31,8 @@ use crate::{
 };
 
 impl GroveDb {
+    /// Verifies a proof against a path query with the given options, returning
+    /// the root hash and deserialized results.
     pub fn verify_query_with_options(
         proof: &[u8],
         query: &PathQuery,
@@ -126,6 +128,8 @@ impl GroveDb {
         Ok((root_hash, tree_feature_type, result))
     }
 
+    /// Verifies a proof against a path query and returns the root hash
+    /// with raw (not deserialized) proved key-value results.
     pub fn verify_query_raw(
         proof: &[u8],
         query: &PathQuery,
@@ -1512,6 +1516,8 @@ impl GroveDb {
         Ok(root_hash)
     }
 
+    /// Verifies a proof against a path query with succinctness checks,
+    /// returning the root hash and deserialized results.
     pub fn verify_query(
         proof: &[u8],
         query: &PathQuery,
@@ -1533,6 +1539,8 @@ impl GroveDb {
         )
     }
 
+    /// Verifies a proof against a path query without succinctness checks,
+    /// allowing the proof to contain extra data beyond what the query requires.
     pub fn verify_subset_query(
         proof: &[u8],
         query: &PathQuery,
@@ -1604,6 +1612,8 @@ impl GroveDb {
         )
     }
 
+    /// Verifies a proof that includes absence proofs for non-existing searched
+    /// keys, returning the root hash and deserialized results.
     pub fn verify_query_with_absence_proof(
         proof: &[u8],
         query: &PathQuery,
@@ -1629,6 +1639,8 @@ impl GroveDb {
         )
     }
 
+    /// Verifies a subset proof that includes absence proofs for non-existing
+    /// searched keys, without succinctness checks.
     pub fn verify_subset_query_with_absence_proof(
         proof: &[u8],
         query: &PathQuery,

--- a/grovedb/src/query/mod.rs
+++ b/grovedb/src/query/mod.rs
@@ -313,6 +313,7 @@ impl PathQuery {
         }
     }
 
+    /// Returns whether the parent tree element should be included in results at the given path.
     pub fn should_add_parent_tree_at_path(
         &self,
         path: &[&[u8]],
@@ -433,6 +434,7 @@ impl PathQuery {
         })
     }
 
+    /// Returns the query items applicable at the given path, if any.
     pub fn query_items_at_path(
         &self,
         path: &[&[u8]],

--- a/grovedb/src/query_result_type.rs
+++ b/grovedb/src/query_result_type.rs
@@ -59,15 +59,19 @@ impl fmt::Display for QueryResultElements {
     }
 }
 
+/// A node in the hierarchical query result tree: either a nested level or a leaf element.
 #[derive(Debug, Clone)]
 pub enum BTreeMapLevelResultOrItem {
+    /// A nested level containing further key-value results.
     BTreeMapLevelResult(BTreeMapLevelResult),
+    /// A leaf element result.
     ResultItem(Element),
 }
 
 /// BTreeMap level result
 #[derive(Debug, Clone)]
 pub struct BTreeMapLevelResult {
+    /// The mapping of keys to their result values at this level.
     pub key_values: BTreeMap<Key, BTreeMapLevelResultOrItem>,
 }
 
@@ -114,6 +118,7 @@ impl BTreeMapLevelResult {
 }
 
 impl BTreeMapLevelResult {
+    /// Returns the number of values at the given path within this result tree.
     pub fn len_of_values_at_path(&self, path: &[&[u8]]) -> u16 {
         let mut current = self;
 

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -28,10 +28,12 @@ pub type ChunkIdentifier = (
     Vec<Vec<u8>>,
 );
 
+/// Current version of the state sync protocol.
 pub const CURRENT_STATE_SYNC_VERSION: u16 = 1;
 
 #[cfg(feature = "minimal")]
 impl GroveDb {
+    /// Starts a new state synchronization session with the given app hash and batch size.
     pub fn start_syncing_session(
         &self,
         app_hash: [u8; 32],
@@ -40,6 +42,7 @@ impl GroveDb {
         MultiStateSyncSession::new(self, app_hash, subtrees_batch_size)
     }
 
+    /// Commits a completed state synchronization session.
     pub fn commit_session(&self, session: Pin<Box<MultiStateSyncSession>>) -> Result<(), Error> {
         session
             .commit()

--- a/grovedb/src/replication/state_sync_session.rs
+++ b/grovedb/src/replication/state_sync_session.rs
@@ -202,10 +202,12 @@ impl<'db> MultiStateSyncSession<'db> {
         })
     }
 
+    /// Returns true if there are no prefixes currently being synced.
     pub fn is_empty(&self) -> bool {
         self.current_prefixes.is_empty()
     }
 
+    /// Returns true if all subtrees have been fully synchronized.
     pub fn is_sync_completed(&self) -> bool {
         for (_, subtree_state_info) in self.current_prefixes.iter() {
             if !subtree_state_info.pending_chunks.is_empty() {
@@ -220,6 +222,7 @@ impl<'db> MultiStateSyncSession<'db> {
         true
     }
 
+    /// Commits the sync session by finalizing the underlying transaction.
     pub fn commit(self: Pin<Box<Self>>) -> Result<(), Error> {
         // SAFETY: the struct isn't used anymore and no storage contexts would access
         // transaction

--- a/merk/src/debugger.rs
+++ b/merk/src/debugger.rs
@@ -7,6 +7,7 @@ use grovedb_version::version::GroveVersion;
 use crate::{tree::kv::ValueDefinedCostType, CryptoHash, Error, Merk, TreeFeatureType};
 
 impl<'a, S: StorageContext<'a>> Merk<S> {
+    /// Fetches a node by key and returns its debug representation.
     pub fn get_node_dbg(&self, key: &[u8]) -> Result<Option<NodeDbg>, Error> {
         self.get_node_direct_fn(
             key,
@@ -30,6 +31,7 @@ impl<'a, S: StorageContext<'a>> Merk<S> {
         .unwrap()
     }
 
+    /// Fetches the root node and returns its debug representation.
     pub fn get_root_node_dbg(&self) -> Result<Option<NodeDbg>, Error> {
         Ok(self.use_tree(|tree_opt| {
             tree_opt.map(|tree| NodeDbg {
@@ -47,15 +49,25 @@ impl<'a, S: StorageContext<'a>> Merk<S> {
     }
 }
 
+/// Debug representation of a Merk tree node.
 #[derive(Debug)]
 pub struct NodeDbg {
+    /// The node's key.
     pub key: Vec<u8>,
+    /// The node's value.
     pub value: Vec<u8>,
+    /// Key of the left child node, if any.
     pub left_child: Option<Vec<u8>>,
+    /// Merk hash of the left child, if any.
     pub left_merk_hash: Option<[u8; 32]>,
+    /// Key of the right child node, if any.
     pub right_child: Option<Vec<u8>>,
+    /// Merk hash of the right child, if any.
     pub right_merk_hash: Option<[u8; 32]>,
+    /// Hash of the node's value.
     pub value_hash: CryptoHash,
+    /// Combined key-value digest hash.
     pub kv_digest_hash: CryptoHash,
+    /// The feature type of this node.
     pub feature_type: TreeFeatureType,
 }

--- a/merk/src/element/costs.rs
+++ b/merk/src/element/costs.rs
@@ -17,6 +17,7 @@ use crate::{
     Error,
 };
 
+/// Extension trait for element cost calculations.
 pub trait ElementCostExtensions {
     /// Get tree costs for a key value
     fn specialized_costs_for_key_value(
@@ -43,6 +44,7 @@ pub trait ElementCostExtensions {
     ) -> Option<ValueDefinedCostType>;
 }
 
+/// Private extension trait for internal element cost operations.
 pub trait ElementCostPrivateExtensions {
     /// Get tree cost for the element
     fn get_specialized_cost(&self, grove_version: &GroveVersion) -> Result<u32, Error>;

--- a/merk/src/element/decode.rs
+++ b/merk/src/element/decode.rs
@@ -3,6 +3,7 @@ use grovedb_version::version::GroveVersion;
 
 use crate::{element::costs::ElementCostExtensions, tree::TreeNode, Error};
 
+/// Extension trait for decoding elements from raw bytes.
 pub trait ElementDecodeExtensions {
     /// Decode from bytes
     fn raw_decode(bytes: &[u8], grove_version: &GroveVersion) -> Result<Element, Error>;

--- a/merk/src/element/delete.rs
+++ b/merk/src/element/delete.rs
@@ -10,6 +10,7 @@ use crate::{
     element::costs::ElementCostExtensions, BatchEntry, Error, Merk, MerkOptions, Op, TreeType,
 };
 
+/// Extension trait for deleting elements from Merk storage.
 pub trait ElementDeleteFromStorageExtensions {
     /// Delete an element from Merk under a key
     fn delete<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(

--- a/merk/src/element/exists.rs
+++ b/merk/src/element/exists.rs
@@ -8,6 +8,7 @@ use grovedb_version::{check_grovedb_v0_with_cost, version::GroveVersion};
 
 use crate::{element::costs::ElementCostExtensions, Error, Merk};
 
+/// Extension trait for checking element existence in Merk storage.
 pub trait ElementExistsInStorageExtensions {
     /// Helper function that returns whether an element at the key for the
     /// element already exists.

--- a/merk/src/element/get.rs
+++ b/merk/src/element/get.rs
@@ -21,6 +21,7 @@ use crate::{
     CryptoHash, Error, Merk,
 };
 
+/// Extension trait for fetching elements from Merk storage.
 pub trait ElementFetchFromStorageExtensions {
     /// Get an element from Merk under a key; path should be resolved and proper
     /// Merk should be loaded by this moment

--- a/merk/src/element/insert.rs
+++ b/merk/src/element/insert.rs
@@ -18,6 +18,7 @@ use crate::{
     BatchEntry, CryptoHash, Error, Merk, MerkOptions, Op, TreeFeatureType,
 };
 
+/// Extension trait for inserting elements into Merk storage.
 pub trait ElementInsertToStorageExtensions {
     /// Insert an element in Merk under a key; path should be resolved and
     /// proper Merk should be loaded by this moment

--- a/merk/src/element/mod.rs
+++ b/merk/src/element/mod.rs
@@ -4,8 +4,10 @@ use grovedb_element::{error::ElementError, Element};
 use crate::tree::value_hash;
 
 #[cfg(feature = "minimal")]
+/// Element cost calculation extensions.
 pub mod costs;
 #[cfg(feature = "minimal")]
+/// Element decoding extensions.
 pub mod decode;
 #[cfg(feature = "minimal")]
 pub mod delete;
@@ -17,9 +19,12 @@ pub mod get;
 pub mod insert;
 #[cfg(feature = "minimal")]
 pub mod reconstruct;
+/// Element tree type extensions.
 pub mod tree_type;
 
+/// Extension trait for computing element value hashes.
 pub trait ElementExt {
+    /// Computes the value hash for this element.
     fn value_hash(
         &self,
         grove_version: &grovedb_version::version::GroveVersion,

--- a/merk/src/element/tree_type.rs
+++ b/merk/src/element/tree_type.rs
@@ -8,6 +8,7 @@ use crate::{
     TreeType,
 };
 
+/// Extension trait for determining tree type information from elements.
 pub trait ElementTreeTypeExtensions {
     /// Check if the element is a tree and return the root_tree info and tree
     /// type

--- a/merk/src/error.rs
+++ b/merk/src/error.rs
@@ -121,9 +121,11 @@ pub enum Error {
     /// Version error
     VersionError(grovedb_version::error::GroveVersionError),
 
+    /// Big sum tree under normal sum tree error
     #[error("big sum tree under normal sum tree error {0}")]
     BigSumTreeUnderNormalSumTree(String),
 
+    /// Unknown tree type error
     #[error("unknown tree type {0}")]
     UnknownTreeType(String),
 
@@ -208,7 +210,9 @@ impl From<grovedb_query::error::Error> for Error {
     }
 }
 
+/// Extension trait for adding context to merk error results.
 pub trait MerkErrorExt {
+    /// Appends additional context to the error message.
     fn add_context(self, append: impl AsRef<str>) -> Self;
 }
 

--- a/merk/src/lib.rs
+++ b/merk/src/lib.rs
@@ -11,6 +11,7 @@
 #[cfg(feature = "minimal")]
 pub mod merk;
 
+/// Debug inspection support for GroveDbg.
 #[cfg(feature = "grovedbg")]
 pub mod debugger;
 

--- a/merk/src/lib.rs
+++ b/merk/src/lib.rs
@@ -1,7 +1,6 @@
 //! High-performance Merkle key/value store
 
-// #![deny(missing_docs)]
-
+#![deny(missing_docs)]
 // Pre-existing patterns throughout the crate; fix incrementally.
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
@@ -39,7 +38,9 @@ pub mod error;
 /// Estimated costs
 pub mod estimated_costs;
 
+/// Element definitions for Merk tree entries.
 pub mod element;
+/// Tree type definitions describing the different kinds of Merk trees.
 pub mod tree_type;
 #[cfg(feature = "minimal")]
 mod visualize;

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -27,12 +27,17 @@ use crate::{
 /// ChunkProof for replication of a single subtree
 #[derive(Debug)]
 pub struct SubtreeChunk {
+    /// The proof operations representing this chunk.
     chunk: Vec<Op>,
+    /// The index of the next chunk, or `None` if this is the last.
     next_index: Option<usize>,
+    /// The remaining byte budget after producing this chunk.
     remaining_limit: Option<usize>,
 }
 
 impl SubtreeChunk {
+    /// Creates a new `SubtreeChunk` with the given proof ops, next index, and
+    /// remaining limit.
     pub fn new(chunk: Vec<Op>, next_index: Option<usize>, remaining_limit: Option<usize>) -> Self {
         Self {
             chunk,
@@ -45,12 +50,17 @@ impl SubtreeChunk {
 /// ChunkProof for the replication of multiple subtrees.
 #[derive(Debug)]
 pub struct MultiChunk {
+    /// The chunk operations representing multiple subtree chunks.
     pub chunk: Vec<ChunkOp>,
+    /// The chunk identifier for the next chunk, or `None` if complete.
     pub next_index: Option<Vec<u8>>,
+    /// The remaining byte budget after producing these chunks.
     pub remaining_limit: Option<usize>,
 }
 
 impl MultiChunk {
+    /// Creates a new `MultiChunk` with the given chunk ops, next index, and
+    /// remaining limit.
     pub fn new(
         chunk: Vec<ChunkOp>,
         next_index: Option<Vec<u8>>,
@@ -353,6 +363,7 @@ where
         number_of_chunks(self.height)
     }
 
+    /// Returns `true` if the tree has no chunks.
     pub fn is_empty(&self) -> bool {
         number_of_chunks(self.height) == 0
     }
@@ -392,6 +403,8 @@ impl<'db, S> ChunkProducer<'db, S>
 where
     S: StorageContext<'db>,
 {
+    /// Returns the next chunk in iteration order, or `None` if all chunks
+    /// have been yielded.
     pub fn next(
         &mut self,
         grove_version: &GroveVersion,

--- a/merk/src/merk/committer.rs
+++ b/merk/src/merk/committer.rs
@@ -4,6 +4,7 @@ use crate::{
     Error,
 };
 
+/// Collects tree nodes during commit for batch writing to storage.
 pub struct MerkCommitter {
     /// The batch has a key, maybe a value, with the value bytes, maybe the left
     /// child size and maybe the right child size, then the

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -28,18 +28,26 @@
 
 //! Merk
 
+/// Chunk-based tree replication.
 pub mod chunks;
 pub(crate) mod defaults;
 
 pub mod options;
 
+/// Applying operations (inserts, updates, deletes) to a Merk tree.
 pub mod apply;
+/// Clearing all data from a Merk tree.
 pub mod clear;
+/// Commit logic for writing tree nodes to storage.
 pub mod committer;
+/// Getting values by key from a Merk tree.
 pub mod get;
+/// Opening and loading a Merk tree from storage.
 pub mod open;
+/// Generating Merkle proofs for queries against a Merk tree.
 pub mod prove;
 pub mod restore;
+/// Source implementation for fetching tree nodes from storage.
 pub mod source;
 
 use std::{
@@ -85,9 +93,13 @@ use crate::{
 
 /// Key update types
 pub struct KeyUpdates {
+    /// Keys that were newly inserted.
     pub new_keys: BTreeSet<Vec<u8>>,
+    /// Keys whose values were updated.
     pub updated_keys: BTreeSet<Vec<u8>>,
+    /// Keys that were deleted, along with their storage costs.
     pub deleted_keys: LinkedList<(Vec<u8>, KeyValueStorageCost)>,
+    /// The previous root key if the root key changed.
     pub updated_root_key_from: Option<Vec<u8>>,
 }
 
@@ -293,7 +305,9 @@ impl<S> fmt::Debug for Merk<S> {
     }
 }
 
-// key, maybe value, maybe child reference hooks, maybe key value storage costs
+/// Result type for tree mutation operations, containing tuples of
+/// (key, optional cost type and feature sum length, children sizes with value,
+/// key-value storage cost).
 pub type UseTreeMutResult = CostResult<
     Vec<(
         Vec<u8>,

--- a/merk/src/merk/source.rs
+++ b/merk/src/merk/source.rs
@@ -21,6 +21,7 @@ where
 }
 
 #[derive(Debug)]
+/// A `Fetch` implementation that loads tree nodes from Merk storage.
 pub struct MerkSource<'s, S> {
     storage: &'s S,
     tree_type: TreeType,

--- a/merk/src/proofs/chunk.rs
+++ b/merk/src/proofs/chunk.rs
@@ -2,8 +2,11 @@
 
 mod binary_range;
 #[cfg(feature = "minimal")]
+/// Chunk generation and verification for tree synchronization.
 pub mod chunk;
+/// Chunk operation types for encoding and decoding.
 pub mod chunk_op;
+/// Chunk-related error types.
 pub mod error;
 #[cfg(feature = "minimal")]
 pub mod util;

--- a/merk/src/proofs/chunk/chunk.rs
+++ b/merk/src/proofs/chunk/chunk.rs
@@ -39,7 +39,9 @@ use crate::{
     CryptoHash, Error,
 };
 
+/// Traversal direction constant representing a left child.
 pub const LEFT: bool = true;
+/// Traversal direction constant representing a right child.
 pub const RIGHT: bool = false;
 
 impl<S> RefWalker<'_, S>
@@ -267,7 +269,8 @@ where
     }
 }
 
-// TODO: add documentation
+/// Verifies a height proof against the expected root hash and returns the
+/// proven height of the tree.
 pub fn verify_height_proof(proof: Vec<Op>, expected_root_hash: CryptoHash) -> Result<usize, Error> {
     // todo: remove unwrap
     let height_proof_tree = execute(proof.into_iter().map(Ok), false, |_| Ok(())).unwrap()?;
@@ -283,7 +286,8 @@ pub fn verify_height_proof(proof: Vec<Op>, expected_root_hash: CryptoHash) -> Re
     verify_height_tree(&height_proof_tree)
 }
 
-// TODO: add documentation
+/// Recursively verifies a height proof tree and returns the height by
+/// counting left-child KVHash nodes.
 pub fn verify_height_tree(height_proof_tree: &Tree) -> Result<usize, Error> {
     Ok(match height_proof_tree.child(LEFT) {
         Some(child) => {

--- a/merk/src/proofs/chunk/chunk.rs
+++ b/merk/src/proofs/chunk/chunk.rs
@@ -303,6 +303,7 @@ pub fn verify_height_tree(height_proof_tree: &Tree) -> Result<usize, Error> {
     })
 }
 
+/// Tests for chunk verification and height proofs.
 #[cfg(test)]
 pub mod tests {
     use ed::Encode;

--- a/merk/src/proofs/chunk/chunk_op.rs
+++ b/merk/src/proofs/chunk/chunk_op.rs
@@ -36,7 +36,10 @@ use crate::proofs::Op;
 /// Represents the chunk generated from a given starting chunk id
 #[derive(PartialEq, Debug)]
 pub enum ChunkOp {
+    /// A chunk identifier represented as a traversal instruction (sequence of
+    /// left/right booleans).
     ChunkId(Vec<bool>),
+    /// A chunk of proof operations.
     Chunk(Vec<Op>),
 }
 

--- a/merk/src/proofs/chunk/error.rs
+++ b/merk/src/proofs/chunk/error.rs
@@ -69,6 +69,7 @@ pub enum ChunkError {
     #[error("invalid multi chunk: {0}")]
     InvalidMultiChunk(&'static str),
 
+    /// Finalize called before all expected chunks have been received
     #[error("called finalize too early still expecting chunks")]
     RestorationNotComplete,
 

--- a/merk/src/proofs/chunk/util.rs
+++ b/merk/src/proofs/chunk/util.rs
@@ -339,6 +339,8 @@ pub fn vec_bytes_as_traversal_instruction(
         .collect()
 }
 
+/// Writes the given byte slice to a writer, mapping I/O errors to
+/// `InternalError`.
 pub fn write_to_vec<W: Write>(dest: &mut W, value: &[u8]) -> Result<(), Error> {
     dest.write_all(value)
         .map_err(|_e| InternalError("failed to write to vector"))

--- a/merk/src/proofs/mod.rs
+++ b/merk/src/proofs/mod.rs
@@ -4,6 +4,7 @@
 pub mod branch;
 #[cfg(feature = "minimal")]
 pub mod chunk;
+/// Query proof generation and verification.
 pub mod query;
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub mod tree;

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -41,6 +41,8 @@ use crate::TreeFeatureType;
 #[cfg(feature = "minimal")]
 use crate::TreeType;
 
+/// Result type for proof generation: contains the proof ops, a tuple indicating
+/// left/right absence, and the current proof status (remaining limit).
 #[cfg(feature = "minimal")]
 pub type ProofAbsenceLimit = (LinkedList<Op>, (bool, bool), ProofStatus);
 

--- a/merk/src/proofs/query/verify.rs
+++ b/merk/src/proofs/query/verify.rs
@@ -34,6 +34,7 @@ pub fn verify(bytes: &[u8], expected_hash: MerkHash) -> CostResult<Map, Error> {
     })
 }
 
+/// Options controlling proof verification behavior.
 #[derive(Copy, Clone, Debug)]
 pub struct VerifyOptions {
     /// When set to true, this will give back absence proofs for any query items

--- a/merk/src/proofs/tree.rs
+++ b/merk/src/proofs/tree.rs
@@ -40,6 +40,8 @@ pub struct Child {
 }
 
 impl Child {
+    /// Converts this child into a `Link::Reference` for use during tree
+    /// reconstruction.
     #[cfg(feature = "minimal")]
     pub fn as_link(&self) -> Link {
         let (key, aggregate_data) = match &self.tree.node {

--- a/merk/src/tree/kv.rs
+++ b/merk/src/tree/kv.rs
@@ -255,6 +255,7 @@ impl KV {
         &self.hash
     }
 
+    /// Returns the feature type of this key-value node.
     pub fn feature_type(&self) -> TreeFeatureType {
         self.feature_type
     }

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -169,6 +169,8 @@ impl TreeNode {
         self.inner.kv.feature_type.node_type()
     }
 
+    /// Computes the storage cost when updating a value, comparing old and new
+    /// byte costs.
     pub fn storage_cost_for_update(current_value_byte_cost: u32, old_cost: u32) -> StorageCost {
         let mut value_storage_cost = StorageCost {
             ..Default::default()

--- a/merk/src/tree/tree_feature_type.rs
+++ b/merk/src/tree/tree_feature_type.rs
@@ -12,19 +12,28 @@ use self::TreeFeatureType::{
 use crate::tree_type::TreeType;
 
 #[cfg(feature = "minimal")]
+/// Aggregate data associated with tree nodes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum AggregateData {
+    /// No aggregate data.
     NoAggregateData,
+    /// A signed 64-bit sum value.
     Sum(i64),
+    /// A signed 128-bit sum value for large sums.
     BigSum(i128),
+    /// An unsigned 64-bit element count.
     Count(u64),
+    /// A combined element count and sum.
     CountAndSum(u64, i64),
+    /// A provable unsigned 64-bit element count.
     ProvableCount(u64),
+    /// A provable combined element count and sum.
     ProvableCountAndSum(u64, i64),
 }
 
 #[cfg(feature = "minimal")]
 impl AggregateData {
+    /// Returns the tree type corresponding to this aggregate data variant.
     pub fn parent_tree_type(&self) -> TreeType {
         match self {
             AggregateData::NoAggregateData => TreeType::NormalTree,
@@ -37,6 +46,7 @@ impl AggregateData {
         }
     }
 
+    /// Returns the sum value as `i64`, or 0 if not a sum variant.
     pub fn as_sum_i64(&self) -> i64 {
         match self {
             AggregateData::NoAggregateData => 0,
@@ -56,6 +66,7 @@ impl AggregateData {
         }
     }
 
+    /// Returns the count value as `u64`, or 0 if not a count variant.
     pub fn as_count_u64(&self) -> u64 {
         match self {
             AggregateData::NoAggregateData => 0,
@@ -68,6 +79,7 @@ impl AggregateData {
         }
     }
 
+    /// Returns the sum value as `i128`, or 0 if not a sum variant.
     pub fn as_summed_i128(&self) -> i128 {
         match self {
             AggregateData::NoAggregateData => 0,

--- a/merk/src/tree_type/costs.rs
+++ b/merk/src/tree_type/costs.rs
@@ -45,7 +45,9 @@ pub const BULK_APPEND_TREE_COST_SIZE: u32 = 9 + 1 + 2; // 12
 /// height (u8) + 2 bytes overhead)
 pub const DENSE_TREE_COST_SIZE: u32 = 3 + 1 + 2; // 6
 
+/// Provides the serialized cost size in bytes for a tree type.
 pub trait CostSize {
+    /// Returns the cost size in bytes for this value.
     fn cost_size(&self) -> u32;
 }
 

--- a/merk/src/tree_type/mod.rs
+++ b/merk/src/tree_type/mod.rs
@@ -10,24 +10,39 @@ use grovedb_element::ElementType;
 use crate::merk::NodeType;
 use crate::{Error, TreeFeatureType};
 
+/// Represents a value that is either a tree or not a tree.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum MaybeTree {
+    /// The value is a tree of the given type.
     Tree(TreeType),
+    /// The value is not a tree.
     NotTree,
 }
 
+/// The type of a Merk subtree, determining its node structure and aggregation behavior.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum TreeType {
+    /// A standard Merk tree with no aggregation.
     NormalTree,
+    /// A tree that maintains a running sum of descendant sum items.
     SumTree,
+    /// A tree that maintains a 256-bit running sum of descendant sum items.
     BigSumTree,
+    /// A tree that counts its elements.
     CountTree,
+    /// A tree that both counts elements and maintains a running sum.
     CountSumTree,
+    /// A count tree with provable count support.
     ProvableCountTree,
+    /// A count-sum tree with provable count support.
     ProvableCountSumTree,
+    /// A commitment tree with a configurable chunk power parameter.
     CommitmentTree(u8),
+    /// A Merkle Mountain Range tree.
     MmrTree,
+    /// A bulk-append optimized tree with a configurable chunk power parameter.
     BulkAppendTree(u8),
+    /// A dense append-only tree with fixed-size entries and a configurable height.
     DenseAppendOnlyFixedSizeTree(u8),
 }
 
@@ -106,6 +121,7 @@ impl TreeType {
         )
     }
 
+    /// Returns whether this tree type allows sum items as children.
     pub fn allows_sum_item(&self) -> bool {
         match self {
             TreeType::NormalTree => false,
@@ -123,6 +139,7 @@ impl TreeType {
     }
 
     #[cfg(feature = "minimal")]
+    /// Returns the inner node type used by nodes within this tree type.
     pub const fn inner_node_type(&self) -> NodeType {
         match self {
             TreeType::NormalTree => NodeType::NormalNode,
@@ -139,6 +156,7 @@ impl TreeType {
         }
     }
 
+    /// Returns the feature type for an empty tree of this type.
     pub fn empty_tree_feature_type(&self) -> TreeFeatureType {
         match self {
             TreeType::NormalTree => TreeFeatureType::BasicMerkNode,


### PR DESCRIPTION
## Summary
- Enables `#![deny(missing_docs)]` on `grovedb` and `merk` crates (previously had no requirement)
- Upgrades `warn(missing_docs)` to `deny(missing_docs)` on `grovedb-query`, `grovedb-commitment-tree`, `grovedb-dense-fixed-sized-merkle-tree`, and `grovedb-merkle-mountain-range`
- Adds documentation for all 185 previously undocumented public items across 48 files

## Test plan
- [ ] Verify `cargo build` succeeds (all crates now fail on missing docs)
- [ ] Verify `cargo clippy -- -D warnings` passes
- [ ] Review doc comments for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error context enhancement for improved debugging messages.
  * Introduced new proof verification APIs for query validation.
  * Added debug inspection capabilities for tree node analysis.
  * Expanded query functionality with new public methods.

* **Chores**
  * Enforced stricter documentation requirements across crates to improve code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->