### PR TITLE
fix: remove dead code guards in duplicate detection loop

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -806,13 +806,9 @@ impl QualifiedGroveDbOp {
             .map(|op| (op.clone(), 1))
             .collect();
 
-        let ops_len = ops.len();
         // operations should not have any duplicates
         let mut repeated_ops = internal_only_ops;
         for (i, op) in ops.iter().enumerate() {
-            if i == ops_len {
-                continue;
-            } // Don't do last one
             let count = ops
                 .split_at(i + 1)
                 .1
@@ -829,9 +825,6 @@ impl QualifiedGroveDbOp {
         // No double insert or delete of same key in same path.
         // Keyless ops (append-only tree ops) can't conflict — skip them.
         for (i, op) in ops.iter().enumerate() {
-            if i == ops_len {
-                continue;
-            } // Don't do last one
             if op.key.is_none() {
                 continue;
             } // Keyless ops can't conflict


### PR DESCRIPTION
## Summary

- **Finding L6**: The `verify_consistency_of_operations` function in `grovedb/src/batch/mod.rs` contained two `if i == ops_len { continue; }` guards in its duplicate detection loops. Since `ops.iter().enumerate()` yields indices `0..ops_len-1`, the condition `i == ops_len` is never true, making these guards dead code.
- The loops already work correctly without the guards: when `i` is the last index, `split_at(i+1).1` returns an empty slice, so the inner filter finds nothing.
- Also removes the now-unused `ops_len` variable.

## Test plan

- [x] `cargo build -p grovedb` compiles cleanly
- [x] All 295 batch-related tests pass (`cargo test -p grovedb batch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized batch operation processing by removing redundant boundary checks. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->