### PR TITLE
fix: preserve original error information in map_err calls

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1199,8 +1199,8 @@ where
         if let Some(referenced_element) = referenced_element {
             let element = cost_return_on_error_no_add!(
                 cost,
-                Element::deserialize(referenced_element.as_slice(), grove_version).map_err(|_| {
-                    Error::CorruptedData(String::from("unable to deserialize element"))
+                Element::deserialize(referenced_element.as_slice(), grove_version).map_err(|e| {
+                    Error::CorruptedData(format!("unable to deserialize element: {e}"))
                 })
             );
 
@@ -1601,7 +1601,7 @@ where
 
         merk.set_base_root_key(root_key)
             .add_cost(cost)
-            .map_err(|_| Error::InternalError("unable to set base root key".to_string()))
+            .map_err(|e| Error::InternalError(format!("unable to set base root key: {e}")))
     }
 
     fn execute_ops_on_path(
@@ -1801,8 +1801,8 @@ where
                         );
                         cost_return_on_error_no_add!(
                             cost,
-                            Element::deserialize(value.as_slice(), grove_version).map_err(|_| {
-                                Error::CorruptedData(String::from("unable to deserialize element"))
+                            Element::deserialize(value.as_slice(), grove_version).map_err(|e| {
+                                Error::CorruptedData(format!("unable to deserialize element: {e}"))
                             })
                         )
                     };
@@ -2930,8 +2930,10 @@ impl GroveDb {
                         Some(&Element::value_defined_cost_for_serialized_value),
                         grove_version,
                     )
-                    .map_err(|_| {
-                        Error::CorruptedData("cannot open a subtree with given root key".to_owned())
+                    .map_err(|e| {
+                        Error::CorruptedData(format!(
+                            "cannot open a subtree with given root key: {e}"
+                        ))
                     })
                     .add_cost(cost)
                 } else {
@@ -2955,7 +2957,7 @@ impl GroveDb {
                 Some(&Element::value_defined_cost_for_serialized_value),
                 grove_version,
             )
-            .map_err(|_| Error::CorruptedData("cannot open a the root subtree".to_owned()))
+            .map_err(|e| Error::CorruptedData(format!("cannot open the root subtree: {e}")))
             .add_cost(cost)
         }
     }

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -382,10 +382,10 @@ impl GroveDb {
                 Some(&Element::value_defined_cost_for_serialized_value),
                 grove_version,
             )
-            .map_err(|_| {
-                Error::CorruptedData(
-                    "cannot open a subtree by prefix with given root key".to_owned(),
-                )
+            .map_err(|e| {
+                Error::CorruptedData(format!(
+                    "cannot open a subtree by prefix with given root key: {e}"
+                ))
             })
             .add_cost(cost)
         } else {
@@ -395,7 +395,7 @@ impl GroveDb {
                 Some(&Element::value_defined_cost_for_serialized_value),
                 grove_version,
             )
-            .map_err(|_| Error::CorruptedData("cannot open a root subtree by prefix".to_owned()))
+            .map_err(|e| Error::CorruptedData(format!("cannot open a root subtree by prefix: {e}")))
             .add_cost(cost)
         }
     }
@@ -441,8 +441,10 @@ impl GroveDb {
                         Some(&Element::value_defined_cost_for_serialized_value),
                         grove_version,
                     )
-                    .map_err(|_| {
-                        Error::CorruptedData("cannot open a subtree with given root key".to_owned())
+                    .map_err(|e| {
+                        Error::CorruptedData(format!(
+                            "cannot open a subtree with given root key: {e}"
+                        ))
                     })
                     .unwrap()?,
                     root_key,
@@ -461,7 +463,7 @@ impl GroveDb {
                     None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
                     grove_version,
                 )
-                .map_err(|_| Error::CorruptedData("cannot open a the root subtree".to_owned()))
+                .map_err(|e| Error::CorruptedData(format!("cannot open the root subtree: {e}")))
                 .unwrap()?,
                 None,
                 TreeType::NormalTree,
@@ -522,8 +524,8 @@ impl GroveDb {
                     grove_version,
                 )
                 .map(|merk_res| {
-                    merk_res.map_err(|_| {
-                        crate::Error::CorruptedData("cannot open a subtree".to_owned())
+                    merk_res.map_err(|e| {
+                        crate::Error::CorruptedData(format!("cannot open a subtree: {e}"))
                     })
                 })
             })
@@ -719,8 +721,10 @@ impl GroveDb {
                 Some(&Element::value_defined_cost_for_serialized_value),
                 grove_version,
             )
-            .map_err(|_| {
-                Error::InvalidPath("can't find subtree in parent during propagation".to_owned())
+            .map_err(|e| {
+                Error::InvalidPath(format!(
+                    "can't find subtree in parent during propagation: {e}"
+                ))
             })
             .map_ok(|subtree_opt| {
                 subtree_opt.ok_or_else(|| {
@@ -739,10 +743,10 @@ impl GroveDb {
             })
             .flatten()
             .map_ok(|element_bytes| {
-                Element::deserialize(&element_bytes, grove_version).map_err(|_| {
-                    Error::CorruptedData(
-                        "failed to deserialized parent during propagation".to_owned(),
-                    )
+                Element::deserialize(&element_bytes, grove_version).map_err(|e| {
+                    Error::CorruptedData(format!(
+                        "failed to deserialize parent during propagation: {e}"
+                    ))
                 })
             })
             .flatten()


### PR DESCRIPTION
## Summary

- **Audit finding E9**: 12 occurrences of `map_err(|_| ...)` were discarding the original error, making debugging harder.
- Changed all 12 sites to `map_err(|e| ...)` with `format!("...: {e}")` so the underlying error is preserved in the message.
- 7 fixes in `grovedb/src/lib.rs`, 5 fixes in `grovedb/src/batch/mod.rs`.
- Also fixed two minor typos in error messages: "cannot open a the root subtree" -> "cannot open the root subtree" and "failed to deserialized" -> "failed to deserialize".

## Test plan

- [x] `cargo build --features full` compiles successfully
- [x] No remaining `map_err(|_|` patterns in either file
- [ ] Existing tests continue to pass (`cargo test -p grovedb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)