### PR TITLE
fix: use u32 for element count in pack/unpack_nested_bytes to prevent truncation

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -476,8 +476,9 @@ pub(crate) mod utils {
     /// vector.
     ///
     /// The encoding format is as follows:
-    /// 1. The first byte stores the number of elements.
-    /// 2. Each element is prefixed with its length as a 2-byte (`u16`) value in
+    /// 1. The first four bytes store the number of elements as a `u32` in
+    ///    big-endian format.
+    /// 2. Each element is prefixed with its length as a 4-byte (`u32`) value in
     ///    big-endian format.
     /// 3. The actual byte sequence of the element is then appended.
     ///
@@ -493,8 +494,8 @@ pub(crate) mod utils {
     pub fn pack_nested_bytes(nested_bytes: Vec<Vec<u8>>) -> Vec<u8> {
         let mut packed_data = Vec::new();
 
-        // Store the number of elements (2 bytes)
-        packed_data.extend_from_slice(&(nested_bytes.len() as u16).to_be_bytes());
+        // Store the number of elements (4 bytes)
+        packed_data.extend_from_slice(&(nested_bytes.len() as u32).to_be_bytes());
 
         for bytes in nested_bytes {
             // Store length as 4 bytes (big-endian)
@@ -514,8 +515,9 @@ pub(crate) mod utils {
     /// representation.
     ///
     /// # Encoding Format:
-    /// - The first two bytes represents the number of nested byte arrays.
-    /// - Each nested array is prefixed with a **2-byte (u16) length** in
+    /// - The first four bytes represent the number of nested byte arrays
+    ///   (u32, big-endian).
+    /// - Each nested array is prefixed with a **4-byte (u32) length** in
     ///   big-endian format.
     /// - The byte sequence of each nested array follows.
     ///
@@ -536,14 +538,21 @@ pub(crate) mod utils {
     /// - The number of expected chunks does not match the actual data length.
     /// - The data is truncated or malformed.
     pub fn unpack_nested_bytes(packed_data: &[u8]) -> Result<Vec<Vec<u8>>, Error> {
-        if packed_data.is_empty() {
-            return Err(Error::CorruptedData("Input data is empty".to_string()));
+        if packed_data.len() < 4 {
+            return Err(Error::CorruptedData(
+                "Input data is too short to contain element count".to_string(),
+            ));
         }
 
-        // Read num_elements as u16 (big-endian)
-        let num_elements = u16::from_be_bytes([packed_data[0], packed_data[1]]) as usize;
+        // Read num_elements as u32 (big-endian)
+        let num_elements = u32::from_be_bytes([
+            packed_data[0],
+            packed_data[1],
+            packed_data[2],
+            packed_data[3],
+        ]) as usize;
         let mut nested_bytes = Vec::with_capacity(num_elements);
-        let mut index = 2;
+        let mut index = 4;
 
         for i in 0..num_elements {
             // Ensure there is enough data to read the 4-byte length

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -551,6 +551,17 @@ pub(crate) mod utils {
             packed_data[2],
             packed_data[3],
         ]) as usize;
+
+        // Each element requires at least 4 bytes for its length prefix, so
+        // num_elements cannot exceed the remaining data divided by 4.
+        let remaining = packed_data.len() - 4;
+        let max_elements = remaining / 4;
+        if num_elements > max_elements {
+            return Err(Error::CorruptedData(format!(
+                "Declared element count ({num_elements}) exceeds what the input can hold ({max_elements} max)"
+            )));
+        }
+
         let mut nested_bytes = Vec::with_capacity(num_elements);
         let mut index = 4;
 

--- a/grovedb/src/tests/replication_utils_tests.rs
+++ b/grovedb/src/tests/replication_utils_tests.rs
@@ -137,7 +137,7 @@ mod tests {
     fn unpack_truncated_bytes_error_missing_element_data() {
         // Header says 1 element, but no length/data follows
         let mut packed = vec![];
-        packed.extend_from_slice(&1u16.to_be_bytes()); // num_elements = 1
+        packed.extend_from_slice(&1u32.to_be_bytes()); // num_elements = 1
                                                        // No length bytes or data follow
         let result = unpack_nested_bytes(&packed);
         assert!(
@@ -149,11 +149,11 @@ mod tests {
     #[test]
     fn unpack_truncated_bytes_error_incomplete_length_prefix() {
         // Header says 1 element, but only 1-3 bytes of the 4-byte length prefix
-        // are present. This exercises the boundary where the guard (index + 1)
-        // is weaker than the subsequent 4-byte read.
+        // are present. This exercises the boundary where the guard (index + 4)
+        // catches insufficient data for the subsequent 4-byte read.
         for trailing in 1..=3u8 {
             let mut packed = vec![];
-            packed.extend_from_slice(&1u16.to_be_bytes()); // num_elements = 1
+            packed.extend_from_slice(&1u32.to_be_bytes()); // num_elements = 1
             packed.extend(vec![0xAA; trailing as usize]); // partial length prefix
             let result = unpack_nested_bytes(&packed);
             assert!(
@@ -167,7 +167,7 @@ mod tests {
     fn unpack_truncated_bytes_error_short_element_content() {
         // Header says 1 element of length 10, but only 3 bytes of content provided
         let mut packed = vec![];
-        packed.extend_from_slice(&1u16.to_be_bytes()); // num_elements = 1
+        packed.extend_from_slice(&1u32.to_be_bytes()); // num_elements = 1
         packed.extend_from_slice(&10u32.to_be_bytes()); // element length = 10
         packed.extend_from_slice(&[0xAA, 0xBB, 0xCC]); // only 3 bytes
         let result = unpack_nested_bytes(&packed);


### PR DESCRIPTION
## Summary

- **Security finding S1**: `pack_nested_bytes` encoded the element count as `u16`, silently truncating if there were more than 65,535 elements. Changed to `u32` to support up to ~4 billion elements.
- Updated `unpack_nested_bytes` to read a 4-byte `u32` element count instead of 2-byte `u16`, and improved the initial bounds check from `is_empty()` to `len() < 4` (also fixes related finding L1 about a potential panic on 1-byte input).
- Updated doc comments on both functions to reflect the new encoding format.
- Updated tests that hard-coded the old `u16` header format.

## Breaking Change

This is a **breaking change to the wire format** for replication data. Packed data produced by the new code is not compatible with the old decoder, and vice versa. Any peers communicating via `pack_nested_bytes` / `unpack_nested_bytes` must be upgraded together.

## Test plan

- [x] `cargo test -p grovedb --lib -- replication` — all 39 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced data validation and error detection for replication data handling with more comprehensive boundary checks and error reporting for corrupted or incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->