### PR TITLE
fix: start protocol_version numbering at 1 instead of 0

### DIFF
--- a/grovedb-version/src/tests.rs
+++ b/grovedb-version/src/tests.rs
@@ -83,13 +83,13 @@ fn grove_versions_ordered_by_protocol_version() {
 // ── Version constant field differences (V1 vs V2) ────────────────────
 
 #[test]
-fn v1_protocol_version_is_zero() {
-    assert_eq!(GROVE_V1.protocol_version, 0);
+fn v1_protocol_version_is_one() {
+    assert_eq!(GROVE_V1.protocol_version, 1);
 }
 
 #[test]
-fn v2_protocol_version_is_one() {
-    assert_eq!(GROVE_V2.protocol_version, 1);
+fn v2_protocol_version_is_two() {
+    assert_eq!(GROVE_V2.protocol_version, 2);
 }
 
 #[test]

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -14,7 +14,7 @@ use crate::version::{
 };
 
 pub const GROVE_V1: GroveVersion = GroveVersion {
-    protocol_version: 0,
+    protocol_version: 1,
     grovedb_versions: GroveDBVersions {
         apply_batch: GroveDBApplyBatchVersions {
             apply_batch_structure: 0,

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -14,7 +14,7 @@ use crate::version::{
 };
 
 pub const GROVE_V2: GroveVersion = GroveVersion {
-    protocol_version: 1,
+    protocol_version: 2,
     grovedb_versions: GroveDBVersions {
         apply_batch: GroveDBApplyBatchVersions {
             apply_batch_structure: 0,


### PR DESCRIPTION
## Summary
- Change `protocol_version` in `GROVE_V1` from `0` to `1`
- Change `protocol_version` in `GROVE_V2` from `1` to `2`
- Update corresponding tests

Protocol versions should be 1-indexed to match Platform conventions.

## Test plan
- [x] `cargo test -p grovedb-version` — all 47 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)