### PR TITLE
fix: return error instead of panicking in prove_query_many for empty input

### DIFF
--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -48,6 +48,12 @@ impl GroveDb {
                 .proof
                 .prove_query_many
         );
+        if query.is_empty() {
+            return Err(Error::InvalidInput(
+                "prove_query_many called with empty query vector",
+            ))
+            .wrap_with_cost(OperationCost::default());
+        }
         if query.len() > 1 {
             let query = cost_return_on_error_default!(PathQuery::merge(query, grove_version));
             self.prove_query(&query, prove_options, grove_version)

--- a/grovedb/src/tests/proof_advanced_tests.rs
+++ b/grovedb/src/tests/proof_advanced_tests.rs
@@ -162,15 +162,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn prove_query_many_empty_queries_panics() {
-        // prove_query_many with an empty query list will index out of bounds
-        // in the current implementation (it accesses query[0] when len <= 1).
+    fn prove_query_many_empty_queries_returns_error() {
+        // prove_query_many with an empty query list should return an error.
         let grove_version = GroveVersion::latest();
         let db = make_test_grovedb(grove_version);
 
-        // This should panic because the code does `query[0]` on an empty vec.
-        let _result = db.prove_query_many(vec![], None, grove_version);
+        let result = db.prove_query_many(vec![], None, grove_version).unwrap();
+        assert!(
+            result.is_err(),
+            "prove_query_many with empty vector should return InvalidInput error"
+        );
     }
 
     // =========================================================================

--- a/grovedb/src/tests/proof_advanced_tests.rs
+++ b/grovedb/src/tests/proof_advanced_tests.rs
@@ -167,10 +167,17 @@ mod tests {
         let grove_version = GroveVersion::latest();
         let db = make_test_grovedb(grove_version);
 
-        let result = db.prove_query_many(vec![], None, grove_version).unwrap();
+        let err = db
+            .prove_query_many(vec![], None, grove_version)
+            .unwrap()
+            .expect_err("prove_query_many with empty vector should return an error");
         assert!(
-            result.is_err(),
-            "prove_query_many with empty vector should return InvalidInput error"
+            matches!(
+                err,
+                crate::Error::InvalidInput("prove_query_many called with empty query vector")
+            ),
+            "expected InvalidInput with exact message, got: {:?}",
+            err
         );
     }
 


### PR DESCRIPTION
## Summary
- `prove_query_many` previously panicked with an index-out-of-bounds when called with an empty query vector (`query[0]` on empty `Vec`)
- Now returns `Err(InvalidInput("prove_query_many called with empty query vector"))` instead
- Updated the existing `#[should_panic]` test to verify the error return

Found during automated codebase audit (finding L2).

## Test plan
- [x] `prove_query_many_empty_queries_returns_error` — verifies error on empty input
- [x] All existing `prove_query_many` tests still pass (5/5)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query operations now include robust early input validation, returning clear and actionable error messages when operations are called with invalid or empty parameters instead of experiencing unexpected system crashes. This improvement provides users with detailed feedback for faster troubleshooting and significantly increases overall system reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->