### PR TITLE
fix: use explicit .value for discarded costs in Restorer (L9)

### DIFF
--- a/merk/src/merk/restore.rs
+++ b/merk/src/merk/restore.rs
@@ -335,11 +335,11 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
             },
         )?;
 
-        // write the batch
+        // write the batch (costs intentionally discarded — restorer does not track them)
         self.merk
             .storage
             .commit_batch(batch)
-            .unwrap()
+            .value
             .map_err(StorageError)?;
 
         Ok(new_chunk_ids)
@@ -475,10 +475,11 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
 
         self.merk.tree.set(Some(tree));
 
+        // costs intentionally discarded — restorer does not track them
         self.merk
             .storage
             .commit_batch(batch)
-            .unwrap()
+            .value
             .map_err(StorageError)
     }
 


### PR DESCRIPTION
## Summary
- Replace ambiguous `.unwrap()` calls on `CostContext` with explicit `.value` field access in `Restorer::write_chunk` and `Restorer::rewrite_heights`
- Add comments clarifying costs are intentionally discarded since the Restorer does not track operation costs

## Test plan
- [x] `cargo build -p grovedb-merk` — clean
- [x] `cargo test -p grovedb-merk --lib -- restore` — 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)