### PR TITLE
docs: document why encode_into expect is unreachable (L15)

### DIFF
--- a/grovedb-query/src/proofs/encoding.rs
+++ b/grovedb-query/src/proofs/encoding.rs
@@ -878,11 +878,17 @@ impl Op {
     }
 }
 
-/// Encode a sequence of Ops into a byte vector
+/// Encode a sequence of Ops into a byte vector.
+///
+/// # Panics
+/// Panics if encoding fails — this is unreachable when writing to a `Vec<u8>`
+/// since `Vec<u8>: Write` never returns IO errors. The only theoretical error
+/// source is `ed::Error::UnexpectedByte`, which would indicate a bug in the
+/// encoding logic itself.
 pub fn encode_into<'a, T: Iterator<Item = &'a Op>>(ops: T, output: &mut Vec<u8>) {
     for op in ops {
         op.encode_into_with_error(output)
-            .expect("encoding should not fail");
+            .expect("encoding into Vec<u8> is infallible");
     }
 }
 


### PR DESCRIPTION
## Summary
- Add doc comment explaining that `encode_into`'s `.expect()` is unreachable: encoding into `Vec<u8>` is infallible since `Vec<u8>: Write` never returns IO errors
- Improve the expect message from "encoding should not fail" to "encoding into Vec<u8> is infallible"

## Test plan
- [x] `cargo build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for proof encoding functionality with additional clarification notes.

* **Chores**
  * Improved error handling clarity in encoding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->