### PR TITLE
fix: implement proof succinctness and completeness verification

### DIFF
--- a/grovedb-element/src/element/helpers.rs
+++ b/grovedb-element/src/element/helpers.rs
@@ -212,6 +212,29 @@ impl Element {
         }
     }
 
+    /// Check if the element is a non-empty tree that should have child data.
+    ///
+    /// For merk-backed trees this means the root key is `Some(_)` (at least one
+    /// node). Non-merk tree types (MmrTree, BulkAppendTree, CommitmentTree,
+    /// DenseAppendOnlyFixedSizeTree) always carry their own data and are
+    /// considered non-empty regardless of their count field.
+    pub fn is_non_empty_tree(&self) -> bool {
+        matches!(
+            self,
+            Element::Tree(Some(_), _)
+                | Element::SumTree(Some(_), ..)
+                | Element::BigSumTree(Some(_), ..)
+                | Element::CountTree(Some(_), ..)
+                | Element::CountSumTree(Some(_), ..)
+                | Element::ProvableCountTree(Some(_), ..)
+                | Element::ProvableCountSumTree(Some(_), ..)
+                | Element::CommitmentTree(..)
+                | Element::MmrTree(..)
+                | Element::BulkAppendTree(..)
+                | Element::DenseAppendOnlyFixedSizeTree(..)
+        )
+    }
+
     /// Check if the element is a reference
     pub fn is_reference(&self) -> bool {
         matches!(self, Element::Reference(..))

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -14,7 +14,7 @@ use crate::version::{
 };
 
 pub const GROVE_V3: GroveVersion = GroveVersion {
-    protocol_version: 2,
+    protocol_version: 3,
     grovedb_versions: GroveDBVersions {
         apply_batch: GroveDBApplyBatchVersions {
             apply_batch_structure: 0,

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -140,6 +140,11 @@ impl GroveDBProof {
 
     /// Verifies a query using the proof and returns the root hash and the query
     /// result.
+    ///
+    /// Note: `verify_proof_succinctness` is requested but **not yet
+    /// implemented** — cross-subtree completeness is not currently checked.
+    /// Within a single Merk tree, boundary proof verification does enforce
+    /// completeness.
     pub fn verify(
         &self,
         query: &PathQuery,
@@ -160,6 +165,9 @@ impl GroveDBProof {
 
     /// Verifies a query with an absence proof and returns the root hash and the
     /// query result.
+    ///
+    /// Note: `verify_proof_succinctness` is requested but **not yet
+    /// implemented** — cross-subtree completeness is not currently checked.
     pub fn verify_with_absence_proof(
         &self,
         query: &PathQuery,

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -139,12 +139,8 @@ impl GroveDBProof {
     }
 
     /// Verifies a query using the proof and returns the root hash and the query
-    /// result.
-    ///
-    /// Note: `verify_proof_succinctness` is requested but **not yet
-    /// implemented** — cross-subtree completeness is not currently checked.
-    /// Within a single Merk tree, boundary proof verification does enforce
-    /// completeness.
+    /// result. Rejects proofs containing extra data beyond what the query
+    /// requires (succinctness check enabled).
     pub fn verify(
         &self,
         query: &PathQuery,
@@ -164,10 +160,8 @@ impl GroveDBProof {
     }
 
     /// Verifies a query with an absence proof and returns the root hash and the
-    /// query result.
-    ///
-    /// Note: `verify_proof_succinctness` is requested but **not yet
-    /// implemented** — cross-subtree completeness is not currently checked.
+    /// query result. Rejects proofs containing extra data beyond what the
+    /// query requires (succinctness check enabled).
     pub fn verify_with_absence_proof(
         &self,
         query: &PathQuery,

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -622,7 +622,33 @@ impl GroveDb {
                         if limit_left == &Some(0) {
                             break;
                         }
+                    } else if element.is_non_empty_tree()
+                        && internal_query.has_subquery_or_matching_in_path_on_key(key)
+                    {
+                        return Err(Error::InvalidProof(
+                            query.clone(),
+                            format!(
+                                "V1 proof is missing lower layer for non-empty tree at key {}",
+                                hex::encode(key),
+                            ),
+                        ));
                     }
+                }
+            }
+        }
+
+        // Succinctness check: reject proof if it contains lower layers
+        // for keys that the query did not require
+        if options.verify_proof_succinctness {
+            for key in layer_proof.lower_layers.keys() {
+                if !verified_keys.contains(key) {
+                    return Err(Error::InvalidProof(
+                        query.clone(),
+                        format!(
+                            "V1 proof contains extra lower layer for key {} not required by query",
+                            hex::encode(key),
+                        ),
+                    ));
                 }
             }
         }
@@ -1498,17 +1524,33 @@ impl GroveDb {
                         if limit_left == &Some(0) {
                             break;
                         }
-                    } else {
-                        #[cfg(feature = "proof_debug")]
-                        {
-                            println!(
-                                "we have subquery on key {} with value {}: {}",
-                                hex_to_ascii(key),
-                                element,
-                                level_query
-                            )
-                        }
+                    } else if element.is_non_empty_tree()
+                        && internal_query.has_subquery_or_matching_in_path_on_key(key)
+                    {
+                        return Err(Error::InvalidProof(
+                            query.clone(),
+                            format!(
+                                "Proof is missing lower layer for non-empty tree at key {}",
+                                hex::encode(key),
+                            ),
+                        ));
                     }
+                }
+            }
+        }
+
+        // Succinctness check: reject proof if it contains lower layers
+        // for keys that the query did not require
+        if options.verify_proof_succinctness {
+            for key in layer_proof.lower_layers.keys() {
+                if !verified_keys.contains(key) {
+                    return Err(Error::InvalidProof(
+                        query.clone(),
+                        format!(
+                            "Proof contains extra lower layer for key {} not required by query",
+                            hex::encode(key),
+                        ),
+                    ));
                 }
             }
         }

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -37,6 +37,7 @@ mod query_result_type_tests;
 mod reference_path_tests;
 mod replication_session_tests;
 mod replication_utils_tests;
+mod succinctness_gap_test;
 mod test_compaction_sizes;
 mod test_provable_count_fresh;
 mod tree_hashes_tests;

--- a/grovedb/src/tests/succinctness_gap_test.rs
+++ b/grovedb/src/tests/succinctness_gap_test.rs
@@ -1,0 +1,166 @@
+//! Proof succinctness and completeness tests.
+//!
+//! Succinctness: a proof should not contain extra data beyond what the query
+//! requires. `verify_query` (succinctness=true) should reject such proofs,
+//! while `verify_subset_query` (succinctness=false) should accept them.
+//!
+//! Completeness: a proof must not omit lower layers for non-empty trees that
+//! the query traverses into. Both verify methods must reject such proofs.
+
+use grovedb_version::version::GroveVersion;
+
+use crate::{
+    operations::proof::GroveDBProof,
+    tests::{make_deep_tree, TEST_LEAF},
+    GroveDb, PathQuery, Query,
+};
+
+/// Test succinctness enforcement.
+///
+/// Tree structure (from make_deep_tree):
+///   root -> test_leaf -> innertree  -> {k1, k2, k3}
+///                     -> innertree4 -> {k4, k5}
+///
+/// Broad query: all items under test_leaf/* (both subtrees)
+/// Narrow query: only items under test_leaf/innertree (one subtree)
+///
+/// Generate proof for the broad query, then verify with the narrow query.
+/// - verify_subset_query (succinctness=false): should PASS (extra data OK)
+/// - verify_query (succinctness=true): should FAIL (extra data not OK)
+#[test]
+fn test_succinctness_rejects_extra_proof_data() {
+    let grove_version = GroveVersion::latest();
+    let db = make_deep_tree(grove_version);
+
+    // Broad query: all subtrees under TEST_LEAF
+    let mut broad_inner = Query::new();
+    broad_inner.insert_all();
+    let mut broad_outer = Query::new();
+    broad_outer.insert_all();
+    broad_outer.set_subquery(broad_inner);
+    let broad_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], broad_outer);
+
+    // Generate proof covering both innertree and innertree4
+    let proof_bytes = db
+        .prove_query(&broad_query, None, grove_version)
+        .unwrap()
+        .expect("should generate broad proof");
+
+    // Sanity: broad proof verifies with broad query
+    let (root_hash, broad_results) =
+        GroveDb::verify_query(&proof_bytes, &broad_query, grove_version)
+            .expect("broad proof should verify with broad query");
+    let expected_root = db.root_hash(None, grove_version).unwrap().unwrap();
+    assert_eq!(root_hash, expected_root);
+    assert_eq!(broad_results.len(), 5, "broad query should return 5 items");
+
+    // Narrow query: only innertree (not innertree4)
+    let mut narrow_inner = Query::new();
+    narrow_inner.insert_all();
+    let mut narrow_outer = Query::new();
+    narrow_outer.insert_key(b"innertree".to_vec());
+    narrow_outer.set_subquery(narrow_inner);
+    let narrow_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], narrow_outer);
+
+    // verify_subset_query (succinctness OFF): should accept the broad proof
+    // with the narrow query — extra data (innertree4) is tolerated
+    let subset_result = GroveDb::verify_subset_query(&proof_bytes, &narrow_query, grove_version);
+    assert!(
+        subset_result.is_ok(),
+        "verify_subset_query should accept broad proof with narrow query"
+    );
+    let (subset_root, subset_results) = subset_result.unwrap();
+    assert_eq!(subset_root, expected_root);
+    assert_eq!(
+        subset_results.len(),
+        3,
+        "subset verification should return only the 3 items from innertree"
+    );
+
+    // verify_query (succinctness ON): should reject the broad proof because
+    // it contains extra data (innertree4 proof) not required by the narrow query
+    let strict_result = GroveDb::verify_query(&proof_bytes, &narrow_query, grove_version);
+    assert!(
+        strict_result.is_err(),
+        "verify_query should reject broad proof verified with narrow query (extra data)"
+    );
+}
+
+/// Test completeness enforcement.
+///
+/// Stripping a non-empty subtree's lower-layer proof must be rejected by
+/// both verify_query and verify_subset_query — this is a soundness
+/// requirement, not a succinctness preference.
+#[test]
+fn test_missing_lower_layer_for_non_empty_tree_is_rejected() {
+    let grove_version = GroveVersion::latest();
+    let db = make_deep_tree(grove_version);
+
+    // Query all items under all subtrees of TEST_LEAF
+    let mut inner_query = Query::new();
+    inner_query.insert_all();
+    let mut outer_query = Query::new();
+    outer_query.insert_all();
+    outer_query.set_subquery(inner_query);
+    let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], outer_query);
+
+    // Generate and verify honest proof
+    let proof_bytes = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("should generate proof");
+
+    let (honest_root_hash, honest_results) =
+        GroveDb::verify_query(&proof_bytes, &path_query, grove_version)
+            .expect("honest proof should verify");
+
+    let expected_root = db.root_hash(None, grove_version).unwrap().unwrap();
+    assert_eq!(honest_root_hash, expected_root);
+    assert_eq!(
+        honest_results.len(),
+        5,
+        "honest proof should return 5 items (k1..k5)"
+    );
+
+    // Tamper: decode proof, remove innertree4's lower layer, re-encode
+    let config = bincode::config::standard()
+        .with_big_endian()
+        .with_no_limit();
+    let mut grovedb_proof: GroveDBProof = bincode::decode_from_slice(&proof_bytes, config)
+        .expect("should decode proof")
+        .0;
+
+    let test_leaf_key = TEST_LEAF.to_vec();
+    let innertree4_key = b"innertree4".to_vec();
+    let had_layer = match &mut grovedb_proof {
+        GroveDBProof::V0(v0) => v0
+            .root_layer
+            .lower_layers
+            .get_mut(&test_leaf_key)
+            .and_then(|tl| tl.lower_layers.remove(&innertree4_key))
+            .is_some(),
+        GroveDBProof::V1(v1) => v1
+            .root_layer
+            .lower_layers
+            .get_mut(&test_leaf_key)
+            .and_then(|tl| tl.lower_layers.remove(&innertree4_key))
+            .is_some(),
+    };
+    assert!(had_layer, "innertree4 should have had a lower layer proof");
+
+    let tampered_bytes =
+        bincode::encode_to_vec(&grovedb_proof, config).expect("should re-encode tampered proof");
+
+    // Both must reject — this is a completeness/soundness requirement
+    let result = GroveDb::verify_query(&tampered_bytes, &path_query, grove_version);
+    assert!(
+        result.is_err(),
+        "verify_query must reject proof missing a non-empty subtree's lower layer"
+    );
+
+    let result = GroveDb::verify_subset_query(&tampered_bytes, &path_query, grove_version);
+    assert!(
+        result.is_err(),
+        "verify_subset_query must reject proof missing a non-empty subtree's lower layer"
+    );
+}

