### PR TITLE
fix: enforce key length limit in proof encoding at runtime

### DIFF
--- a/grovedb-query/src/proofs/encoding.rs
+++ b/grovedb-query/src/proofs/encoding.rs
@@ -15,6 +15,22 @@ use crate::{
 /// allocations.
 const MAX_VALUE_LEN: u32 = 64 * 1024 * 1024;
 
+/// Validates that a key length fits in a single byte (< 256).
+///
+/// Proof encoding stores key lengths as a u8. Keys with 256 or more bytes
+/// would have their length silently truncated via `as u8`, corrupting the
+/// proof. This function enforces the limit at runtime.
+#[inline]
+fn validate_key_len(key: &[u8]) -> ed::Result<()> {
+    if key.len() >= 256 {
+        return Err(ed::Error::IOError(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "key length must be less than 256",
+        )));
+    }
+    Ok(())
+}
+
 impl Encode for Op {
     fn encode_into<W: Write>(&self, dest: &mut W) -> ed::Result<()> {
         match self {
@@ -28,6 +44,7 @@ impl Encode for Op {
                 dest.write_all(kv_hash)?;
             }
             Op::Push(Node::KV(key, value)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x03, key.len() as u8])?;
@@ -42,6 +59,7 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVValueHash(key, value, value_hash)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x04, key.len() as u8])?;
@@ -58,6 +76,7 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVDigest(key, value_hash)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
 
                 dest.write_all(&[0x05, key.len() as u8])?;
@@ -65,6 +84,7 @@ impl Encode for Op {
                 dest.write_all(value_hash)?;
             }
             Op::Push(Node::KVRefValueHash(key, value, value_hash)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x06, key.len() as u8])?;
@@ -81,6 +101,7 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVValueHashFeatureType(key, value, value_hash, feature_type)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x07, key.len() as u8])?;
@@ -99,6 +120,7 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVCount(key, value, count)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x14, key.len() as u8])?;
@@ -120,6 +142,7 @@ impl Encode for Op {
                 count.encode_into(dest)?;
             }
             Op::Push(Node::KVRefValueHashCount(key, value, value_hash, count)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x18, key.len() as u8])?;
@@ -138,6 +161,7 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVDigestCount(key, value_hash, count)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
 
                 dest.write_all(&[0x1a, key.len() as u8])?;
@@ -156,6 +180,7 @@ impl Encode for Op {
                 dest.write_all(kv_hash)?;
             }
             Op::PushInverted(Node::KV(key, value)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x0a, key.len() as u8])?;
@@ -170,6 +195,7 @@ impl Encode for Op {
                 }
             }
             Op::PushInverted(Node::KVValueHash(key, value, value_hash)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x0b, key.len() as u8])?;
@@ -186,6 +212,7 @@ impl Encode for Op {
                 }
             }
             Op::PushInverted(Node::KVDigest(key, value_hash)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
 
                 dest.write_all(&[0x0c, key.len() as u8])?;
@@ -193,6 +220,7 @@ impl Encode for Op {
                 dest.write_all(value_hash)?;
             }
             Op::PushInverted(Node::KVRefValueHash(key, value, value_hash)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x0d, key.len() as u8])?;
@@ -214,6 +242,7 @@ impl Encode for Op {
                 value_hash,
                 feature_type,
             )) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x0e, key.len() as u8])?;
@@ -232,6 +261,7 @@ impl Encode for Op {
                 }
             }
             Op::PushInverted(Node::KVCount(key, value, count)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x16, key.len() as u8])?;
@@ -253,6 +283,7 @@ impl Encode for Op {
                 count.encode_into(dest)?;
             }
             Op::PushInverted(Node::KVRefValueHashCount(key, value, value_hash, count)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
                 if value.len() < 65536 {
                     dest.write_all(&[0x19, key.len() as u8])?;
@@ -271,6 +302,7 @@ impl Encode for Op {
                 }
             }
             Op::PushInverted(Node::KVDigestCount(key, value_hash, count)) => {
+                validate_key_len(key)?;
                 debug_assert!(key.len() < 256);
 
                 dest.write_all(&[0x1b, key.len() as u8])?;


### PR DESCRIPTION
## Summary
- **Security fix (audit finding H2)**: Proof encoding in `grovedb-query/src/proofs/encoding.rs` stored key lengths as `u8` but only checked `key.len() < 256` via `debug_assert!`, which is stripped in release builds. Keys >= 256 bytes would have their length silently truncated modulo 256, corrupting proofs and potentially enabling proof forgery.
- Added a `validate_key_len()` helper function that performs the check at runtime, returning `ed::Error::IOError` with `InvalidData` kind for keys >= 256 bytes. All 16 encoding paths that cast `key.len() as u8` now call this validation before proceeding.
- Existing `debug_assert!` lines are retained as belt-and-suspenders for debug builds.

## Test plan
- [x] `cargo build -p grovedb-query` compiles successfully
- [ ] Verify existing tests pass: `cargo test -p grovedb-query`
- [ ] Confirm a key of length 256+ returns an error instead of silently truncating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced proof encoding validation by implementing comprehensive runtime checks across all encoding paths to ensure key lengths do not exceed 255 bytes. Keys exceeding this limit now trigger detailed error messages during the encoding process, improving error visibility and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->