### PR TITLE
fix: return error on deserialization failure during proof generation (L14)

### DIFF
--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -508,8 +508,12 @@ impl GroveDb {
                             | Ok(Element::MmrTree(..))
                             | Ok(Element::BulkAppendTree(..))
                             | Ok(Element::DenseAppendOnlyFixedSizeTree(..)) => continue,
-                            // Deserialization errors: skip silently
-                            Err(_) => continue,
+                            Err(e) => {
+                                return Err(Error::CorruptedData(format!(
+                                    "failed to deserialize element during proof generation: {e}"
+                                )))
+                                .wrap_with_cost(cost);
+                            }
                         }
                     }
                     _ => continue,
@@ -1174,8 +1178,12 @@ impl GroveDb {
                             | Ok(Element::MmrTree(..))
                             | Ok(Element::BulkAppendTree(..))
                             | Ok(Element::DenseAppendOnlyFixedSizeTree(..)) => continue,
-                            // Deserialization errors: skip silently
-                            Err(_) => continue,
+                            Err(e) => {
+                                return Err(Error::CorruptedData(format!(
+                                    "failed to deserialize element during proof generation: {e}"
+                                )))
+                                .wrap_with_cost(cost);
+                            }
                         }
                     }
                     _ => continue,


### PR DESCRIPTION
## Summary
- Replace silent `Err(_) => continue` on Element deserialization errors with `CorruptedData` error returns (2 locations in `generate.rs`)
- Silently skipping corrupted elements would produce incomplete proofs that omit data the verifier expects

## Test plan
- [x] `cargo build -p grovedb` — clean
- [x] `cargo test -p grovedb --lib -- proof` — 198 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)