### PR TITLE
fix: prevent arithmetic overflow and truncation (L1,L3,L7,L8,L13,L18,L19)

### DIFF
--- a/costs/src/lib.rs
+++ b/costs/src/lib.rs
@@ -212,21 +212,21 @@ impl OperationCost {
             let mut paid_value_len = value_len;
             // We need to remove the child sizes if they exist
             if let Some((in_sum_tree, left_child, right_child)) = children_sizes {
-                paid_value_len -= 2; // for the child options
+                paid_value_len = paid_value_len.saturating_sub(2); // for the child options
 
                 // We need to remove the costs of the children
                 if let Some((left_child_len, left_child_sum_len)) = left_child {
-                    paid_value_len -= left_child_len;
-                    paid_value_len -= left_child_sum_len;
+                    paid_value_len = paid_value_len.saturating_sub(left_child_len);
+                    paid_value_len = paid_value_len.saturating_sub(left_child_sum_len);
                 }
                 if let Some((right_child_len, right_child_sum_len)) = right_child {
-                    paid_value_len -= right_child_len;
-                    paid_value_len -= right_child_sum_len;
+                    paid_value_len = paid_value_len.saturating_sub(right_child_len);
+                    paid_value_len = paid_value_len.saturating_sub(right_child_sum_len);
                 }
 
                 let sum_tree_node_size = if let Some((tree_cost_type, sum_tree_len)) = in_sum_tree {
                     let cost_size = tree_cost_type.cost_size();
-                    paid_value_len -= sum_tree_len;
+                    paid_value_len = paid_value_len.saturating_sub(sum_tree_len);
                     paid_value_len += cost_size;
                     cost_size
                 } else {
@@ -292,22 +292,30 @@ impl Add for OperationCost {
 
     fn add(self, rhs: Self) -> Self::Output {
         OperationCost {
-            seek_count: self.seek_count + rhs.seek_count,
+            seek_count: self.seek_count.saturating_add(rhs.seek_count),
             storage_cost: self.storage_cost + rhs.storage_cost,
-            storage_loaded_bytes: self.storage_loaded_bytes + rhs.storage_loaded_bytes,
-            hash_node_calls: self.hash_node_calls + rhs.hash_node_calls,
-            sinsemilla_hash_calls: self.sinsemilla_hash_calls + rhs.sinsemilla_hash_calls,
+            storage_loaded_bytes: self
+                .storage_loaded_bytes
+                .saturating_add(rhs.storage_loaded_bytes),
+            hash_node_calls: self.hash_node_calls.saturating_add(rhs.hash_node_calls),
+            sinsemilla_hash_calls: self
+                .sinsemilla_hash_calls
+                .saturating_add(rhs.sinsemilla_hash_calls),
         }
     }
 }
 
 impl AddAssign for OperationCost {
     fn add_assign(&mut self, rhs: Self) {
-        self.seek_count += rhs.seek_count;
+        self.seek_count = self.seek_count.saturating_add(rhs.seek_count);
         self.storage_cost += rhs.storage_cost;
-        self.storage_loaded_bytes += rhs.storage_loaded_bytes;
-        self.hash_node_calls += rhs.hash_node_calls;
-        self.sinsemilla_hash_calls += rhs.sinsemilla_hash_calls;
+        self.storage_loaded_bytes = self
+            .storage_loaded_bytes
+            .saturating_add(rhs.storage_loaded_bytes);
+        self.hash_node_calls = self.hash_node_calls.saturating_add(rhs.hash_node_calls);
+        self.sinsemilla_hash_calls = self
+            .sinsemilla_hash_calls
+            .saturating_add(rhs.sinsemilla_hash_calls);
     }
 }
 

--- a/grovedb-epoch-based-storage-flags/src/lib.rs
+++ b/grovedb-epoch-based-storage-flags/src/lib.rs
@@ -775,9 +775,10 @@ impl StorageFlags {
             while bytes_left > 0 {
                 if let Some((epoch_index, bytes_in_epoch)) = rev_iter.next() {
                     if *bytes_in_epoch <= bytes_left + MINIMUM_NON_BASE_FLAGS_SIZE {
-                        sectioned_storage_removal
-                            .insert(*epoch_index, *bytes_in_epoch - MINIMUM_NON_BASE_FLAGS_SIZE);
-                        bytes_left -= *bytes_in_epoch - MINIMUM_NON_BASE_FLAGS_SIZE;
+                        let epoch_removable =
+                            bytes_in_epoch.saturating_sub(MINIMUM_NON_BASE_FLAGS_SIZE);
+                        sectioned_storage_removal.insert(*epoch_index, epoch_removable);
+                        bytes_left = bytes_left.saturating_sub(epoch_removable);
                     } else {
                         // Correctly take only the required bytes_left from this epoch
                         sectioned_storage_removal.insert(*epoch_index, bytes_left);

--- a/grovedb/src/batch/key_info.rs
+++ b/grovedb/src/batch/key_info.rs
@@ -110,7 +110,11 @@ impl Hash for KeyInfo {
 impl WorstKeyLength for KeyInfo {
     fn max_length(&self) -> u8 {
         match self {
-            Self::KnownKey(key) => key.len() as u8,
+            Self::KnownKey(key) => {
+                // Keys are validated to be <= 255 bytes at insert time,
+                // but saturate to avoid silent truncation on unexpected data.
+                u8::try_from(key.len()).unwrap_or(u8::MAX)
+            }
             Self::MaxKeySize { max_size, .. } => *max_size,
         }
     }

--- a/grovedb/src/operations/delete/delete_up_tree.rs
+++ b/grovedb/src/operations/delete/delete_up_tree.rs
@@ -159,7 +159,7 @@ impl GroveDb {
             transaction,
             grove_version,
         )
-        .map_ok(|_| ops_len as u16)
+        .map_ok(|_| u16::try_from(ops_len).unwrap_or(u16::MAX))
     }
 
     /// Returns a vector of GroveDb ops

--- a/grovedb/src/query_result_type.rs
+++ b/grovedb/src/query_result_type.rs
@@ -119,7 +119,7 @@ impl BTreeMapLevelResult {
 
 impl BTreeMapLevelResult {
     /// Returns the number of values at the given path within this result tree.
-    pub fn len_of_values_at_path(&self, path: &[&[u8]]) -> u16 {
+    pub fn len_of_values_at_path(&self, path: &[&[u8]]) -> usize {
         let mut current = self;
 
         // Traverse the path
@@ -139,7 +139,7 @@ impl BTreeMapLevelResult {
             }
         }
 
-        current.key_values.len() as u16
+        current.key_values.len()
     }
 }
 

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -577,16 +577,30 @@ pub(crate) mod utils {
             }
 
             // Read length as u32 (big-endian)
-            let byte_length = u32::from_be_bytes([
+            let byte_length_u32 = u32::from_be_bytes([
                 packed_data[index],
                 packed_data[index + 1],
                 packed_data[index + 2],
                 packed_data[index + 3],
-            ]) as usize;
+            ]);
+            let byte_length: usize = byte_length_u32 as usize;
+            // Guard against truncation on 32-bit platforms where usize is 32 bits
+            if byte_length as u32 != byte_length_u32 {
+                return Err(Error::CorruptedData(format!(
+                    "Nested array {} length {} exceeds platform address space",
+                    i, byte_length_u32
+                )));
+            }
             index += 4; // Move past the length bytes
 
-            // Ensure there's enough data for the byte sequence
-            if index + byte_length > packed_data.len() {
+            // Use checked addition to prevent overflow on the bounds check
+            let end = index.checked_add(byte_length).ok_or_else(|| {
+                Error::CorruptedData(format!(
+                    "Nested array {} length overflow (index: {}, length: {})",
+                    i, index, byte_length
+                ))
+            })?;
+            if end > packed_data.len() {
                 return Err(Error::CorruptedData(format!(
                     "Unexpected end of data while reading nested array {} (expected length: {})",
                     i, byte_length
@@ -594,8 +608,8 @@ pub(crate) mod utils {
             }
 
             // Extract the byte sequence
-            let byte_sequence = packed_data[index..index + byte_length].to_vec();
-            index += byte_length;
+            let byte_sequence = packed_data[index..end].to_vec();
+            index = end;
 
             // Push into the result
             nested_bytes.push(byte_sequence);

--- a/merk/src/tree/link.rs
+++ b/merk/src/tree/link.rs
@@ -205,7 +205,17 @@ impl Link {
             Link::Uncommitted { child_heights, .. } => *child_heights,
             Link::Loaded { child_heights, .. } => *child_heights,
         };
-        right_height as i8 - left_height as i8
+        // Subtract in i16 to avoid wrapping when u8 heights exceed 127,
+        // then clamp to i8 range. For a valid AVL tree the result is in
+        // [-2, 2], but corrupted data could produce larger differences.
+        let diff = right_height as i16 - left_height as i16;
+        if diff > i8::MAX as i16 {
+            i8::MAX
+        } else if diff < i8::MIN as i16 {
+            i8::MIN
+        } else {
+            diff as i8
+        }
     }
 
     /// Consumes the link and converts to variant `Link::Reference`. Panics if


### PR DESCRIPTION
## Summary
- **L1**: `saturating_sub` in epoch storage flag removal to prevent underflow when `bytes_in_epoch < MINIMUM_NON_BASE_FLAGS_SIZE`
- **L3**: `saturating_add`/`saturating_sub` in `OperationCost` `Add`/`AddAssign` and `paid_value_len` calculations to prevent wrapping on accumulation
- **L7**: `checked_add` for bounds check and `u32`→`usize` truncation guard in replication `unpack_and_verify_nested_bytes`
- **L8**: Compute `balance_factor` in `i16` and clamp to `i8` range to prevent wrapping when `u8` heights exceed 127
- **L13**: Change `len_of_values_at_path` return type from `u16` to `usize` to eliminate truncation
- **L18**: Use `u8::try_from(key.len()).unwrap_or(u8::MAX)` instead of `key.len() as u8` in `KeyInfo::max_length()`
- **L19**: Use `u16::try_from(ops_len).unwrap_or(u16::MAX)` instead of `ops_len as u16` in `delete_up_tree_while_empty`

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test -p grovedb-merk --lib` — 332 passed
- [x] `cargo test -p grovedb --lib -- delete_up_tree` — 21 passed
- [x] `cargo test -p grovedb --lib -- query_result_type` — 33 passed
- [x] `cargo test -p grovedb --lib -- replication` — 39 passed
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)