### PR TITLE
fix: replace unreachable!() with error returns in Walker::detach (L11)

### DIFF
--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -69,13 +69,23 @@ where
         let child = if link.tree().is_some() {
             match self.tree.own_return(|t| t.detach(left)) {
                 Some(child) => child,
-                _ => unreachable!("Expected Some"),
+                _ => {
+                    return Err(Error::CorruptedState(
+                        "expected child tree after detach but got None",
+                    ))
+                    .wrap_with_cost(cost);
+                }
             }
         } else {
             let link = self.tree.slot_mut(left).take();
             match link {
                 Some(Link::Reference { .. }) => (),
-                _ => unreachable!("Expected Some(Link::Reference)"),
+                _ => {
+                    return Err(Error::CorruptedState(
+                        "expected Link::Reference but found other variant or None",
+                    ))
+                    .wrap_with_cost(cost);
+                }
             }
             cost_return_on_error!(
                 &mut cost,


### PR DESCRIPTION
## Summary
- Replace two `unreachable!()` calls in `Walker::detach` with `CorruptedState` error returns
- These branches could be reached with corrupted tree data (e.g., link claims tree is loaded but detach returns None, or link is not `Reference` variant when expected)
- Fails gracefully instead of panicking

## Test plan
- [x] `cargo build -p grovedb-merk` — clean
- [x] `cargo test -p grovedb-merk --lib` — 332 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)