### PR TITLE
fix: return empty maps instead of panicking on empty tree in Merk::verify()

### DIFF
--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -647,14 +647,16 @@ where
     ) -> (BTreeMap<Vec<u8>, CryptoHash>, BTreeMap<Vec<u8>, Vec<u8>>) {
         let tree = self.tree.take();
 
+        let Some(ref tree_node) = tree else {
+            return (BTreeMap::new(), BTreeMap::new());
+        };
+
         let mut bad_link_map: BTreeMap<Vec<u8>, CryptoHash> = BTreeMap::new();
         let mut parent_keys: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
         let mut root_traversal_instruction = vec![];
 
-        // TODO: remove clone
         self.verify_tree(
-            // TODO: handle unwrap
-            &tree.clone().unwrap(),
+            tree_node,
             &mut root_traversal_instruction,
             &mut bad_link_map,
             &mut parent_keys,


### PR DESCRIPTION
## Summary
- **Audit finding E2**: `Merk::verify()` called `.unwrap()` on `self.tree.take()`, which would panic if the internal tree was `None` (i.e., empty).
- Replaced the `.unwrap()` with a `let Some(ref tree_node) = tree else { ... }` guard that returns empty maps for an empty tree.
- This also removes the unnecessary `.clone()` on the tree, resolving the adjacent TODO comment.

## Why returning two empty `BTreeMap`s is correct

`Merk::verify()` returns `(BTreeMap<Vec<u8>, CryptoHash>, BTreeMap<Vec<u8>, Vec<u8>>)` where:
- The first map (`bad_link_map`) contains links that failed verification — keyed by traversal instruction, valued by the expected hash.
- The second map (`parent_keys`) contains the parent keys of those bad links.

An empty Merk has no tree nodes, therefore no links to verify, therefore no possible bad links. Returning two empty maps is the correct "all clear" result — it means "zero verification failures found," which is trivially true for an empty tree.

All callers check whether `bad_link_map.is_empty()` to determine success (e.g., `Restorer::finalize()` at `restore.rs:525`), so empty maps correctly signal a healthy (albeit empty) tree.

## Test plan
- [x] `cargo check -p grovedb-merk` passes
- [ ] CI passes all existing tests (no behavioral change for non-empty trees)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification stability by gracefully handling missing data structures instead of causing failures, and reduced memory overhead through more efficient data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->