--- a/grovedb/src/tests/succinctness_gap_test.rs
+++ b/grovedb/src/tests/succinctness_gap_test.rs
@@ -7,7 +7,7 @@
 //! Completeness: a proof must not omit lower layers for non-empty trees that
 //! the query traverses into. Both verify methods must reject such proofs.
 
-use grovedb_version::version::GroveVersion;
+use grovedb_version::version::{v1::GROVE_V1, GroveVersion};
 
 use crate::{
     operations::proof::GroveDBProof,
@@ -162,5 +162,103 @@ fn test_missing_lower_layer_for_non_empty_tree_is_rejected() {
     assert!(
         result.is_err(),
         "verify_subset_query must reject proof missing a non-empty subtree's lower layer"
+    );
+}
+
+/// Same as test_succinctness_rejects_extra_proof_data but forces V0 proofs
+/// (using GROVE_V1 which generates MerkOnlyLayerProof).
+#[test]
+fn test_succinctness_rejects_extra_proof_data_v0() {
+    let grove_version = &GROVE_V1;
+    let db = make_deep_tree(grove_version);
+
+    let mut broad_inner = Query::new();
+    broad_inner.insert_all();
+    let mut broad_outer = Query::new();
+    broad_outer.insert_all();
+    broad_outer.set_subquery(broad_inner);
+    let broad_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], broad_outer);
+
+    let proof_bytes = db
+        .prove_query(&broad_query, None, grove_version)
+        .unwrap()
+        .expect("should generate broad proof");
+
+    let mut narrow_inner = Query::new();
+    narrow_inner.insert_all();
+    let mut narrow_outer = Query::new();
+    narrow_outer.insert_key(b"innertree".to_vec());
+    narrow_outer.set_subquery(narrow_inner);
+    let narrow_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], narrow_outer);
+
+    let subset_result = GroveDb::verify_subset_query(&proof_bytes, &narrow_query, grove_version);
+    assert!(
+        subset_result.is_ok(),
+        "V0: verify_subset_query should accept broad proof with narrow query"
+    );
+
+    let strict_result = GroveDb::verify_query(&proof_bytes, &narrow_query, grove_version);
+    assert!(
+        strict_result.is_err(),
+        "V0: verify_query should reject broad proof with narrow query (extra data)"
+    );
+}
+
+/// Same as test_missing_lower_layer but forces V0 proofs.
+#[test]
+fn test_missing_lower_layer_for_non_empty_tree_is_rejected_v0() {
+    let grove_version = &GROVE_V1;
+    let db = make_deep_tree(grove_version);
+
+    let mut inner_query = Query::new();
+    inner_query.insert_all();
+    let mut outer_query = Query::new();
+    outer_query.insert_all();
+    outer_query.set_subquery(inner_query);
+    let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], outer_query);
+
+    let proof_bytes = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("should generate proof");
+
+    let config = bincode::config::standard()
+        .with_big_endian()
+        .with_no_limit();
+    let mut grovedb_proof: GroveDBProof = bincode::decode_from_slice(&proof_bytes, config)
+        .expect("should decode proof")
+        .0;
+
+    let test_leaf_key = TEST_LEAF.to_vec();
+    let innertree4_key = b"innertree4".to_vec();
+    let had_layer = match &mut grovedb_proof {
+        GroveDBProof::V0(v0) => v0
+            .root_layer
+            .lower_layers
+            .get_mut(&test_leaf_key)
+            .and_then(|tl| tl.lower_layers.remove(&innertree4_key))
+            .is_some(),
+        GroveDBProof::V1(v1) => v1
+            .root_layer
+            .lower_layers
+            .get_mut(&test_leaf_key)
+            .and_then(|tl| tl.lower_layers.remove(&innertree4_key))
+            .is_some(),
+    };
+    assert!(had_layer, "innertree4 should have had a lower layer proof");
+
+    let tampered_bytes =
+        bincode::encode_to_vec(&grovedb_proof, config).expect("should re-encode tampered proof");
+
+    let result = GroveDb::verify_query(&tampered_bytes, &path_query, grove_version);
+    assert!(
+        result.is_err(),
+        "V0: verify_query must reject proof missing a non-empty subtree's lower layer"
+    );
+
+    let result = GroveDb::verify_subset_query(&tampered_bytes, &path_query, grove_version);
+    assert!(
+        result.is_err(),
+        "V0: verify_subset_query must reject proof missing a non-empty subtree's lower layer"
     );
 }

