### PR TITLE
fix: clamp BigSum values to i64 range in as_sum_i64()

### DIFF
--- a/merk/src/tree/tree_feature_type.rs
+++ b/merk/src/tree/tree_feature_type.rs
@@ -52,9 +52,10 @@ impl AggregateData {
             AggregateData::NoAggregateData => 0,
             AggregateData::Sum(s) => *s,
             AggregateData::BigSum(i) => {
-                let max = i64::MAX as i128;
-                if *i > max {
+                if *i > i64::MAX as i128 {
                     i64::MAX
+                } else if *i < i64::MIN as i128 {
+                    i64::MIN
                 } else {
                     *i as i64
                 }
@@ -154,6 +155,11 @@ mod tests {
         assert_eq!(
             AggregateData::BigSum(i64::MAX as i128 + 1).as_sum_i64(),
             i64::MAX
+        );
+        // BigSum underflow => saturates to i64::MIN
+        assert_eq!(
+            AggregateData::BigSum(i64::MIN as i128 - 1).as_sum_i64(),
+            i64::MIN
         );
         assert_eq!(AggregateData::Count(99).as_sum_i64(), 0);
         assert_eq!(AggregateData::CountAndSum(5, 20).as_sum_i64(), 20);


### PR DESCRIPTION
## Summary

- **Finding L3**: `as_sum_i64()` on `AggregateData::BigSum` only checked for values above `i64::MAX`, silently truncating values below `i64::MIN` via an unchecked `as i64` cast. This adds the missing lower-bound check so that BigSum values are properly clamped to the full `i64` range (`i64::MIN..=i64::MAX`).
- Added a test case for underflow saturation to `i64::MIN`.

## Test plan

- [x] Existing `aggregate_data_as_sum_i64_all_variants` test passes (upper bound saturation)
- [x] New assertion for `BigSum(i64::MIN as i128 - 1)` saturating to `i64::MIN` passes
- [x] All 5 `tree_feature_type` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of aggregate data operations by implementing proper boundary handling for large numerical values, preventing overflow and underflow issues.

* **Tests**
  * Added test coverage for underflow saturation scenarios in aggregate data calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->