### PR TITLE
fix: return error instead of panicking on None tree in rewrite_heights (M11)

### DIFF
--- a/merk/src/merk/restore.rs
+++ b/merk/src/merk/restore.rs
@@ -467,8 +467,13 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
         }
 
         let mut batch = self.merk.storage.new_batch();
-        // TODO: deal with unwrap
-        let mut tree = self.merk.tree.take().unwrap();
+        let mut tree =
+            self.merk
+                .tree
+                .take()
+                .ok_or(Error::ChunkRestoringError(ChunkError::InternalError(
+                    "tree is None in rewrite_heights",
+                )))?;
         let walker = RefWalker::new(&mut tree, self.merk.source());
 
         rewrite_child_heights(walker, &mut batch, grove_version)?;


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` on `self.merk.tree.take()` in `Restorer::rewrite_heights` with `.ok_or()` error return
- Prevents panic if tree is unexpectedly None during chunk restoration

## Test plan
- [x] `cargo build -p grovedb-merk` — clean
- [x] `cargo test -p grovedb-merk --lib -- restore` — 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)