### PR TITLE
fix: use tree-type-aware hash in Merk::verify (H1)

### DIFF
--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -769,7 +769,7 @@ where
         }
 
         let node = node.unwrap();
-        if node.hash().unwrap() != hash {
+        if node.hash_for_link(self.tree_type).unwrap() != hash {
             bad_link_map.insert(instruction_id.to_vec(), hash);
             parent_keys.insert(instruction_id.to_vec(), parent_key.to_vec());
             return;


### PR DESCRIPTION
## Summary

**Severity: High** — Fixes incorrect hash verification that breaks chunk restoration for ProvableCountTree.

### The Bug

`Merk::verify_link()` computes the expected hash using `node.hash()`, which calls `node_hash(kv_hash, left, right)` — a 3-argument hash. However, `ProvableCountTree` and `ProvableCountSumTree` nodes use `node_hash_with_count(kv_hash, left, right, count)` — a 4-argument hash that includes the aggregate count.

This means when `verify()` is called on a ProvableCountTree (e.g., during chunk restoration finalization), **every single link** is reported as invalid because the hash function doesn't match, even though the data is correct.

### The Fix

Changed `node.hash()` to `node.hash_for_link(self.tree_type)` at `merk/src/merk/mod.rs:772`. The `hash_for_link` method dispatches to:
- `node_hash_with_count` for `ProvableCountTree` and `ProvableCountSumTree`
- `node_hash` (regular) for all other tree types

This is a one-line fix that makes the verification use the same hash function as the tree construction.

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test -p grovedb-merk` — all 332 tests + 9 doc tests pass
- [x] `cargo test -p grovedb-merk -- verify` — all 17 verify tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)