### PR TITLE
fix: remove leftover eprintln in proof verification (L12)

### DIFF
--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -1322,7 +1322,6 @@ impl GroveDb {
             )
             .unwrap()
             .map_err(|e| {
-                eprintln!("{e}");
                 Error::InvalidProof(
                     query.clone(),
                     format!("Invalid proof verification parameters: {}", e),


### PR DESCRIPTION
## Summary
- Remove debug `eprintln!("{e}")` in proof verification error path that leaked error details to stderr in production
- The error info is already captured in the `InvalidProof` error message returned to the caller

## Test plan
- [x] `cargo build -p grovedb` — clean
- [x] `cargo test -p grovedb --lib -- proof` — 198 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)