### PR TITLE
fix: initialize last_level from previous ops in continue_from_ops (M13)

### DIFF
--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -111,7 +111,8 @@ where
         let mut cost = OperationCost::default();
 
         let mut ops_by_level_paths: OpsByLevelPath = previous_ops.unwrap_or_default();
-        let mut current_last_level: u32 = 0;
+        let mut current_last_level: u32 =
+            ops_by_level_paths.iter().map(|(k, _)| k).max().unwrap_or(0);
 
         // qualified paths meaning path + key
         let mut ops_by_qualified_paths: BTreeMap<Vec<Vec<u8>>, GroveOp> = BTreeMap::new();


### PR DESCRIPTION
## Summary

Fixes a bug in `continue_from_ops` where `current_last_level` was initialized to 0 instead of being derived from the max level already present in `previous_ops`.

### How batch application works

Batch ops are organized by tree depth level in an `IntMap<u32, OpsByPath>`. Application starts at the deepest level (`last_level`) and walks up to level 0, applying ops bottom-up and propagating root hashes to parent levels:

```
current_level = last_level;  // e.g. 5
while let Some(ops) = ops_by_level_paths.remove(current_level) {
    // process ops, propagate root hashes up to parent level
    current_level = current_level.saturating_sub(1);
}
```

### The bug

`continue_from_ops` is called when resuming a paused batch. It receives `previous_ops` (leftover ops from the paused batch) and merges in new `ops`. The `current_last_level` tracking variable was initialized to 0 and only updated inside an `.or_insert_with()` closure that fires when a *new* level entry is created in the IntMap:

```rust
let ops_on_level = ops_by_level_paths.entry(level).or_insert_with(|| {
    if current_last_level < level {
        current_last_level = level;  // only fires for NEW levels
    }
    BTreeMap::new()
});
```

If `previous_ops` already has ops at levels 3 and 5, and the new ops only touch those same levels (no new levels created), the closure never fires and `current_last_level` stays 0. The application loop then starts at level 0, finds nothing (or only root ops), and terminates — **silently skipping all ops at levels 1–5**.

This doesn't affect `from_ops` (non-resumed path) because with no `previous_ops`, every level is new and the closure always fires.

### The fix

Initialize `current_last_level` from the max key already present in `previous_ops`:

```rust
let mut current_last_level: u32 =
    ops_by_level_paths.iter().map(|(k, _)| k).max().unwrap_or(0);
```

## Test plan
- [x] `cargo build -p grovedb` — clean
- [x] `cargo test -p grovedb --lib -- batch` — 298 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)