### PR TITLE
perf: use range deletion for wipe instead of per-key iteration

### DIFF
--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -468,16 +468,20 @@ impl RocksDbStorage {
             return Ok(()); // CF is already empty
         };
         iter.seek_to_last();
-        let last_key = iter
-            .key()
-            .expect("CF has at least one key since first_key exists");
+        let Some(last_key) = iter.key() else {
+            return Ok(());
+        };
         // delete_range_cf is [from, to) exclusive — extend last_key by a zero byte
         // to ensure it's included in the range.
         let mut upper = last_key.to_vec();
         upper.push(0);
         self.db
             .delete_range_cf(&cf_handle, first_key, upper)
-            .map_err(RocksDBError)?;
+            .map_err(|e| {
+                Error::StorageError(format!(
+                    "wipe_column_family({column_family_name}) delete_range_cf failed: {e}"
+                ))
+            })?;
         Ok(())
     }
 }

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -440,15 +440,18 @@ impl RocksDbStorage {
         }
     }
 
-    /// Destroys the OptimisticTransactionDB and drops instance
+    /// Clears all data from the database using range deletion on each
+    /// column family. Uses a single range tombstone per CF instead of
+    /// iterating and deleting every key individually.
     pub fn wipe(&self) -> Result<(), Error> {
-        // TODO: fix this
-        // very inefficient way of doing this, time complexity is O(n)
-        // we can do O(1)
-        self.wipe_column_family(DEFAULT_COLUMN_FAMILY_NAME)?;
-        self.wipe_column_family(ROOTS_CF_NAME)?;
-        self.wipe_column_family(AUX_CF_NAME)?;
-        self.wipe_column_family(META_CF_NAME)?;
+        for cf_name in [
+            DEFAULT_COLUMN_FAMILY_NAME,
+            ROOTS_CF_NAME,
+            AUX_CF_NAME,
+            META_CF_NAME,
+        ] {
+            self.wipe_column_family(cf_name)?;
+        }
         Ok(())
     }
 
@@ -461,11 +464,20 @@ impl RocksDbStorage {
             ))?;
         let mut iter = self.db.raw_iterator_cf(&cf_handle);
         iter.seek_to_first();
-        while iter.valid() {
-            let key = iter.key().expect("should have key").to_vec();
-            self.db.delete_cf(&cf_handle, key)?;
-            iter.next()
-        }
+        let Some(first_key) = iter.key().map(|k| k.to_vec()) else {
+            return Ok(()); // CF is already empty
+        };
+        iter.seek_to_last();
+        let last_key = iter
+            .key()
+            .expect("CF has at least one key since first_key exists");
+        // delete_range_cf is [from, to) exclusive — extend last_key by a zero byte
+        // to ensure it's included in the range.
+        let mut upper = last_key.to_vec();
+        upper.push(0);
+        self.db
+            .delete_range_cf(&cf_handle, first_key, upper)
+            .map_err(RocksDBError)?;
         Ok(())
     }
 }

--- a/storage/src/rocksdb_storage/tests.rs
+++ b/storage/src/rocksdb_storage/tests.rs
@@ -1340,4 +1340,109 @@ mod storage_management {
         assert!(verify_context.get_root(b"rk").unwrap().unwrap().is_none());
         assert!(verify_context.get_meta(b"mk").unwrap().unwrap().is_none());
     }
+
+    #[test]
+    fn test_wipe_range_deletion_with_many_keys() {
+        let storage = TempStorage::new();
+        let tx = storage.start_transaction();
+        let context = storage
+            .get_immediate_storage_context([b"many"].as_ref().into(), &tx)
+            .unwrap();
+
+        // Insert many keys across all column families
+        for i in 0u32..100 {
+            let key = format!("key_{:04}", i);
+            let val = format!("val_{}", i);
+            context
+                .put(key.as_bytes(), val.as_bytes(), None, None)
+                .unwrap()
+                .unwrap();
+            context
+                .put_aux(key.as_bytes(), val.as_bytes(), None)
+                .unwrap()
+                .unwrap();
+            context
+                .put_root(key.as_bytes(), val.as_bytes(), None)
+                .unwrap()
+                .unwrap();
+            context
+                .put_meta(key.as_bytes(), val.as_bytes(), None)
+                .unwrap()
+                .unwrap();
+        }
+
+        storage
+            .commit_transaction(tx)
+            .unwrap()
+            .expect("tx commit should succeed");
+
+        storage.wipe().expect("wipe should succeed");
+
+        // Verify all keys are gone
+        let verify_tx = storage.start_transaction();
+        let verify_ctx = storage
+            .get_immediate_storage_context([b"many"].as_ref().into(), &verify_tx)
+            .unwrap();
+
+        for i in 0u32..100 {
+            let key = format!("key_{:04}", i);
+            assert!(
+                verify_ctx.get(key.as_bytes()).unwrap().unwrap().is_none(),
+                "default CF key {key} should be gone after wipe"
+            );
+            assert!(
+                verify_ctx
+                    .get_aux(key.as_bytes())
+                    .unwrap()
+                    .unwrap()
+                    .is_none(),
+                "aux CF key {key} should be gone after wipe"
+            );
+            assert!(
+                verify_ctx
+                    .get_root(key.as_bytes())
+                    .unwrap()
+                    .unwrap()
+                    .is_none(),
+                "roots CF key {key} should be gone after wipe"
+            );
+            assert!(
+                verify_ctx
+                    .get_meta(key.as_bytes())
+                    .unwrap()
+                    .unwrap()
+                    .is_none(),
+                "meta CF key {key} should be gone after wipe"
+            );
+        }
+
+        // Verify DB is still functional after wipe — can insert new data
+        drop(verify_ctx);
+        storage
+            .commit_transaction(verify_tx)
+            .unwrap()
+            .expect("verify tx commit should succeed");
+
+        let tx2 = storage.start_transaction();
+        let ctx2 = storage
+            .get_immediate_storage_context([b"many"].as_ref().into(), &tx2)
+            .unwrap();
+        ctx2.put(b"after_wipe", b"works", None, None)
+            .unwrap()
+            .unwrap();
+        storage
+            .commit_transaction(tx2)
+            .unwrap()
+            .expect("post-wipe tx commit should succeed");
+
+        let tx3 = storage.start_transaction();
+        let ctx3 = storage
+            .get_immediate_storage_context([b"many"].as_ref().into(), &tx3)
+            .unwrap();
+        assert_eq!(
+            ctx3.get(b"after_wipe").unwrap().unwrap().as_deref(),
+            Some(b"works".as_ref()),
+            "DB should be functional after wipe"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Replaces O(n) per-key delete loop in `wipe_column_family` with a single `delete_range_cf` call
- Creates one range tombstone per column family instead of issuing individual delete operations for every key
- Handles empty CFs gracefully (early return)

The old code had a comment: "very inefficient way of doing this, time complexity is O(n) — we can do O(1)".

Audit finding P6.

## Test plan

- [x] `cargo test -p grovedb-storage` — all 5 tests pass
- [x] `cargo test -p grovedb wipe` — both wipe tests pass
- [x] `cargo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the wipe operation to iterate over storage partitions and perform efficient range deletions, speeding up large dataset clearing.

* **Tests**
  * Added a test that populates many keys across partitions, verifies wipe removes them all, and confirms normal database operations after wipe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->