### PR TITLE
fix: return Result from element constructors instead of panicking (audit M1)

### DIFF
--- a/grovedb-element/src/element/constructor.rs
+++ b/grovedb-element/src/element/constructor.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     element::{BigSumValue, CountValue, Element, ElementFlags, MaxReferenceHop, SumValue},
+    error::ElementError,
     reference_path::ReferencePathType,
 };
 
@@ -289,16 +290,27 @@ impl Element {
         Element::ProvableCountSumTree(maybe_root_key, count_value, sum_value, flags)
     }
 
-    /// Set element to an empty commitment tree
-    pub fn empty_commitment_tree(chunk_power: u8) -> Self {
-        assert!(chunk_power <= 31, "chunk_power must be <= 31");
-        Element::CommitmentTree(0, chunk_power, None)
+    /// Set element to an empty commitment tree.
+    ///
+    /// Returns `InvalidInput` if `chunk_power > 31`.
+    pub fn empty_commitment_tree(chunk_power: u8) -> Result<Self, ElementError> {
+        if chunk_power > 31 {
+            return Err(ElementError::InvalidInput("chunk_power must be <= 31"));
+        }
+        Ok(Element::CommitmentTree(0, chunk_power, None))
     }
 
-    /// Set element to an empty commitment tree with flags
-    pub fn empty_commitment_tree_with_flags(chunk_power: u8, flags: Option<ElementFlags>) -> Self {
-        assert!(chunk_power <= 31, "chunk_power must be <= 31");
-        Element::CommitmentTree(0, chunk_power, flags)
+    /// Set element to an empty commitment tree with flags.
+    ///
+    /// Returns `InvalidInput` if `chunk_power > 31`.
+    pub fn empty_commitment_tree_with_flags(
+        chunk_power: u8,
+        flags: Option<ElementFlags>,
+    ) -> Result<Self, ElementError> {
+        if chunk_power > 31 {
+            return Err(ElementError::InvalidInput("chunk_power must be <= 31"));
+        }
+        Ok(Element::CommitmentTree(0, chunk_power, flags))
     }
 
     /// Set element to a commitment tree with all fields
@@ -325,16 +337,27 @@ impl Element {
         Element::MmrTree(mmr_size, flags)
     }
 
-    /// Set element to an empty bulk append tree without flags
-    pub fn empty_bulk_append_tree(chunk_power: u8) -> Self {
-        assert!(chunk_power <= 31, "chunk_power must be <= 31");
-        Element::BulkAppendTree(0, chunk_power, None)
+    /// Set element to an empty bulk append tree without flags.
+    ///
+    /// Returns `InvalidInput` if `chunk_power > 31`.
+    pub fn empty_bulk_append_tree(chunk_power: u8) -> Result<Self, ElementError> {
+        if chunk_power > 31 {
+            return Err(ElementError::InvalidInput("chunk_power must be <= 31"));
+        }
+        Ok(Element::BulkAppendTree(0, chunk_power, None))
     }
 
-    /// Set element to an empty bulk append tree with flags
-    pub fn empty_bulk_append_tree_with_flags(chunk_power: u8, flags: Option<ElementFlags>) -> Self {
-        assert!(chunk_power <= 31, "chunk_power must be <= 31");
-        Element::BulkAppendTree(0, chunk_power, flags)
+    /// Set element to an empty bulk append tree with flags.
+    ///
+    /// Returns `InvalidInput` if `chunk_power > 31`.
+    pub fn empty_bulk_append_tree_with_flags(
+        chunk_power: u8,
+        flags: Option<ElementFlags>,
+    ) -> Result<Self, ElementError> {
+        if chunk_power > 31 {
+            return Err(ElementError::InvalidInput("chunk_power must be <= 31"));
+        }
+        Ok(Element::BulkAppendTree(0, chunk_power, flags))
     }
 
     /// Set element to a bulk append tree with all fields

--- a/grovedb-element/tests/element_constructors_helpers.rs
+++ b/grovedb-element/tests/element_constructors_helpers.rs
@@ -221,11 +221,11 @@ fn constructors_create_expected_provable_tree_variants() {
 fn constructors_create_expected_commitment_mmr_bulk_dense_variants() {
     // Commitment tree constructors
     assert_eq!(
-        Element::empty_commitment_tree(4),
+        Element::empty_commitment_tree(4).expect("valid chunk_power"),
         Element::CommitmentTree(0, 4, None)
     );
     assert_eq!(
-        Element::empty_commitment_tree_with_flags(4, sample_flags()),
+        Element::empty_commitment_tree_with_flags(4, sample_flags()).expect("valid chunk_power"),
         Element::CommitmentTree(0, 4, sample_flags())
     );
     assert_eq!(
@@ -246,11 +246,11 @@ fn constructors_create_expected_commitment_mmr_bulk_dense_variants() {
 
     // Bulk append tree constructors
     assert_eq!(
-        Element::empty_bulk_append_tree(6),
+        Element::empty_bulk_append_tree(6).expect("valid chunk_power"),
         Element::BulkAppendTree(0, 6, None)
     );
     assert_eq!(
-        Element::empty_bulk_append_tree_with_flags(6, sample_flags()),
+        Element::empty_bulk_append_tree_with_flags(6, sample_flags()).expect("valid chunk_power"),
         Element::BulkAppendTree(0, 6, sample_flags())
     );
     assert_eq!(
@@ -384,14 +384,22 @@ fn value_helpers_and_conversion_errors_work() {
     assert!(Element::empty_count_sum_tree().is_any_tree());
     assert!(Element::empty_provable_count_tree().is_any_tree());
     assert!(Element::empty_provable_count_sum_tree().is_any_tree());
-    assert!(Element::empty_commitment_tree(1).is_any_tree());
+    assert!(Element::empty_commitment_tree(1)
+        .expect("valid chunk_power")
+        .is_any_tree());
     assert!(Element::empty_mmr_tree().is_any_tree());
-    assert!(Element::empty_bulk_append_tree(1).is_any_tree());
+    assert!(Element::empty_bulk_append_tree(1)
+        .expect("valid chunk_power")
+        .is_any_tree());
     assert!(Element::empty_dense_tree(2).is_any_tree());
 
-    assert!(Element::empty_commitment_tree(2).is_commitment_tree());
+    assert!(Element::empty_commitment_tree(2)
+        .expect("valid chunk_power")
+        .is_commitment_tree());
     assert!(Element::empty_mmr_tree().is_mmr_tree());
-    assert!(Element::empty_bulk_append_tree(2).is_bulk_append_tree());
+    assert!(Element::empty_bulk_append_tree(2)
+        .expect("valid chunk_power")
+        .is_bulk_append_tree());
     assert!(Element::empty_dense_tree(3).is_dense_tree());
 
     assert!(reference.is_reference());
@@ -405,9 +413,13 @@ fn value_helpers_and_conversion_errors_work() {
     assert!(item_with_sum.is_sum_item());
     assert!(item_with_sum.is_item_with_sum_item());
 
-    assert!(Element::empty_commitment_tree(2).uses_non_merk_data_storage());
+    assert!(Element::empty_commitment_tree(2)
+        .expect("valid chunk_power")
+        .uses_non_merk_data_storage());
     assert!(Element::empty_mmr_tree().uses_non_merk_data_storage());
-    assert!(Element::empty_bulk_append_tree(2).uses_non_merk_data_storage());
+    assert!(Element::empty_bulk_append_tree(2)
+        .expect("valid chunk_power")
+        .uses_non_merk_data_storage());
     assert!(Element::empty_dense_tree(2).uses_non_merk_data_storage());
     assert!(!Element::empty_tree().uses_non_merk_data_storage());
     assert!(!item.uses_non_merk_data_storage());

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -4805,7 +4805,7 @@ mod tests {
         db.insert(
             EMPTY_PATH,
             b"ct",
-            Element::empty_commitment_tree(4),
+            Element::empty_commitment_tree(4).expect("valid chunk_power"),
             None,
             Some(&tx),
             grove_version,
@@ -4851,7 +4851,7 @@ mod tests {
         db.insert(
             EMPTY_PATH,
             b"ct",
-            Element::empty_commitment_tree(4),
+            Element::empty_commitment_tree(4).expect("valid chunk_power"),
             None,
             Some(&tx),
             grove_version,

--- a/grovedb/src/tests/batch_rejection_tests.rs
+++ b/grovedb/src/tests/batch_rejection_tests.rs
@@ -292,7 +292,7 @@ fn test_batch_all_four_non_merk_tree_types() {
     db.insert(
         [b"parent"].as_ref(),
         b"ct",
-        Element::empty_commitment_tree(10),
+        Element::empty_commitment_tree(10).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -314,7 +314,7 @@ fn test_batch_all_four_non_merk_tree_types() {
     db.insert(
         [b"parent"].as_ref(),
         b"bulk",
-        Element::empty_bulk_append_tree(2),
+        Element::empty_bulk_append_tree(2).expect("valid chunk_power"),
         None,
         None,
         grove_version,

--- a/grovedb/src/tests/batch_unit_tests.rs
+++ b/grovedb/src/tests/batch_unit_tests.rs
@@ -530,7 +530,7 @@ mod tests {
         db.insert(
             EMPTY_PATH,
             b"ct",
-            Element::empty_commitment_tree(10),
+            Element::empty_commitment_tree(10).expect("valid chunk_power"),
             None,
             None,
             grove_version,
@@ -592,7 +592,7 @@ mod tests {
         db.insert(
             EMPTY_PATH,
             b"bulk",
-            Element::empty_bulk_append_tree(10),
+            Element::empty_bulk_append_tree(10).expect("valid chunk_power"),
             None,
             None,
             grove_version,
@@ -668,7 +668,7 @@ mod tests {
             QualifiedGroveDbOp::insert_or_replace_op(
                 vec![b"parent".to_vec()],
                 b"ct".to_vec(),
-                Element::empty_commitment_tree(10),
+                Element::empty_commitment_tree(10).expect("valid chunk_power"),
             ),
             QualifiedGroveDbOp::insert_or_replace_op(
                 vec![b"parent".to_vec(), b"ct".to_vec()],
@@ -736,7 +736,7 @@ mod tests {
             QualifiedGroveDbOp::insert_or_replace_op(
                 vec![b"parent".to_vec()],
                 b"bulk".to_vec(),
-                Element::empty_bulk_append_tree(10),
+                Element::empty_bulk_append_tree(10).expect("valid chunk_power"),
             ),
             QualifiedGroveDbOp::insert_or_replace_op(
                 vec![b"parent".to_vec(), b"bulk".to_vec()],
@@ -1136,7 +1136,7 @@ mod tests {
         let ops = vec![QualifiedGroveDbOp::insert_or_replace_op(
             vec![b"parent".to_vec()],
             b"ct_elem".to_vec(),
-            Element::empty_commitment_tree(10),
+            Element::empty_commitment_tree(10).expect("valid chunk_power"),
         )];
 
         db.apply_batch(ops, None, None, grove_version)

--- a/grovedb/src/tests/bulk_append_tree_tests.rs
+++ b/grovedb/src/tests/bulk_append_tree_tests.rs
@@ -29,7 +29,7 @@ fn test_insert_bulk_append_tree_at_root() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -63,7 +63,7 @@ fn test_bulk_append_tree_under_normal_tree() {
     db.insert(
         [b"parent"].as_ref(),
         b"notes",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -87,7 +87,8 @@ fn test_bulk_append_tree_with_flags() {
     db.insert(
         EMPTY_PATH,
         b"flagged",
-        Element::empty_bulk_append_tree_with_flags(TEST_CHUNK_POWER, flags.clone()),
+        Element::empty_bulk_append_tree_with_flags(TEST_CHUNK_POWER, flags.clone())
+            .expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -105,7 +106,7 @@ fn test_bulk_append_tree_with_flags() {
 
 #[test]
 fn test_bulk_append_tree_is_any_tree() {
-    let element = Element::empty_bulk_append_tree(TEST_CHUNK_POWER);
+    let element = Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power");
     assert!(element.is_any_tree());
     assert!(element.is_bulk_append_tree());
     assert!(!element.is_any_item());
@@ -132,7 +133,7 @@ fn test_bulk_append_single_value() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -157,7 +158,7 @@ fn test_bulk_append_multiple_in_buffer() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -197,7 +198,7 @@ fn test_bulk_get_value_from_buffer() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -237,7 +238,7 @@ fn test_bulk_get_buffer() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -267,7 +268,7 @@ fn test_bulk_state_root_changes_each_append() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -300,7 +301,7 @@ fn test_bulk_compaction_at_chunk_boundary() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -345,7 +346,7 @@ fn test_bulk_chunk_blob_retrievable() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -383,7 +384,7 @@ fn test_bulk_values_accessible_after_compaction() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -423,7 +424,7 @@ fn test_bulk_state_root_deterministic() {
         db.insert(
             EMPTY_PATH,
             b"bulk",
-            Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+            Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
             None,
             None,
             grove_version,
@@ -469,7 +470,7 @@ fn test_bulk_multi_chunk() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -524,7 +525,7 @@ fn test_bulk_three_full_chunks() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -575,7 +576,7 @@ fn test_bulk_batch_single_append() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -613,7 +614,7 @@ fn test_bulk_batch_multiple_appends() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -652,7 +653,7 @@ fn test_bulk_batch_spanning_compaction() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -709,7 +710,7 @@ fn test_bulk_batch_matches_direct_ops() {
     db1.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -728,7 +729,7 @@ fn test_bulk_batch_matches_direct_ops() {
     db2.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -785,7 +786,7 @@ fn test_bulk_batch_with_mixed_ops() {
     db.insert(
         [b"parent"].as_ref(),
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -851,7 +852,7 @@ fn test_bulk_root_hash_propagation() {
     db.insert(
         [b"parent"].as_ref(),
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -892,7 +893,7 @@ fn test_bulk_transaction_commit() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -937,7 +938,7 @@ fn test_bulk_transaction_rollback() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1001,7 +1002,7 @@ fn test_bulk_get_value_out_of_range() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1021,9 +1022,11 @@ fn test_bulk_get_value_out_of_range() {
 }
 
 #[test]
-#[should_panic(expected = "chunk_power must be <= 31")]
 fn test_bulk_invalid_chunk_power() {
-    let _element = Element::empty_bulk_append_tree(32); // Power too large
+    assert!(
+        Element::empty_bulk_append_tree(32).is_err(),
+        "chunk_power > 31 should return error"
+    );
 }
 
 // ===========================================================================
@@ -1038,7 +1041,7 @@ fn test_bulk_delete_empty() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1064,7 +1067,7 @@ fn test_bulk_delete_non_empty() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1107,7 +1110,7 @@ fn test_bulk_delete_non_empty_with_compaction() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1157,7 +1160,7 @@ fn test_bulk_delete_non_empty_error() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1191,7 +1194,7 @@ fn test_bulk_delete_and_recreate() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1225,7 +1228,7 @@ fn test_bulk_delete_and_recreate() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1258,7 +1261,7 @@ fn test_verify_grovedb_bulk_tree_valid() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1296,7 +1299,7 @@ fn test_bulk_persistence_across_reopen() {
         db.insert(
             EMPTY_PATH,
             b"bulk",
-            Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+            Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
             None,
             None,
             grove_version,
@@ -1388,7 +1391,7 @@ fn test_bulk_batch_with_transaction() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1458,7 +1461,7 @@ fn test_bulk_batch_transaction_rollback() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1508,7 +1511,7 @@ fn test_verify_grovedb_bulk_tree_empty() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(TEST_CHUNK_POWER),
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,

--- a/grovedb/src/tests/commitment_tree_tests.rs
+++ b/grovedb/src/tests/commitment_tree_tests.rs
@@ -86,7 +86,7 @@ fn test_insert_commitment_tree_at_root() {
     db.insert(
         EMPTY_PATH,
         b"commitments",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -122,7 +122,7 @@ fn test_commitment_tree_under_normal_tree() {
     db.insert(
         [b"parent"].as_ref(),
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -146,7 +146,8 @@ fn test_commitment_tree_with_flags() {
     db.insert(
         EMPTY_PATH,
         b"flagged",
-        Element::empty_commitment_tree_with_flags(TEST_CHUNK_POWER, flags.clone()),
+        Element::empty_commitment_tree_with_flags(TEST_CHUNK_POWER, flags.clone())
+            .expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -169,7 +170,7 @@ fn test_empty_commitment_tree_serialization_roundtrip() {
     db.insert(
         EMPTY_PATH,
         b"ct",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -197,7 +198,7 @@ fn test_commitment_tree_insert_single() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -249,7 +250,7 @@ fn test_commitment_tree_insert_multiple() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -324,7 +325,7 @@ fn test_commitment_tree_insert_with_transaction() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -382,7 +383,7 @@ fn test_commitment_tree_insert_transaction_rollback() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -428,7 +429,7 @@ fn test_commitment_tree_anchor_empty() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -454,7 +455,7 @@ fn test_commitment_tree_anchor_changes_after_insert() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -499,7 +500,7 @@ fn test_commitment_tree_anchor_deterministic() {
         db.insert(
             EMPTY_PATH,
             b"pool",
-            Element::empty_commitment_tree(TEST_CHUNK_POWER),
+            Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
             None,
             None,
             grove_version,
@@ -558,7 +559,7 @@ fn test_commitment_tree_insert_propagates_root_hash() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -605,7 +606,7 @@ fn test_commitment_tree_nested_propagation() {
     db.insert(
         [b"parent"].as_ref(),
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -643,7 +644,7 @@ fn test_commitment_tree_count() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -692,7 +693,7 @@ fn test_commitment_tree_get_value() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -747,7 +748,7 @@ fn test_commitment_tree_compaction() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(2),
+        Element::empty_commitment_tree(2).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -812,7 +813,7 @@ fn test_commitment_tree_batch_insert() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -878,7 +879,7 @@ fn test_commitment_tree_batch_with_transaction() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -929,7 +930,7 @@ fn test_commitment_tree_batch_and_nonbatch_same_result() {
     db_a.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -956,7 +957,7 @@ fn test_commitment_tree_batch_and_nonbatch_same_result() {
     db_b.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1008,7 +1009,7 @@ fn test_commitment_tree_delete() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1052,7 +1053,7 @@ fn test_commitment_tree_delete_and_recreate() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1085,7 +1086,7 @@ fn test_commitment_tree_delete_and_recreate() {
     db.insert(
         EMPTY_PATH,
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1187,7 +1188,7 @@ fn test_multiple_commitment_trees_independent() {
     db.insert(
         EMPTY_PATH,
         b"pool_a",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1198,7 +1199,7 @@ fn test_multiple_commitment_trees_independent() {
     db.insert(
         EMPTY_PATH,
         b"pool_b",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1268,7 +1269,7 @@ fn test_verify_grovedb_commitment_tree_valid() {
     db.insert(
         EMPTY_PATH,
         b"ct",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1319,7 +1320,7 @@ fn test_commitment_tree_delete_empty() {
     db.insert(
         EMPTY_PATH,
         b"ct",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1346,7 +1347,7 @@ fn test_commitment_tree_delete_non_empty_error() {
     db.insert(
         EMPTY_PATH,
         b"ct",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1400,7 +1401,7 @@ fn test_verify_grovedb_after_commitment_tree_delete() {
     db.insert(
         EMPTY_PATH,
         b"ct",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1485,7 +1486,7 @@ fn test_commitment_tree_prove_query_v1_empty() {
     db.insert(
         &[b"root"],
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1557,7 +1558,7 @@ fn test_commitment_tree_prove_query_v1_buffer_only() {
     db.insert(
         &[b"root"],
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1680,7 +1681,7 @@ fn test_commitment_tree_prove_query_v1_with_chunks() {
     db.insert(
         &[b"root"],
         b"pool",
-        Element::empty_commitment_tree(chunk_power),
+        Element::empty_commitment_tree(chunk_power).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1795,7 +1796,7 @@ fn test_commitment_tree_prove_query_v1_partial_range() {
     db.insert(
         &[b"root"],
         b"pool",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1975,7 +1976,7 @@ fn test_commitment_tree_persistence_across_reopen() {
         db.insert(
             EMPTY_PATH,
             b"pool",
-            Element::empty_commitment_tree(TEST_CHUNK_POWER),
+            Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
             None,
             None,
             grove_version,
@@ -2052,7 +2053,7 @@ fn test_verify_grovedb_commitment_tree_empty() {
     db.insert(
         EMPTY_PATH,
         b"ct",
-        Element::empty_commitment_tree(TEST_CHUNK_POWER),
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
         None,
         None,
         grove_version,

--- a/grovedb/src/tests/proof_coverage_tests.rs
+++ b/grovedb/src/tests/proof_coverage_tests.rs
@@ -2960,7 +2960,7 @@ mod tests {
         db.insert(
             [b"root"].as_ref(),
             b"bat",
-            Element::empty_bulk_append_tree(2), // chunk_power = 2 (epoch_size = 4)
+            Element::empty_bulk_append_tree(2).expect("valid chunk_power"), // chunk_power = 2 (epoch_size = 4)
             None,
             None,
             grove_version,
@@ -4245,7 +4245,7 @@ mod tests {
         db.insert(
             EMPTY_PATH,
             b"bat",
-            Element::empty_bulk_append_tree(2),
+            Element::empty_bulk_append_tree(2).expect("valid chunk_power"),
             None,
             None,
             grove_version,
@@ -4424,7 +4424,7 @@ mod tests {
         db.insert(
             [b"root"].as_ref(),
             b"bat",
-            Element::empty_bulk_append_tree(2),
+            Element::empty_bulk_append_tree(2).expect("valid chunk_power"),
             None,
             None,
             grove_version,
@@ -5148,7 +5148,7 @@ mod tests {
         db.insert(
             [b"root"].as_ref(),
             b"bat",
-            Element::empty_bulk_append_tree(2), // chunk_power = 2 (epoch_size = 4)
+            Element::empty_bulk_append_tree(2).expect("valid chunk_power"), // chunk_power = 2 (epoch_size = 4)
             None,
             None,
             grove_version,
@@ -5577,7 +5577,7 @@ mod tests {
         db.insert(
             [b"root"].as_ref(),
             b"pool",
-            Element::empty_commitment_tree(2),
+            Element::empty_commitment_tree(2).expect("valid chunk_power"),
             None,
             None,
             grove_version,

--- a/grovedb/src/tests/v1_proof_tests.rs
+++ b/grovedb/src/tests/v1_proof_tests.rs
@@ -276,7 +276,7 @@ fn test_bulk_append_tree_v1_proof_buffer_range() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(2),
+        Element::empty_bulk_append_tree(2).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -362,7 +362,7 @@ fn test_bulk_append_tree_v1_proof_chunk_and_buffer() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(2),
+        Element::empty_bulk_append_tree(2).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -755,7 +755,7 @@ fn test_bulk_append_tree_v1_proof_disjoint_query_succinctness() {
     db.insert(
         EMPTY_PATH,
         b"bulk",
-        Element::empty_bulk_append_tree(2),
+        Element::empty_bulk_append_tree(2).expect("valid chunk_power"),
         None,
         None,
         grove_version,
@@ -1155,7 +1155,7 @@ fn test_v0_proof_rejects_bulk_append_tree_subquery() {
     db.insert(
         [b"parent"].as_ref(),
         b"bulk",
-        Element::empty_bulk_append_tree(2),
+        Element::empty_bulk_append_tree(2).expect("valid chunk_power"),
         None,
         None,
         grove_version,


### PR DESCRIPTION
## Summary

- Change `empty_commitment_tree`, `empty_commitment_tree_with_flags`, `empty_bulk_append_tree`, and `empty_bulk_append_tree_with_flags` to return `Result<Element, ElementError>` instead of panicking via `assert!` when `chunk_power > 31`
- Uses existing `ElementError::InvalidInput` variant
- Updated all ~90 call sites in tests to use `.expect("valid chunk_power")`
- Existing `test_bulk_invalid_chunk_power` test converted from `#[should_panic]` to `assert!(is_err())`

Audit finding M1.

## Test plan

- [x] `cargo test -p grovedb-element --all-features` — 4 passed
- [x] `cargo test -p grovedb --lib --features full` — 1272 passed
- [x] `test_bulk_invalid_chunk_power` verifies error return on chunk_power=32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tree constructors now validate input parameters and return results indicating success or failure instead of silently accepting invalid values, improving error handling and preventing downstream issues.

* **Tests**
  * Updated test cases to properly handle the new constructor behavior with validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->