### PR TITLE
fix: replace panics with error returns in TreeNode::load

### DIFF
--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -1214,8 +1214,12 @@ impl TreeNode {
     where
         V: Fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>,
     {
-        // TODO: return Err instead of panic?
-        let link = self.link(left).expect("Expected link");
+        let Some(link) = self.link(left) else {
+            return Err(Error::CorruptedState(
+                "Expected link but found None in TreeNode::load",
+            ))
+            .wrap_with_cost(Default::default());
+        };
         let (child_heights, hash, aggregate_data) = match link {
             Link::Reference {
                 child_heights,
@@ -1223,7 +1227,12 @@ impl TreeNode {
                 aggregate_data,
                 ..
             } => (child_heights, hash, aggregate_data),
-            _ => panic!("Expected Some(Link::Reference)"),
+            _ => {
+                return Err(Error::CorruptedState(
+                    "Expected Link::Reference in TreeNode::load",
+                ))
+                .wrap_with_cost(Default::default());
+            }
         };
 
         let mut cost = OperationCost::default();


### PR DESCRIPTION
## Summary
- `TreeNode::load()` panicked via `.expect("Expected link")` and `panic!("Expected Some(Link::Reference)")` for conditions that should return errors
- Both are now proper `Err(Error::CorruptedState(...))` returns, matching the function's existing `CostResult<(), Error>` return type
- Removes the TODO comment that requested this exact change

## Test plan
- [x] All 330 merk unit tests pass (`cargo test -p grovedb-merk --lib`)
- [x] `cargo build -p grovedb-merk` compiles cleanly

Fixes audit finding M9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)