### PR TITLE
fix: use saturating_sub for limit/offset decrements (L2)

### DIFF
--- a/grovedb/src/element/query.rs
+++ b/grovedb/src/element/query.rs
@@ -487,10 +487,10 @@ impl ElementQueryExtensions for Element {
                     };
 
                     if let Some(limit) = limit {
-                        *limit -= 1;
+                        *limit = limit.saturating_sub(1);
                     }
                 } else if let Some(offset) = offset {
-                    *offset -= 1;
+                    *offset = offset.saturating_sub(1);
                 }
             } else if allow_get_raw {
                 cost_return_on_error_no_add!(
@@ -825,10 +825,10 @@ impl ElementQueryExtensions for Element {
                 }
             }
             if let Some(limit) = limit {
-                *limit -= 1;
+                *limit = limit.saturating_sub(1);
             }
         } else if let Some(offset) = offset {
-            *offset -= 1;
+            *offset = offset.saturating_sub(1);
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Replace unchecked `*limit -= 1` and `*offset -= 1` with `saturating_sub(1)` in `path_query_push` and `basic_push` (4 locations in `grovedb/src/element/query.rs`)
- Prevents potential u16 underflow if limit or offset reaches 0 unexpectedly
- Consistent with the saturating approach already used elsewhere in the same file (lines 401, 403, 407)

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test -p grovedb --lib -- query` — 335 passed
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved query limit and offset handling to prevent underflow issues during query processing, ensuring more reliable and stable query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->