### PR TITLE
fix: return error instead of panicking on missing flags in JIT update (L20)

### DIFF
--- a/grovedb/src/batch/just_in_time_reference_update.rs
+++ b/grovedb/src/batch/just_in_time_reference_update.rs
@@ -129,18 +129,26 @@ where
 
             let mut new_element_cloned = original_new_element.clone();
 
+            let new_flags = cost_return_on_error_no_add!(
+                cost,
+                new_element_cloned
+                    .get_flags_mut()
+                    .as_mut()
+                    .ok_or(Error::CorruptedCodeExecution(
+                        "element has no flags for just-in-time update",
+                    ))
+            );
             let changed = cost_return_on_error_no_add!(
                 cost,
-                (flags_update)(
-                    &storage_costs,
-                    maybe_old_flags.clone(),
-                    new_element_cloned.get_flags_mut().as_mut().unwrap()
-                )
-                .map_err(|e| match e {
-                    Error::JustInTimeElementFlagsClientError(_) => {
-                        MerkError::ClientCorruptionError(e.to_string()).into()
+                (flags_update)(&storage_costs, maybe_old_flags.clone(), new_flags).map_err(|e| {
+                    match e {
+                        Error::JustInTimeElementFlagsClientError(_) => {
+                            MerkError::ClientCorruptionError(e.to_string()).into()
+                        }
+                        _ => {
+                            MerkError::ClientCorruptionError("non client error".to_string()).into()
+                        }
                     }
-                    _ => MerkError::ClientCorruptionError("non client error".to_string(),).into(),
                 })
             );
             if !changed {


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` on `get_flags_mut().as_mut()` with `.ok_or()` error return in `process_old_element_flags`
- If an element has no flags during just-in-time reference update, returns a `CorruptedCodeExecution` error instead of panicking

## Test plan
- [x] `cargo build -p grovedb` — clean
- [x] `cargo test -p grovedb --lib -- batch` — 298 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)