### PR TITLE
fix: propagate error instead of silently discarding in Restorer::process_chunk

### DIFF
--- a/merk/src/merk/restore.rs
+++ b/merk/src/merk/restore.rs
@@ -105,9 +105,9 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
         let mut root_traversal_instruction = vec_bytes_as_traversal_instruction(chunk_id)?;
 
         if root_traversal_instruction.is_empty() {
-            let _ = self
-                .merk
-                .set_base_root_key(chunk_tree.key().map(|k| k.to_vec()));
+            self.merk
+                .set_base_root_key(chunk_tree.key().map(|k| k.to_vec()))
+                .value?;
         } else {
             // every non root chunk has some associated parent with an placeholder link
             // here we update the placeholder link to represent the true data


### PR DESCRIPTION
## Summary

- **Audit finding E6**: In `Restorer::process_chunk()`, the call to `self.merk.set_base_root_key(...)` returned a `CostResult<(), Error>` that was silently discarded via `let _ =`. If `set_base_root_key` fails (e.g., due to a storage error), the restorer would continue operating on corrupt state without any indication of failure.
- This fix extracts the inner `Result` via `.value` and propagates errors with `?`, matching the error-handling pattern used elsewhere in the same method.

## Test plan

- [x] Verified the crate compiles successfully with `cargo build -p grovedb-merk`
- [ ] Existing restore/chunk tests continue to pass (`cargo test -p grovedb-merk`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)