### PR TITLE
perf: reduce cloning in batch structure construction

### DIFF
--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -117,32 +117,34 @@ where
         let mut ops_by_qualified_paths: BTreeMap<Vec<Vec<u8>>, GroveOp> = BTreeMap::new();
 
         for op in ops.into_iter() {
+            let QualifiedGroveDbOp {
+                path: op_path,
+                key: op_key,
+                op: grove_op,
+            } = op;
+
             // Keyless ops (append-only tree ops) are handled by preprocessing.
             // In estimated-cost paths they have no cost model yet — skip.
-            let key = match op.key {
+            let key = match op_key {
                 Some(k) => k,
                 None => continue,
             };
 
-            let mut path = op.path.clone();
-            path.push(key.clone());
-            ops_by_qualified_paths.insert(path.to_path_consume(), op.op.clone());
+            // Build qualified path (path + key) for reference lookups
+            let mut qualified_path = op_path.clone();
+            qualified_path.push(key.clone());
+            ops_by_qualified_paths.insert(qualified_path.to_path_consume(), grove_op.clone());
+
             let op_cost = OperationCost::default();
-            let op_result = match &op.op {
+            let op_result = match &grove_op {
                 GroveOp::InsertOnly { element }
                 | GroveOp::InsertOrReplace { element }
                 | GroveOp::Replace { element }
                 | GroveOp::Patch { element, .. } => {
                     if let Some(tree_type) = element.tree_type() {
-                        // Reconstruct op with key for insert call
-                        let keyed_op = QualifiedGroveDbOp {
-                            path: op.path.clone(),
-                            key: Some(key.clone()),
-                            op: op.op.clone(),
-                        };
                         cost_return_on_error!(
                             &mut cost,
-                            merk_tree_cache.insert(&keyed_op, tree_type)
+                            merk_tree_cache.insert(&op_path, &key, tree_type)
                         );
                     }
                     Ok(())
@@ -170,26 +172,17 @@ where
                 return Err(e).wrap_with_cost(op_cost);
             }
 
-            let level = op.path.len();
-            if let Some(ops_on_level) = ops_by_level_paths.get_mut(level) {
-                if let Some(ops_on_path) = ops_on_level.get_mut(&op.path) {
-                    ops_on_path.insert(key, op.op);
-                } else {
-                    let mut ops_on_path: BTreeMap<KeyInfo, GroveOp> = BTreeMap::new();
-                    ops_on_path.insert(key, op.op);
-                    ops_on_level.insert(op.path.clone(), ops_on_path);
-                }
-            } else {
-                let mut ops_on_path: BTreeMap<KeyInfo, GroveOp> = BTreeMap::new();
-                ops_on_path.insert(key, op.op);
-                let mut ops_on_level: BTreeMap<KeyInfoPath, BTreeMap<KeyInfo, GroveOp>> =
-                    BTreeMap::new();
-                ops_on_level.insert(op.path, ops_on_path);
-                ops_by_level_paths.insert(level, ops_on_level);
+            let level = op_path.len();
+            let ops_on_level = ops_by_level_paths.entry(level).or_insert_with(|| {
                 if current_last_level < level {
                     current_last_level = level;
                 }
-            }
+                BTreeMap::new()
+            });
+            ops_on_level
+                .entry(op_path)
+                .or_default()
+                .insert(key, grove_op);
         }
 
         Ok(BatchStructure {

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -25,8 +25,7 @@ use crate::Element;
 #[cfg(feature = "minimal")]
 use crate::{
     batch::{
-        key_info::KeyInfo, mode::BatchRunMode, BatchApplyOptions, GroveOp, KeyInfoPath,
-        QualifiedGroveDbOp, TreeCache,
+        key_info::KeyInfo, mode::BatchRunMode, BatchApplyOptions, GroveOp, KeyInfoPath, TreeCache,
     },
     Error, GroveDb,
 };
@@ -312,16 +311,15 @@ impl fmt::Debug for AverageCaseTreeCacheKnownPaths {
 
 #[cfg(feature = "minimal")]
 impl<G, SR> TreeCache<G, SR> for AverageCaseTreeCacheKnownPaths {
-    fn insert(&mut self, op: &QualifiedGroveDbOp, tree_type: TreeType) -> CostResult<(), Error> {
+    fn insert(
+        &mut self,
+        path: &KeyInfoPath,
+        key: &KeyInfo,
+        tree_type: TreeType,
+    ) -> CostResult<(), Error> {
         let mut average_case_cost = OperationCost::default();
-        let mut inserted_path = op.path.clone();
-        let key = cost_return_on_error_no_add!(
-            average_case_cost,
-            op.key
-                .clone()
-                .ok_or(Error::InvalidBatchOperation("insert op is missing a key"))
-        );
-        inserted_path.push(key);
+        let mut inserted_path = path.clone();
+        inserted_path.push(key.clone());
         // There is no need to pay for getting a merk, because we know the merk to be
         // empty at this point.
         // There is however a hash call that creates the prefix

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -25,8 +25,7 @@ use crate::Element;
 #[cfg(feature = "minimal")]
 use crate::{
     batch::{
-        key_info::KeyInfo, mode::BatchRunMode, BatchApplyOptions, GroveOp, KeyInfoPath,
-        QualifiedGroveDbOp, TreeCache,
+        key_info::KeyInfo, mode::BatchRunMode, BatchApplyOptions, GroveOp, KeyInfoPath, TreeCache,
     },
     Error, GroveDb,
 };
@@ -319,16 +318,15 @@ impl fmt::Debug for WorstCaseTreeCacheKnownPaths {
 
 #[cfg(feature = "minimal")]
 impl<G, SR> TreeCache<G, SR> for WorstCaseTreeCacheKnownPaths {
-    fn insert(&mut self, op: &QualifiedGroveDbOp, _tree_type: TreeType) -> CostResult<(), Error> {
+    fn insert(
+        &mut self,
+        path: &KeyInfoPath,
+        key: &KeyInfo,
+        _tree_type: TreeType,
+    ) -> CostResult<(), Error> {
         let mut worst_case_cost = OperationCost::default();
-        let mut inserted_path = op.path.clone();
-        let key = cost_return_on_error_no_add!(
-            worst_case_cost,
-            op.key
-                .clone()
-                .ok_or(Error::InvalidBatchOperation("insert op is missing a key"))
-        );
-        inserted_path.push(key);
+        let mut inserted_path = path.clone();
+        inserted_path.push(key.clone());
         // There is no need to pay for getting a merk, because we know the merk to be
         // empty at this point.
         // There is however a hash call that creates the prefix

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -969,7 +969,12 @@ impl<S, F> fmt::Debug for TreeCacheMerkByPath<S, F> {
 
 #[allow(dead_code)] // get_batch_run_mode is defined for future use
 trait TreeCache<G, SR> {
-    fn insert(&mut self, op: &QualifiedGroveDbOp, tree_type: TreeType) -> CostResult<(), Error>;
+    fn insert(
+        &mut self,
+        path: &KeyInfoPath,
+        key: &KeyInfo,
+        tree_type: TreeType,
+    ) -> CostResult<(), Error>;
 
     fn get_batch_run_mode(&self) -> BatchRunMode;
 
@@ -1562,16 +1567,15 @@ where
     F: FnMut(&[Vec<u8>], bool) -> CostResult<Merk<S>, Error>,
     S: StorageContext<'db>,
 {
-    fn insert(&mut self, op: &QualifiedGroveDbOp, tree_type: TreeType) -> CostResult<(), Error> {
+    fn insert(
+        &mut self,
+        path: &KeyInfoPath,
+        key: &KeyInfo,
+        tree_type: TreeType,
+    ) -> CostResult<(), Error> {
         let mut cost = OperationCost::default();
 
-        let mut inserted_path = op.path.to_path();
-        let key = cost_return_on_error_no_add!(
-            cost,
-            op.key
-                .as_ref()
-                .ok_or(Error::InvalidBatchOperation("insert op is missing a key"))
-        );
+        let mut inserted_path = path.to_path();
         inserted_path.push(key.get_key_clone());
         if let HashMapEntry::Vacant(e) = self.merks.entry(inserted_path.clone()) {
             let mut merk =


### PR DESCRIPTION
## Summary
- Change `TreeCache::insert` trait to take `(&KeyInfoPath, &KeyInfo, TreeType)` instead of `&QualifiedGroveDbOp`, eliminating the need to reconstruct a full op just to pass a reference
- Destructure `QualifiedGroveDbOp` early in the loop and move owned values into final destinations instead of cloning
- Use entry API on IntMap and BTreeMap to avoid redundant path clones for map insertion

Reduces per-op clones from ~7 (for tree element ops) to 3. Addresses audit finding P3.

## Test plan
- [x] All 267 batch tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)