### PR TITLE
fix: validate key length in batch operations to prevent Merk encoding corruption

### DIFF
--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -133,11 +133,11 @@ where
             // Validate key length: Merk link encoding stores key length as a
             // single u8, so keys longer than 255 bytes would corrupt the
             // encoding.
-            if let KeyInfo::KnownKey(ref key_bytes) = key {
-                if key_bytes.len() > u8::MAX as usize {
-                    return Err(Error::InvalidInput("key length must be at most 255 bytes"))
-                        .wrap_with_cost(cost);
-                }
+            if let KeyInfo::KnownKey(ref key_bytes) = key
+                && key_bytes.len() > u8::MAX as usize
+            {
+                return Err(Error::InvalidInput("key length must be at most 255 bytes"))
+                    .wrap_with_cost(cost);
             }
 
             // Build qualified path (path + key) for reference lookups

--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -130,6 +130,16 @@ where
                 None => continue,
             };
 
+            // Validate key length: Merk link encoding stores key length as a
+            // single u8, so keys longer than 255 bytes would corrupt the
+            // encoding.
+            if let KeyInfo::KnownKey(ref key_bytes) = key {
+                if key_bytes.len() > u8::MAX as usize {
+                    return Err(Error::InvalidInput("key length must be at most 255 bytes"))
+                        .wrap_with_cost(cost);
+                }
+            }
+
             // Build qualified path (path + key) for reference lookups
             let mut qualified_path = op_path.clone();
             qualified_path.push(key.clone());

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -5015,4 +5015,46 @@ mod tests {
             _ => panic!("expected DenseAppendOnlyFixedSizeTree element"),
         }
     }
+
+    #[test]
+    fn test_batch_rejects_key_longer_than_255_bytes() {
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        // Create a key that is 256 bytes long (one byte over the limit)
+        let oversized_key = vec![b'x'; 256];
+        let ops = vec![QualifiedGroveDbOp::insert_or_replace_op(
+            vec![],
+            oversized_key,
+            Element::new_item(b"value".to_vec()),
+        )];
+
+        let result = db.apply_batch(ops, None, Some(&tx), grove_version).unwrap();
+        assert!(
+            result.is_err(),
+            "batch with oversized key should be rejected"
+        );
+        match result {
+            Err(Error::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("255"),
+                    "error should mention the 255 byte limit, got: {msg}"
+                );
+            }
+            Err(other) => panic!("expected InvalidInput error, got: {:?}", other),
+            Ok(_) => unreachable!(),
+        }
+
+        // Verify that a key of exactly 255 bytes is accepted
+        let max_key = vec![b'y'; 255];
+        let ops = vec![QualifiedGroveDbOp::insert_or_replace_op(
+            vec![],
+            max_key,
+            Element::new_item(b"value".to_vec()),
+        )];
+        db.apply_batch(ops, None, Some(&tx), grove_version)
+            .unwrap()
+            .expect("batch with 255-byte key should succeed");
+    }
 }


### PR DESCRIPTION
## Summary

- **Audit finding H1**: The batch operation path (`apply_batch`) skipped key length validation, allowing keys >255 bytes to be inserted. Since Merk link encoding stores key length as a single `u8`, this would corrupt the encoding.
- Adds key length validation in `BatchStructure::continue_from_ops` (the central batch structure builder), returning `Error::InvalidInput` when any keyed operation has a key exceeding 255 bytes. Keyless operations (append-only tree ops) are not affected.
- Adds a test that verifies batch operations with 256-byte keys are rejected and 255-byte keys are accepted.

## Details

The direct insert path already validates key length via `validate_key_length()` in `grovedb/src/operations/insert/mod.rs`. The batch path builds operations through `BatchStructure::continue_from_ops` in `grovedb/src/batch/batch_structure.rs`, which previously had no such check. The fix adds the same validation at the point where each operation's key is extracted, before it enters the batch structure.

## Test plan

- [x] `cargo build` succeeds
- [x] New test `test_batch_rejects_key_longer_than_255_bytes` passes
- [x] All 296 existing batch tests pass (`cargo test -p grovedb batch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch processing now validates key length, rejecting keys exceeding 255 bytes with an InvalidInput error indicating the maximum permitted length.

* **Tests**
  * Added test coverage verifying batch processing correctly rejects keys longer than 255 bytes while accepting valid keys up to the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->