### PR TITLE
chore: exclude debug/visualize files from coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,9 @@ ignore:
   - "**/tests.rs"
   - "**/tests/**"
   - "fuzz/**"
+  - "**/debugger.rs"
+  - "**/visualize.rs"
+  - "**/debug.rs"
 
 coverage:
   status:


### PR DESCRIPTION
## Summary
- Excludes `**/debugger.rs`, `**/visualize.rs`, and `**/debug.rs` from Codecov reporting
- These are debug-only utilities behind feature gates (`grovedbg`) not exercised in CI test runs
- Removes ~888 untestable lines from the coverage denominator for a more accurate picture

## Test plan
- [ ] Verify Codecov report no longer includes these files after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage tool configuration to exclude specific patterns from analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->