### PR TITLE
fix: use absolute value in sum limit budget consumption

### DIFF
--- a/grovedb/src/element/aggregate_sum_query/mod.rs
+++ b/grovedb/src/element/aggregate_sum_query/mod.rs
@@ -778,7 +778,7 @@ impl ElementAggregateSumQueryExtensions for Element {
             *limit = limit.saturating_sub(1);
         }
 
-        *sum_limit_left = sum_limit_left.saturating_sub(value);
+        *sum_limit_left = sum_limit_left.saturating_sub(value.saturating_abs());
 
         Ok(())
     }

--- a/grovedb/src/element/aggregate_sum_query/tests.rs
+++ b/grovedb/src/element/aggregate_sum_query/tests.rs
@@ -2536,9 +2536,9 @@ fn test_negative_sum_values() {
     .unwrap()
     .expect("cannot insert element");
 
-    // sum_limit=12: a(10) leaves 2, b(-3) increases remaining to 5, c(5) leaves 0
-    // All three should be returned
-    let aggregate_sum_query = AggregateSumQuery::new(12, None);
+    // sum_limit=18: a(10) leaves 8, b(|-3|=3) leaves 5, c(5) leaves 0
+    // All three should be returned because budget is consumed by absolute values
+    let aggregate_sum_query = AggregateSumQuery::new(18, None);
     let aggregate_sum_path_query = AggregateSumPathQuery {
         path: vec![TEST_LEAF.to_vec()],
         aggregate_sum_query,
@@ -2559,7 +2559,30 @@ fn test_negative_sum_values() {
         vec![(b"a".to_vec(), 10), (b"b".to_vec(), -3), (b"c".to_vec(), 5),]
     );
 
-    // sum_limit=8: a(10) leaves -2, which is <= 0, so stop after a
+    // sum_limit=12: a(10) leaves 2, b(|-3|=3) leaves 0 (saturated), stop after b
+    // Negative items consume budget by their absolute value, not increase it
+    let aggregate_sum_query = AggregateSumQuery::new(12, None);
+    let aggregate_sum_path_query = AggregateSumPathQuery {
+        path: vec![TEST_LEAF.to_vec()],
+        aggregate_sum_query,
+    };
+
+    let result = Element::get_aggregate_sum_query(
+        &db.db,
+        &aggregate_sum_path_query,
+        AggregateSumQueryOptions::default(),
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("expected successful get_query");
+
+    assert_eq!(
+        result.results,
+        vec![(b"a".to_vec(), 10), (b"b".to_vec(), -3)]
+    );
+
+    // sum_limit=8: a(10) leaves -2, which saturates to 0, so stop after a
     let aggregate_sum_query = AggregateSumQuery::new(8, None);
     let aggregate_sum_path_query = AggregateSumPathQuery {
         path: vec![TEST_LEAF.to_vec()],


### PR DESCRIPTION
## Summary

- **Finding L4**: `saturating_sub(value)` on negative SumItems increases the budget instead of decreasing it
- In `basic_aggregate_sum_push`, `sum_limit_left.saturating_sub(value)` adds to the remaining budget when `value` is negative, because subtracting a negative number is addition. This could allow bypassing sum limits by exploiting negative SumItems to artificially inflate the remaining budget.
- Fix: use `value.saturating_abs()` so that negative sum items consume budget proportional to their magnitude, preventing budget bypass.
- Updated the `test_negative_sum_values` test to reflect the correct behavior: negative items should consume budget (not increase it), and added an additional test case verifying that a budget of 12 correctly stops after processing items with absolute values totaling 13 (10 + 3).

## Test plan

- [x] `cargo test -p grovedb aggregate_sum` — all 51 tests pass
- [x] `cargo clippy -p grovedb -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)