### PR TITLE
fix: propagate errors instead of silently discarding in Restorer::finalize

### DIFF
--- a/merk/src/merk/restore.rs
+++ b/merk/src/merk/restore.rs
@@ -507,19 +507,33 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
         }
 
         // get the latest version of the root node
-        let _ = self.merk.load_base_root(
-            None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
-            grove_version,
-        );
+        self.merk
+            .load_base_root(
+                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                grove_version,
+            )
+            .value
+            .map_err(|_| {
+                Error::ChunkRestoringError(ChunkError::InternalError(
+                    "failed to load base root during finalize",
+                ))
+            })?;
 
         // if height values are wrong, rewrite height
         if self.verify_height(grove_version).is_err() {
-            let _ = self.rewrite_heights(grove_version);
+            self.rewrite_heights(grove_version)?;
             // update the root node after height rewrite
-            let _ = self.merk.load_base_root(
-                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
-                grove_version,
-            );
+            self.merk
+                .load_base_root(
+                    None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                    grove_version,
+                )
+                .value
+                .map_err(|_| {
+                    Error::ChunkRestoringError(ChunkError::InternalError(
+                        "failed to reload base root after height rewrite",
+                    ))
+                })?;
         }
 
         if !self


### PR DESCRIPTION
## Summary

- **Audit finding E5**: `Restorer::finalize()` in `merk/src/merk/restore.rs` had three `let _ =` patterns that silently discarded errors from `load_base_root` and `rewrite_heights`.
- Replace all three `let _ =` with proper error propagation: `load_base_root` results are extracted via `.value` and mapped to `ChunkRestoringError(InternalError(...))`, and `rewrite_heights` errors are propagated with `?`.
- This ensures that failures during finalization (loading the root node or rewriting tree heights) are reported to callers instead of being swallowed, preventing silent data corruption.

## Test plan

- [x] `cargo build -p grovedb-merk` compiles cleanly
- [ ] Existing merk restore/chunk tests continue to pass (`cargo test -p grovedb-merk`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)