### PR TITLE
fix: consistency check now catches InsertOnly and DeleteTree

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -902,7 +902,7 @@ impl QualifiedGroveDbOp {
         // Build a map of deleted_qualified_path -> indices of delete ops
         let mut deleted_path_to_op_indices: HashMap<KeyInfoPath, Vec<usize>> = HashMap::new();
         for (idx, op) in ops.iter().enumerate() {
-            if let GroveOp::Delete = op.op {
+            if matches!(op.op, GroveOp::Delete | GroveOp::DeleteTree(..)) {
                 let Some(ref key) = op.key else {
                     continue;
                 };
@@ -919,7 +919,10 @@ impl QualifiedGroveDbOp {
         let mut conflicts: HashMap<KeyInfoPath, Vec<usize>> = HashMap::new();
         for (idx, op) in ops.iter().enumerate() {
             match op.op {
-                GroveOp::InsertOrReplace { .. } | GroveOp::Replace { .. } => {}
+                GroveOp::InsertOnly { .. }
+                | GroveOp::InsertOrReplace { .. }
+                | GroveOp::Replace { .. }
+                | GroveOp::Patch { .. } => {}
                 _ => continue,
             }
             for prefix_len in 1..=op.path.len() as usize {

--- a/grovedb/src/tests/batch_unit_tests.rs
+++ b/grovedb/src/tests/batch_unit_tests.rs
@@ -518,6 +518,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_consistency_insert_only_under_deleted_path() {
+        let ops = vec![
+            QualifiedGroveDbOp::delete_op(vec![b"root".to_vec()], b"subtree".to_vec()),
+            QualifiedGroveDbOp::insert_only_op(
+                vec![b"root".to_vec(), b"subtree".to_vec()],
+                b"key".to_vec(),
+                Element::new_item(b"val".to_vec()),
+            ),
+        ];
+        let results = QualifiedGroveDbOp::verify_consistency_of_operations(&ops);
+        assert!(
+            !results.is_empty(),
+            "InsertOnly under a deleted path should be flagged"
+        );
+    }
+
+    #[test]
+    fn test_consistency_insert_under_delete_tree_path() {
+        let ops = vec![
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![b"root".to_vec()],
+                b"subtree".to_vec(),
+                TreeType::NormalTree,
+            ),
+            QualifiedGroveDbOp::insert_or_replace_op(
+                vec![b"root".to_vec(), b"subtree".to_vec()],
+                b"key".to_vec(),
+                Element::new_item(b"val".to_vec()),
+            ),
+        ];
+        let results = QualifiedGroveDbOp::verify_consistency_of_operations(&ops);
+        assert!(
+            !results.is_empty(),
+            "insert under a DeleteTree path should be flagged"
+        );
+    }
+
     // ===================================================================
     // Group 6: apply_operations_without_batching — non-Merk tree ops
     // ===================================================================


### PR DESCRIPTION
## Summary
- `verify_consistency_of_operations` had two gaps in its "no inserts under deleted paths" check:
  1. Only `GroveOp::Delete` was considered when building deleted paths — `DeleteTree` (which removes everything under a path) was missed
  2. Only `InsertOrReplace` and `Replace` were checked as conflicting inserts — `InsertOnly` and `Patch` were missed
- Both are now included in the respective match arms

## Test plan
- [x] `test_consistency_insert_only_under_deleted_path` — verifies `InsertOnly` under a `Delete` path is flagged
- [x] `test_consistency_insert_under_delete_tree_path` — verifies `InsertOrReplace` under a `DeleteTree` path is flagged
- [x] All 4 consistency tests pass

Note: L16 from the audit ("`count > 1` instead of `count > 0`") is a false positive — the counter starts at 0 and increments per occurrence, so `count > 1` correctly catches ops appearing 2+ times.

Fixes audit finding L17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)