### PR TITLE
fix: return errors instead of panicking on Link::Modified in encoding and traversal

### DIFF
--- a/merk/src/tree/link.rs
+++ b/merk/src/tree/link.rs
@@ -295,7 +295,12 @@ impl Link {
                     key.len() + 52 // 1 + 32 + 2 + 1 + 16
                 }
             },
-            Link::Modified { .. } => panic!("No encoding for Link::Modified"),
+            Link::Modified { .. } => {
+                return Err(ed::Error::IOError(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "no encoding for Link::Modified",
+                )))
+            }
             Link::Uncommitted {
                 tree,
                 aggregate_data,
@@ -346,7 +351,12 @@ impl Encode for Link {
                 child_heights,
             } => (hash, aggregate_data, tree.key(), child_heights),
 
-            Link::Modified { .. } => panic!("No encoding for Link::Modified"),
+            Link::Modified { .. } => {
+                return Err(ed::Error::IOError(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "no encoding for Link::Modified",
+                )))
+            }
         };
 
         debug_assert!(key.len() < 256, "Key length must be less than 256");
@@ -454,7 +464,12 @@ impl Encode for Link {
                     key.len() + encoded_sum_value.len() + encoded_count_value.len() + 36
                 }
             },
-            Link::Modified { .. } => panic!("No encoding for Link::Modified"),
+            Link::Modified { .. } => {
+                return Err(ed::Error::IOError(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "no encoding for Link::Modified",
+                )))
+            }
             Link::Uncommitted {
                 tree,
                 aggregate_data,

--- a/merk/src/tree/walk/ref_walker.rs
+++ b/merk/src/tree/walk/ref_walker.rs
@@ -75,7 +75,10 @@ where
                     return Err(e).wrap_with_cost(cost);
                 }
             }
-            Link::Modified { .. } => panic!("Cannot traverse Link::Modified"),
+            Link::Modified { .. } => {
+                return Err(Error::CorruptedState("cannot traverse Link::Modified"))
+                    .wrap_with_cost(cost)
+            }
             Link::Uncommitted { .. } | Link::Loaded { .. } => {}
         }
 


### PR DESCRIPTION
## Summary

- **Audit finding E7**: Replaced `panic!` calls with proper error returns in 4 locations where `Link::Modified` was encountered unexpectedly
- In `merk/src/tree/link.rs`: replaced 3 panics in `encoding_cost()`, `encode_into()`, and `encoding_length()` with `Err(ed::Error::IOError(...))` returns
- In `merk/src/tree/walk/ref_walker.rs`: replaced 1 panic in `walk()` with `Err(Error::CorruptedState(...))` return using `wrap_with_cost`

These functions already return `Result` types, so the panics were unnecessary and could cause process crashes in production instead of propagating errors gracefully.

## Test plan

- [x] `cargo build -p grovedb-merk` compiles successfully
- [x] `cargo test -p grovedb-merk` — all 329 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in tree operations to gracefully manage edge cases that previously caused system failures, improving overall stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->