### PR TITLE
docs: explain why runtime key length check is unnecessary in proof encoding

### DIFF
--- a/grovedb-query/src/proofs/encoding.rs
+++ b/grovedb-query/src/proofs/encoding.rs
@@ -16,6 +16,11 @@ use crate::{
 const MAX_VALUE_LEN: u32 = 64 * 1024 * 1024;
 
 impl Encode for Op {
+    // Note: `key.len() as u8` casts below are safe because GroveDB enforces a
+    // 255-byte maximum key length at insertion time (both direct insert and
+    // batch paths). The `debug_assert!` guards serve as development-time
+    // verification of this invariant. A runtime check here is unnecessary
+    // since keys exceeding 255 bytes can never be stored in the database.
     fn encode_into<W: Write>(&self, dest: &mut W) -> ed::Result<()> {
         match self {
             // Push


### PR DESCRIPTION
## Summary
- Adds a comment in `grovedb-query/src/proofs/encoding.rs` explaining why the `key.len() as u8` casts are safe
- GroveDB enforces a 255-byte maximum key length at insertion time (both direct insert and batch paths), so keys exceeding 255 bytes can never reach proof encoding
- The existing `debug_assert!` guards are sufficient as development-time verification

## Context
This was identified as H2 in the round 2 codebase audit but determined to be a **false positive** — the insert path already validates key length, making a runtime check here redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation to clarify implementation details and invariant verification practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->