### PR TITLE
perf: avoid heap allocation in delete path comparisons

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -442,6 +442,16 @@ impl KeyInfoPath {
         self.0.iter().map(|k| k.get_key_clone()).collect()
     }
 
+    /// Compare with a byte-vector path without allocating
+    pub fn eq_path_vec(&self, other: &[Vec<u8>]) -> bool {
+        self.0.len() == other.len()
+            && self
+                .0
+                .iter()
+                .zip(other.iter())
+                .all(|(a, b)| a.as_slice() == b.as_slice())
+    }
+
     /// To a path of refs
     pub fn to_path_refs(&self) -> Vec<&[u8]> {
         self.0.iter().map(|k| k.as_slice()).collect()

--- a/grovedb/src/operations/delete/mod.rs
+++ b/grovedb/src/operations/delete/mod.rs
@@ -588,9 +588,7 @@ impl GroveDb {
                         .iter()
                         .filter_map(|op| match op.op {
                             GroveOp::Delete | GroveOp::DeleteTree(_) => {
-                                // todo: to_path clones (best to figure out how to compare
-                                // without cloning)
-                                if op.path.to_path() == subtree_merk_path_vec {
+                                if op.path.eq_path_vec(&subtree_merk_path_vec) {
                                     Some(op.key.as_ref()?.as_slice())
                                 } else {
                                     None
@@ -619,8 +617,7 @@ impl GroveDb {
                 // tree then it is not empty either
                 is_empty &= !current_batch_operations.iter().any(|op| match op.op {
                     GroveOp::Delete | GroveOp::DeleteTree(_) => false,
-                    // todo: fix for to_path (it clones)
-                    _ => op.path.to_path() == subtree_merk_path_vec,
+                    _ => op.path.eq_path_vec(&subtree_merk_path_vec),
                 });
 
                 let result = if !options.allow_deleting_non_empty_trees && !is_empty {


### PR DESCRIPTION
## Summary
- Add `KeyInfoPath::eq_path_vec()` for zero-allocation comparison against `Vec<Vec<u8>>` paths
- Replace two `to_path()` calls in the hot delete path that allocated a new `Vec<Vec<u8>>` on every batch operation comparison (had TODO comments acknowledging the issue)

Addresses audit finding P4.

## Test plan
- [x] All 110 delete tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized path comparison operations in delete functionality to reduce memory allocations and improve performance of subtree operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->