--- a/grovedb/src/tests/sum_tree_tests.rs
+++ b/grovedb/src/tests/sum_tree_tests.rs
@@ -1863,7 +1863,7 @@ mod tests {
         );
 
         let (_root_hash, parent, result_set) =
-            GroveDb::verify_query_get_parent_tree_info(&proof, &path_query, grove_version)
+            GroveDb::verify_subset_query_get_parent_tree_info(&proof, &path_query, grove_version)
                 .expect("should verify proof");
 
         assert_eq!(parent, SummedMerkNode(1));

--- a/merk/src/proofs/query/verify.rs
+++ b/merk/src/proofs/query/verify.rs
@@ -40,8 +40,17 @@ pub struct VerifyOptions {
     /// When set to true, this will give back absence proofs for any query items
     /// that are keys. This means QueryItem::Key(), and not the ranges.
     pub absence_proofs_for_non_existing_searched_keys: bool,
-    /// Verifies that we have all the data. Todo: verify that this works
-    /// properly
+    /// **NOT YET IMPLEMENTED.** This field is accepted but currently ignored.
+    ///
+    /// When implemented, setting this to `true` should verify that the proof
+    /// contains results for ALL keys/ranges matching the query (i.e., the
+    /// prover did not omit any results). Without this check, a malicious
+    /// prover could return a valid but incomplete proof.
+    ///
+    /// Succinctness within a single Merk tree IS enforced by the boundary
+    /// proof verification. The gap is at the GroveDB layer for cross-subtree
+    /// result completeness.
+    // TODO: implement cross-subtree succinctness verification
     pub verify_proof_succinctness: bool,
     /// Should return empty trees in the result?
     pub include_empty_trees_in_result: bool,

--- a/merk/src/proofs/query/verify.rs
+++ b/merk/src/proofs/query/verify.rs
@@ -40,17 +40,10 @@ pub struct VerifyOptions {
     /// When set to true, this will give back absence proofs for any query items
     /// that are keys. This means QueryItem::Key(), and not the ranges.
     pub absence_proofs_for_non_existing_searched_keys: bool,
-    /// **NOT YET IMPLEMENTED.** This field is accepted but currently ignored.
-    ///
-    /// When implemented, setting this to `true` should verify that the proof
-    /// contains results for ALL keys/ranges matching the query (i.e., the
-    /// prover did not omit any results). Without this check, a malicious
-    /// prover could return a valid but incomplete proof.
-    ///
-    /// Succinctness within a single Merk tree IS enforced by the boundary
-    /// proof verification. The gap is at the GroveDB layer for cross-subtree
-    /// result completeness.
-    // TODO: implement cross-subtree succinctness verification
+    /// When true, reject proofs that contain extra lower-layer data beyond
+    /// what the query requires (e.g. proof covers subtrees A and B but query
+    /// only asks for A). When false, extra data is tolerated (subset
+    /// verification).
     pub verify_proof_succinctness: bool,
     /// Should return empty trees in the result?
     pub include_empty_trees_in_result: bool,


### PR DESCRIPTION
## Summary

Implements two proof verification checks that were previously missing:

**Completeness (soundness fix):** Both v0 and v1 `verify_layer_proof` now reject proofs that omit lower layers for non-empty trees the query traverses into. Previously, the else branch silently skipped these cases, allowing a malicious prover to strip subtree proofs while the verifier accepted with fewer results and the same root hash.

**Succinctness (wires up existing flag):** When `verify_proof_succinctness` is true, verification now rejects proofs containing lower layers for keys not required by the query. This implements the behavior that `verify_query` vs `verify_subset_query` was always *intended* to distinguish:
- `verify_query` (succinctness=true) → rejects extra proof data
- `verify_subset_query` (succinctness=false) → tolerates extra proof data

### Changes
- **`grovedb-element/src/element/helpers.rs`** — Added `Element::is_non_empty_tree()` helper for the completeness check
- **`grovedb/src/operations/proof/verify.rs`** — Completeness error in both v0 and v1 verify paths when a non-empty tree has a subquery but no lower layer; succinctness check after result set processing rejects `lower_layers` keys not in `verified_keys`
- **`grovedb/src/tests/succinctness_gap_test.rs`** — TDD tests for both behaviors
- **`grovedb/src/tests/sum_tree_tests.rs`** — Changed `test_verify_query_get_parent_tree_info` to use subset verification (its hardcoded proof has extra lower layers)
- **`grovedb/src/operations/proof/mod.rs`** — Updated doc comments on `verify()` and `verify_with_absence_proof()` (no longer "not yet implemented")
- **`merk/src/proofs/query/verify.rs`** — Updated `verify_proof_succinctness` doc comment
- **`grovedb-version/src/version/v3.rs`** — Fixed `protocol_version` to 3 (merge artifact)

Audit finding H3.

## Test plan

- [x] `cargo test -p grovedb --lib --features full` — 1270 passed
- [x] `cargo test -p grovedb-version` — 47 passed
- [x] `cargo clippy -p grovedb -p grovedb-merk --features full -- -D warnings` — clean
- [x] `test_succinctness_rejects_extra_proof_data` — broad proof rejected by `verify_query` with narrow query, accepted by `verify_subset_query`
- [x] `test_missing_lower_layer_for_non_empty_tree_is_rejected` — tampered proof (stripped lower layer) rejected by both verify methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)