### PR TITLE
fix: prevent u32 overflow in epoch storage flags (audit M2)

### DIFF
--- a/grovedb-epoch-based-storage-flags/src/lib.rs
+++ b/grovedb-epoch-based-storage-flags/src/lib.rs
@@ -209,7 +209,12 @@ impl StorageFlags {
         match original_value {
             None => other_epoch_bytes.insert(*epoch_with_adding_bytes, added_bytes),
             Some(original_bytes) => {
-                other_epoch_bytes.insert(*epoch_with_adding_bytes, original_bytes + added_bytes)
+                let combined = original_bytes.checked_add(added_bytes).ok_or(
+                    StorageFlagsError::StorageFlagsOverflow(
+                        "u32 overflow when combining epoch byte counts".to_string(),
+                    ),
+                )?;
+                other_epoch_bytes.insert(*epoch_with_adding_bytes, combined)
             }
         };
         // println!(
@@ -1926,5 +1931,21 @@ mod storage_flags_additional_tests {
         let flags = StorageFlags::MultiEpoch(1, BTreeMap::from([(2, 300)]));
         // 1 type byte + 2 base epoch bytes + (2 epoch bytes + varint bytes)
         assert_eq!(flags.serialized_size(), 3 + 2 + bytes.len() as u32);
+    }
+
+    #[test]
+    fn combine_with_higher_base_epoch_u32_overflow_returns_error() {
+        // Set up a MultiEpoch with an existing entry at epoch 2 near u32::MAX.
+        let ours = StorageFlags::MultiEpoch(1, BTreeMap::from([(2, u32::MAX - 5)]));
+        // rhs has base epoch 2 (higher), so combine_added_bytes will call
+        // combine_with_higher_base_epoch and attempt to add to the existing
+        // epoch-2 entry.
+        let theirs = StorageFlags::SingleEpoch(2);
+
+        // Adding 6 bytes would push the total past u32::MAX.
+        let err = ours
+            .combine_added_bytes(theirs, 6, MergingOwnersStrategy::UseOurs)
+            .expect_err("expected u32 overflow error");
+        assert!(matches!(err, StorageFlagsError::StorageFlagsOverflow(_)));
     }
 }


### PR DESCRIPTION
## Summary

- **Audit finding M2**: `combine_with_higher_base_epoch` at `grovedb-epoch-based-storage-flags/src/lib.rs` performed unchecked `u32` addition (`original_bytes + added_bytes`) which could overflow/wrap when summing epoch byte counts.
- Replaced with `checked_add`, returning `StorageFlagsError::StorageFlagsOverflow` on overflow. This follows the same pattern already used in `combine_with_higher_base_epoch_remove_bytes` (which uses `checked_sub` with the same error variant).
- Added a regression test that constructs a `MultiEpoch` with a value near `u32::MAX` and verifies that adding bytes past the limit returns an error instead of panicking or wrapping.

## Test plan

- [x] `cargo build -p grovedb-epoch-based-storage-flags` passes
- [x] `cargo test -p grovedb-epoch-based-storage-flags` passes (42 tests including the new one)
- [x] `cargo clippy -p grovedb-epoch-based-storage-flags -- -D warnings` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced storage operations to detect and properly handle overflow conditions, preventing potential data corruption.

* **Tests**
  * Added test coverage for overflow edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->