### PR TITLE
fix: replace expect with error return in range query iterator (audit M3)

### DIFF
--- a/grovedb/src/element/query.rs
+++ b/grovedb/src/element/query.rs
@@ -712,19 +712,26 @@ impl ElementQueryExtensions for Element {
                 .iter_is_valid_for_type(&iter, *limit, None, sized_query.query.left_to_right)
                 .unwrap_add_cost(&mut cost)
             {
+                let value_bytes =
+                    iter.value()
+                        .unwrap_add_cost(&mut cost)
+                        .ok_or(Error::CorruptedData(
+                            "expected iterator value but got None".to_string(),
+                        ));
                 let element = cost_return_on_error_into_no_add!(
                     cost,
                     Element::raw_decode(
-                        iter.value()
-                            .unwrap_add_cost(&mut cost)
-                            .expect("if key exists then value should too"),
+                        cost_return_on_error_no_add!(cost, value_bytes),
                         grove_version
                     )
                 );
                 let key = iter
                     .key()
                     .unwrap_add_cost(&mut cost)
-                    .expect("key should exist");
+                    .ok_or(Error::CorruptedData(
+                        "expected iterator key but got None".to_string(),
+                    ));
+                let key = cost_return_on_error_no_add!(cost, key);
                 let (subquery_path, subquery) =
                     Self::subquery_paths_and_value_for_sized_query(sized_query, key);
                 let result_with_cost = add_element_function(


### PR DESCRIPTION
## Summary

Replace `.expect()` calls on iterator `value()` and `key()` in `Element::query` range handling with proper `Error::CorruptedData` returns. If storage is corrupted, the iterator could return `None` even though `iter_is_valid_for_type` reports valid, causing a panic.

Audit finding M3.

## Test plan

- [x] `cargo build --features full` — clean
- [x] `cargo test -p grovedb --lib --features full -- query_tests` — 65 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)