### PR TITLE
fix: change clear_subtree to return CostResult for API consistency

### DIFF
--- a/grovedb/src/operations/delete/mod.rs
+++ b/grovedb/src/operations/delete/mod.rs
@@ -164,13 +164,12 @@ impl GroveDb {
         options: Option<ClearOptions>,
         transaction: TransactionArg,
         grove_version: &GroveVersion,
-    ) -> Result<bool, Error>
+    ) -> CostResult<bool, Error>
     where
         B: AsRef<[u8]> + 'b,
         P: Into<SubtreePath<'b, B>>,
     {
         self.clear_subtree_with_costs(path, options, transaction, grove_version)
-            .unwrap()
     }
 
     /// Delete all elements in a specified subtree and get back costs
@@ -1803,6 +1802,7 @@ mod tests {
 
         let root_hash_before_clear = db.root_hash(None, grove_version).unwrap().unwrap();
         db.clear_subtree([TEST_LEAF, b"key1"].as_ref(), None, None, grove_version)
+            .unwrap()
             .expect_err("unable to delete subtree");
 
         let success = db
@@ -1816,6 +1816,7 @@ mod tests {
                 None,
                 grove_version,
             )
+            .unwrap()
             .expect("expected no error");
         assert!(!success);
 
@@ -1830,6 +1831,7 @@ mod tests {
                 None,
                 grove_version,
             )
+            .unwrap()
             .expect("unable to delete subtree");
 
         assert!(success);

--- a/grovedb/src/tests/operations_coverage_tests.rs
+++ b/grovedb/src/tests/operations_coverage_tests.rs
@@ -561,6 +561,7 @@ mod tests {
                 None,
                 grove_version,
             )
+            .unwrap()
             .expect("should clear subtree");
         assert!(cleared, "clear_subtree should return true on success");
 
@@ -2542,16 +2543,18 @@ mod tests {
         // Clear with check_for_subtrees=true, allow_deleting_subtrees=false,
         // trying_to_clear_with_subtrees_returns_error=true
         use crate::operations::delete::ClearOptions;
-        let result = db.clear_subtree(
-            [TEST_LEAF, b"parent"].as_ref(),
-            Some(ClearOptions {
-                check_for_subtrees: true,
-                allow_deleting_subtrees: false,
-                trying_to_clear_with_subtrees_returns_error: true,
-            }),
-            None,
-            grove_version,
-        );
+        let result = db
+            .clear_subtree(
+                [TEST_LEAF, b"parent"].as_ref(),
+                Some(ClearOptions {
+                    check_for_subtrees: true,
+                    allow_deleting_subtrees: false,
+                    trying_to_clear_with_subtrees_returns_error: true,
+                }),
+                None,
+                grove_version,
+            )
+            .unwrap();
 
         assert!(
             matches!(result, Err(Error::ClearingTreeWithSubtreesNotAllowed(_))),
@@ -2601,6 +2604,7 @@ mod tests {
                 None,
                 grove_version,
             )
+            .unwrap()
             .expect("should not error");
 
         assert!(
@@ -2660,6 +2664,7 @@ mod tests {
                 None,
                 grove_version,
             )
+            .unwrap()
             .expect("should clear subtree with subtree deletion allowed");
 
         assert!(cleared, "should return true on successful clear");


### PR DESCRIPTION
## Summary

- **Finding A3**: `clear_subtree` was the only mutation method returning `Result<bool, Error>` instead of `CostResult<bool, Error>`, discarding accumulated operation costs by calling `.unwrap()` on the inner `CostResult`.
- Changed `clear_subtree` to return `CostResult<bool, Error>` and delegate directly to `clear_subtree_with_costs`, matching the return type convention used by all other mutation operations in GroveDB.
- Updated all callers (tests in `delete/mod.rs` and `operations_coverage_tests.rs`) to call `.unwrap()` on the `CostResult` before handling the inner `Result`.

## Test plan

- [x] All existing `clear_subtree` tests pass (`test_subtree_clear`, `clear_subtree_with_items`, `clear_subtree_with_subtrees_not_allowed_error`, `clear_subtree_with_subtrees_not_allowed_returns_false`, `clear_subtree_allowing_subtree_deletion`)
- [x] Full crate build succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)