### PR TITLE
docs: mark internal-only GroveOp variants to prevent misuse

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -165,9 +165,15 @@ impl NonMerkTreeMeta {
     }
 }
 
-/// Operations
+/// Operations for batch processing.
+///
+/// User-facing variants: `InsertOnly`, `InsertOrReplace`, `Replace`, `Patch`,
+/// `RefreshReference`, `Delete`, `DeleteTree`, `CommitmentTreeInsert`,
+/// `MmrTreeAppend`, `BulkAppend`, `DenseTreeInsert`.
+/// Other variants are internal and produced by batch propagation.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum GroveOp {
+    /// **Internal only — do not construct directly.**
     /// Replace tree root key for standard Merk trees.
     ///
     /// Used by propagation to update an existing Merk tree's root hash
@@ -202,6 +208,7 @@ pub enum GroveOp {
         /// Byte change
         change_in_bytes: i32,
     },
+    /// **Internal only — do not construct directly.**
     /// Insert tree with root hash for standard Merk trees.
     ///
     /// Created during batch propagation from an `InsertOrReplace`/`InsertOnly`
@@ -217,6 +224,7 @@ pub enum GroveOp {
         /// Aggregate Data such as sum
         aggregate_data: AggregateData,
     },
+    /// **Internal only — do not construct directly.**
     /// Replace root hash for a non-Merk tree (CommitmentTree, MmrTree,
     /// BulkAppendTree, DenseTree). Produced by preprocessing functions.
     ReplaceNonMerkTreeRoot {
@@ -225,6 +233,7 @@ pub enum GroveOp {
         /// Tree-type-specific metadata (count, chunk_power, height, etc.).
         meta: NonMerkTreeMeta,
     },
+    /// **Internal only — do not construct directly.**
     /// Insert a non-Merk tree with root hash during propagation.
     ///
     /// Created when propagation encounters an occupied entry that is a


### PR DESCRIPTION
## Summary

**Audit finding A4**: The `GroveOp` enum is fully `pub` but includes four internal-only variants (`ReplaceTreeRootKey`, `InsertTreeWithRootHash`, `ReplaceNonMerkTreeRoot`, `InsertNonMerkTree`) that users should never construct directly. These variants are produced by batch propagation/preprocessing and constructing them manually would create invalid operations.

Since Rust does not allow individual enum variants to have restricted visibility (`pub(crate)`), this PR adds clear `**Internal only — do not construct directly.**` doc-comment warnings on each of the four internal variants and updates the enum-level documentation to explicitly list which variants are user-facing.

- Added enum-level doc comment listing user-facing vs internal variants
- Added `**Internal only — do not construct directly.**` prefix to `ReplaceTreeRootKey`, `InsertTreeWithRootHash`, `ReplaceNonMerkTreeRoot`, and `InsertNonMerkTree` doc comments

## Test plan

- [x] Documentation-only change; no behavioral changes
- [x] Verified `cargo build` succeeds (pre-commit hooks pass)
- [x] Confirmed all four internal variants are annotated

🤖 Generated with [Claude Code](https://claude.com/claude-code)