### PR TITLE
fix: correct version check function name in prove_query

### DIFF
--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -73,7 +73,7 @@ impl GroveDb {
         grove_version: &GroveVersion,
     ) -> CostResult<Vec<u8>, Error> {
         check_grovedb_v0_with_cost!(
-            "prove_query_many",
+            "prove_query",
             grove_version.grovedb_versions.operations.proof.prove_query
         );
         let mut cost = OperationCost::default();


### PR DESCRIPTION
## Summary

- **Finding A1**: The `check_grovedb_v0_with_cost!` macro call in `prove_query` (line 76 of `grovedb/src/operations/proof/generate.rs`) incorrectly used the string `"prove_query_many"` as the function name identifier. This is a copy-paste error from the neighboring `prove_query_many` method. The correct name is `"prove_query"`.

## Test plan

- [x] Verified the fix is limited to a single string literal change
- [x] Confirmed the neighboring `prove_query_many` method retains its correct label
- [x] Pre-commit hooks pass (fmt, clippy, typos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)