### PR TITLE
fix: handle Link::Uncommitted in verify_link instead of todo!()

### DIFF
--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -731,12 +731,17 @@ where
                 child_heights: _,
                 aggregate_data,
                 tree,
+            }
+            | Link::Uncommitted {
+                hash,
+                child_heights: _,
+                aggregate_data,
+                tree,
             } => (
                 hash.to_owned(),
                 tree.key().to_vec(),
                 aggregate_data.to_owned(),
             ),
-            _ => todo!(),
         };
 
         let instruction_id = traversal_instruction_as_vec_bytes(traversal_instruction);


### PR DESCRIPTION
## Summary
- **Audit finding E1**: The `verify_link` method in `merk/src/merk/mod.rs` contained a `_ => todo!()` wildcard arm that would panic at runtime if a `Link::Uncommitted` variant was encountered.
- `Link::Uncommitted` and `Link::Loaded` are now combined into a single match arm.
- The `_ => todo!()` arm is removed entirely, making the match exhaustive without a wildcard fallback.

## Context: What is `Link::Uncommitted`?

The `Link` enum in Merk represents a reference to a child tree node, with four variants tracking different lifecycle states:

| Variant | Hash up-to-date? | Committed to disk? | Tree in memory? |
|---------|------------------|--------------------|-----------------|
| `Reference` | Yes | Yes | No (only key stored) |
| `Modified` | **No** | No | Yes |
| `Uncommitted` | **Yes** | **No** | Yes |
| `Loaded` | Yes | Yes | Yes |

`Link::Uncommitted` represents a child node that has been modified and had its hash recomputed, but **has not yet been persisted to storage**. It has the exact same fields as `Link::Loaded` (`hash`, `child_heights`, `tree`, `aggregate_data`) — the only difference is that `Loaded` has been committed to the backing store while `Uncommitted` hasn't yet.

The verification logic in `verify_link` only needs the hash, key, and aggregate data to check correctness — it doesn't care about persistence state. So combining these two variants into one match arm is both correct and complete.

## Test plan
- [x] `cargo check -p grovedb-merk` compiles cleanly
- [ ] Existing merk tests pass (`cargo test -p grovedb-merk`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced state handling to support recognition and processing of additional data states, ensuring more comprehensive data handling across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->