### PR TITLE
fix: propagate error and clarify discarded costs in ChunkProducer (L10)

### DIFF
--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -152,7 +152,7 @@ where
 
         self.index = index + 1;
 
-        let chunk_height = chunk_height(self.height, index).unwrap();
+        let chunk_height = chunk_height(self.height, index)?;
 
         let tree_type = self.merk.tree_type;
         let chunk = self
@@ -169,7 +169,8 @@ where
                 )))
                 .wrap_with_cost(Default::default()),
             })
-            .unwrap()?;
+            // costs intentionally discarded — chunk producer does not track them
+            .value?;
 
         // now we need to return the next index
         // how do we know if we should return some or none


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` on `chunk_height` `Result` with `?` to propagate errors instead of panicking
- Replace `.unwrap()` on `CostContext` with `.value` and comment clarifying costs are intentionally discarded

## Test plan
- [x] `cargo build -p grovedb-merk` — clean
- [x] `cargo test -p grovedb-merk --lib -- chunk` — 67 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)