### PR TITLE
fix: return error instead of panicking on missing old storage flags

### DIFF
--- a/grovedb-epoch-based-storage-flags/src/update_element_flags.rs
+++ b/grovedb-epoch-based-storage-flags/src/update_element_flags.rs
@@ -28,8 +28,13 @@ impl StorageFlags {
             .ok_or(StorageFlagsError::RemovingFlagsError(
                 "removing flags from an item with flags is not allowed".to_string(),
             ))?;
-        let binding = maybe_old_storage_flags.clone().unwrap();
-        let old_epoch_index_map = binding.epoch_index_map();
+        let old_storage_flags =
+            maybe_old_storage_flags
+                .clone()
+                .ok_or(StorageFlagsError::RemovingFlagsError(
+                    "old storage flags missing during update".to_string(),
+                ))?;
+        let old_epoch_index_map = old_storage_flags.epoch_index_map();
         let new_epoch_index_map = new_storage_flags.epoch_index_map();
         if old_epoch_index_map.is_some() || new_epoch_index_map.is_some() {
             // println!("> old:{:?} new:{:?}", old_epoch_index_map,


### PR DESCRIPTION
## Summary
- **Audit finding E3**: `update_element_flags()` in `grovedb-epoch-based-storage-flags` called `.unwrap()` on an `Option<StorageFlags>`, which would panic at runtime if `maybe_old_storage_flags` was `None`.
- Replaced the `.unwrap()` with `.ok_or(StorageFlagsError::RemovingFlagsError(...))` so that a `None` value produces a proper error return instead of a panic.
- All 41 existing tests continue to pass.

## Test plan
- [x] Verified `cargo build -p grovedb-epoch-based-storage-flags` compiles successfully
- [x] Verified `cargo test -p grovedb-epoch-based-storage-flags` passes all 41 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for storage state management by adding explicit validation and error messaging when critical storage information is unavailable, making the system more robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->