### PR TITLE
fix: return error instead of panicking on missing subquery in PathQuery::merge

### DIFF
--- a/grovedb/src/query/mod.rs
+++ b/grovedb/src/query/mod.rs
@@ -213,13 +213,19 @@ impl PathQuery {
             }
             path_query
                 .to_subquery_branch_with_offset_start_index(next_index)
-                .map(|unsized_path_query| {
+                .and_then(|unsized_path_query| {
                     if unsized_path_query.subquery_path.is_none() {
-                        queries_for_common_path_this_level
-                            .push(*unsized_path_query.subquery.unwrap());
+                        queries_for_common_path_this_level.push(
+                            *unsized_path_query
+                                .subquery
+                                .ok_or(Error::CorruptedCodeExecution(
+                                    "subquery must exist when subquery_path is none in merge",
+                                ))?,
+                        );
                     } else {
                         queries_for_common_path_sub_level.push(unsized_path_query);
                     }
+                    Ok(())
                 })
         })?;
 


### PR DESCRIPTION
## Summary

- **Audit finding E4**: Replaced `.unwrap()` with proper error handling in `PathQuery::merge()` (in `grovedb/src/query/mod.rs`). When `subquery_path` is `None` but `subquery` is also `None`, the code previously panicked via `.unwrap()`. It now returns `Error::CorruptedCodeExecution` with a descriptive message instead.
- Changed `.map()` to `.and_then()` to propagate the new error through the `Result` chain.

## Test plan

- [x] `cargo check -p grovedb` passes
- [x] Pre-commit hooks (fmt, typos, etc.) pass
- [ ] CI passes all existing tests (no behavioral change for valid inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)