### PR TITLE
fix: replace panic with debug_assert in StorageFlags serialization

### DIFF
--- a/grovedb-epoch-based-storage-flags/src/lib.rs
+++ b/grovedb-epoch-based-storage-flags/src/lib.rs
@@ -444,9 +444,10 @@ impl StorageFlags {
     fn maybe_append_to_vec_epoch_map(&self, buffer: &mut Vec<u8>) {
         match self {
             MultiEpoch(_, epoch_map) | MultiEpochOwned(_, epoch_map, _) => {
-                if epoch_map.is_empty() {
-                    panic!("this should not be empty");
-                }
+                debug_assert!(
+                    !epoch_map.is_empty(),
+                    "epoch map should not be empty for MultiEpoch/MultiEpochOwned"
+                );
                 epoch_map.iter().for_each(|(epoch_index, bytes_added)| {
                     buffer.extend(epoch_index.to_be_bytes());
                     buffer.extend(bytes_added.encode_var_vec());
@@ -1778,8 +1779,9 @@ mod storage_flags_additional_tests {
     }
 
     #[test]
-    #[should_panic(expected = "this should not be empty")]
-    fn serialize_panics_for_empty_epoch_map() {
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "epoch map should not be empty")]
+    fn serialize_debug_asserts_for_empty_epoch_map() {
         let flags = StorageFlags::MultiEpoch(1, BTreeMap::new());
         let _ = flags.serialize();
     }


### PR DESCRIPTION
## Summary

- **Audit finding E8**: The `maybe_append_to_vec_epoch_map` method in `StorageFlags` used `panic!("this should not be empty")` when encountering an empty epoch map during serialization of `MultiEpoch`/`MultiEpochOwned` variants. This could crash production systems.
- Replaced the `panic!` with `debug_assert!` so the invariant is still checked during development and testing, but does not crash in release builds.
- Updated the corresponding test to use `#[cfg(debug_assertions)]` and match the new assertion message.

## Test plan

- [x] All 41 tests in `grovedb-epoch-based-storage-flags` pass
- [x] The renamed test `serialize_debug_asserts_for_empty_epoch_map` verifies the debug assertion fires in debug builds
- [x] Pre-commit hooks pass (fmt, clippy, typos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modified error handling to use debug assertions instead of runtime panics for epoch map validation, improving production build behavior.

* **Tests**
  * Updated test expectations to reflect debug assertion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->