### PR TITLE
fix: validate dense tree height before bit shift (C3)

### DIFF
--- a/grovedb/src/operations/dense_tree.rs
+++ b/grovedb/src/operations/dense_tree.rs
@@ -370,6 +370,12 @@ impl GroveDb {
             // Pre-validate capacity for ALL values before writing anything to
             // storage. Without this check, partial inserts would persist in the
             // transaction on failure.
+            if height >= 16 {
+                return Err(Error::InvalidInput(
+                    "dense tree height must be less than 16",
+                ))
+                .wrap_with_cost(cost);
+            }
             let capacity = ((1u32 << height) - 1) as u16;
             let needed = existing_count as u32 + values.len() as u32;
             if needed > capacity as u32 {


### PR DESCRIPTION
## Summary

**Severity: Critical** — Fixes a panic/corruption from deserialized input.

### The Bug

`Element::DenseAppendOnlyFixedSizeTree(count, height, _)` stores a `height` field that is used to compute tree capacity via `(1u32 << height) - 1`. The height comes from deserialized element data. If corrupted or maliciously crafted:

- **height >= 32**: `1u32 << height` panics in debug mode (shift overflow) or wraps to 0 in release, making `capacity = u16::MAX`
- **height 17-31**: `(1u32 << height) - 1` produces values > `u16::MAX` which silently truncate via the `as u16` cast, leading to incorrect capacity calculations

### The Fix

Added an explicit validation that `height < 16` before the bit shift at `grovedb/src/operations/dense_tree.rs:373`. Returns `Error::InvalidInput("dense tree height must be less than 16")` for invalid heights.

The limit of 16 matches the maximum useful height for a dense tree with `u16` capacity (2^16 - 1 = 65535 nodes).

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test -p grovedb --lib -- dense_tree` — all 55 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)