### PR TITLE
fix: correct RangeSetItem Ord anti-symmetry violation (M3)

### DIFF
--- a/grovedb-query/src/query_item/intersect.rs
+++ b/grovedb-query/src/query_item/intersect.rs
@@ -537,7 +537,7 @@ impl Ord for RangeSetItem {
                 }
             }
 
-            (ExclusiveStart(v1), ExclusiveEnd(v2)) | (ExclusiveEnd(v2), ExclusiveStart(v1)) => {
+            (ExclusiveStart(v1), ExclusiveEnd(v2)) => {
                 // start goes up, end goes down
                 // if they are equal, exclusive end is smaller cause it stops just before the
                 // number
@@ -546,6 +546,10 @@ impl Ord for RangeSetItem {
                     _ => Ordering::Less,
                 }
             }
+            (ExclusiveEnd(v1), ExclusiveStart(v2)) => match v1.cmp(v2) {
+                Ordering::Equal | Ordering::Less => Ordering::Less,
+                _ => Ordering::Greater,
+            },
         }
     }
 }
@@ -912,6 +916,20 @@ mod test {
         assert_eq!(
             RangeSetItem::ExclusiveStart(vec![1]).cmp(&RangeSetItem::ExclusiveEnd(vec![2])),
             Ordering::Less
+        );
+
+        // test anti-symmetry: ExclusiveEnd vs ExclusiveStart (reverse direction)
+        assert_eq!(
+            RangeSetItem::ExclusiveEnd(vec![1]).cmp(&RangeSetItem::ExclusiveStart(vec![1])),
+            Ordering::Less
+        );
+        assert_eq!(
+            RangeSetItem::ExclusiveEnd(vec![1]).cmp(&RangeSetItem::ExclusiveStart(vec![2])),
+            Ordering::Less
+        );
+        assert_eq!(
+            RangeSetItem::ExclusiveEnd(vec![2]).cmp(&RangeSetItem::ExclusiveStart(vec![1])),
+            Ordering::Greater
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes audit finding **M3**: `RangeSetItem` Ord anti-symmetry violation causes incorrect query intersection results.

### Problem

The `Ord` implementation for `RangeSetItem` combined two match arms using a pattern:
```rust
(ExclusiveStart(v1), ExclusiveEnd(v2)) | (ExclusiveEnd(v2), ExclusiveStart(v1)) => {
    match v1.cmp(v2) {
        Ordering::Equal | Ordering::Greater => Ordering::Greater,
        _ => Ordering::Less,
    }
}
```

Due to Rust's pattern matching semantics, variable names in `|`-alternatives are bound **positionally**, not by name. In both arms, `v1` always binds to the first tuple element (self) and `v2` to the second (other), regardless of the apparent intent.

This caused an anti-symmetry violation: `ExclusiveStart(5).cmp(ExclusiveEnd(5))` returned `Greater`, and `ExclusiveEnd(5).cmp(ExclusiveStart(5))` **also** returned `Greater`. This violates the Ord contract where `a > b` must imply `b < a`.

### Fix

Split the combined pattern into two separate match arms with correct logic for each direction:

- `(ExclusiveStart, ExclusiveEnd)`: Equal/Greater → Greater (start is "after" end at same value) 
- `(ExclusiveEnd, ExclusiveStart)`: Equal/Less → Less (end is "before" start at same value)

Added anti-symmetry regression tests that verify `ExclusiveEnd.cmp(ExclusiveStart)` returns the inverse of `ExclusiveStart.cmp(ExclusiveEnd)` for equal, lesser, and greater values.

### Impact

This bug could cause incorrect query intersection results when range queries with exclusive bounds overlap. The `RangeSetItem::cmp` method is used in `RangeSet::intersect`, which powers `QueryItem::intersect` — a core operation for merging and optimizing path queries.

## Test plan

- [x] All grovedb-query tests pass (`cargo test -p grovedb-query`)
- [x] All 1274 grovedb lib tests pass (`cargo test -p grovedb --lib`)
- [x] New anti-symmetry tests added for `ExclusiveEnd.cmp(ExclusiveStart)` covering equal, less, and greater values

🤖 Generated with [Claude Code](https://claude.com/claude-code)