### PR TITLE
feat: enforce internal-only GroveOp variants with #[non_exhaustive]

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -170,7 +170,12 @@ impl NonMerkTreeMeta {
 /// User-facing variants: `InsertOnly`, `InsertOrReplace`, `Replace`, `Patch`,
 /// `RefreshReference`, `Delete`, `DeleteTree`, `CommitmentTreeInsert`,
 /// `MmrTreeAppend`, `BulkAppend`, `DenseTreeInsert`.
-/// Other variants are internal and produced by batch propagation.
+///
+/// Internal variants (`ReplaceTreeRootKey`, `InsertTreeWithRootHash`,
+/// `ReplaceNonMerkTreeRoot`, `InsertNonMerkTree`) are marked
+/// `#[non_exhaustive]` so they **cannot be constructed by external crates**.
+/// They are produced solely by batch propagation / preprocessing within
+/// this crate.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum GroveOp {
     /// **Internal only — do not construct directly.**
@@ -178,6 +183,10 @@ pub enum GroveOp {
     ///
     /// Used by propagation to update an existing Merk tree's root hash
     /// and aggregate data. For non-Merk trees, see `ReplaceNonMerkTreeRoot`.
+    ///
+    /// This variant is `#[non_exhaustive]` and cannot be constructed outside
+    /// of this crate.
+    #[non_exhaustive]
     ReplaceTreeRootKey {
         /// Hash
         hash: [u8; 32],
@@ -214,6 +223,10 @@ pub enum GroveOp {
     /// Created during batch propagation from an `InsertOrReplace`/`InsertOnly`
     /// occupied entry when a child subtree's root hash is propagated upward.
     /// For non-Merk trees, see `InsertNonMerkTree`.
+    ///
+    /// This variant is `#[non_exhaustive]` and cannot be constructed outside
+    /// of this crate.
+    #[non_exhaustive]
     InsertTreeWithRootHash {
         /// Hash
         hash: [u8; 32],
@@ -227,6 +240,10 @@ pub enum GroveOp {
     /// **Internal only — do not construct directly.**
     /// Replace root hash for a non-Merk tree (CommitmentTree, MmrTree,
     /// BulkAppendTree, DenseTree). Produced by preprocessing functions.
+    ///
+    /// This variant is `#[non_exhaustive]` and cannot be constructed outside
+    /// of this crate.
+    #[non_exhaustive]
     ReplaceNonMerkTreeRoot {
         /// New root hash (sinsemilla root, MMR root, state root, dense root).
         hash: [u8; 32],
@@ -239,6 +256,10 @@ pub enum GroveOp {
     /// Created when propagation encounters an occupied entry that is a
     /// non-Merk tree element (CommitmentTree, MmrTree, BulkAppendTree,
     /// DenseTree).
+    ///
+    /// This variant is `#[non_exhaustive]` and cannot be constructed outside
+    /// of this crate.
+    #[non_exhaustive]
     InsertNonMerkTree {
         /// Hash
         hash: [u8; 32],


### PR DESCRIPTION
## Context

Follow-up to #515 (docs: mark internal-only GroveOp variants). While #515 added documentation warnings, this PR adds **compile-time enforcement** using `#[non_exhaustive]` on the four internal-only `GroveOp` variants.

Audit finding A4: The `GroveOp` enum is fully `pub` but includes four internal-only variants that should not be constructed by external crates.

## Changes

Added `#[non_exhaustive]` to:
- `ReplaceTreeRootKey`
- `InsertTreeWithRootHash`
- `ReplaceNonMerkTreeRoot`
- `InsertNonMerkTree`

In Rust, `#[non_exhaustive]` on a struct-like enum variant **prevents external crates from constructing it** while allowing internal (same-crate) code to work normally. External code can still pattern-match these variants (with `..`), but cannot create instances.

**Why `#[non_exhaustive]` over splitting the enum:**
- Minimal change (22 lines, 1 file)
- No breaking changes to internal code or tests
- Idiomatic Rust pattern for this exact use case
- Zero runtime cost
- Provides compile-time enforcement on top of the existing runtime rejection in `batch_structure.rs`

## Validation

- `cargo build` ✅
- `cargo clippy --all-targets` ✅
- `cargo test -p grovedb -- batch_rejection` ✅ (6 tests pass)
- `cargo fmt -- --check` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced batch processing operations with expanded metadata tracking for tree root management, improving internal state consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->