### PR TITLE
fix: save self subquery before overwriting in merge (H4)

### DIFF
--- a/grovedb-query/src/merge.rs
+++ b/grovedb-query/src/merge.rs
@@ -703,3 +703,61 @@ impl Query {
         merged_items
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Query;
+
+    /// Demonstrates that merging a query with a subquery_path into one without
+    /// must preserve the original (self) subquery in the conditional branch,
+    /// not duplicate the other's subquery.
+    #[test]
+    fn merge_default_subquery_branch_preserves_self_subquery() {
+        // "self" query: has subquery_path ["a"] and its own subquery selecting key "self_key"
+        let mut self_query = Query::new();
+        let mut self_subquery = Query::new();
+        self_subquery.insert_key(b"self_key".to_vec());
+
+        self_query.default_subquery_branch = SubqueryBranch {
+            subquery_path: Some(vec![b"a".to_vec()]),
+            subquery: Some(Box::new(self_subquery.clone())),
+        };
+
+        // "other" branch: no subquery_path, has its own subquery selecting key "other_key"
+        let mut other_subquery = Query::new();
+        other_subquery.insert_key(b"other_key".to_vec());
+
+        let other_branch = SubqueryBranch {
+            subquery_path: None,
+            subquery: Some(Box::new(other_subquery.clone())),
+        };
+
+        self_query.merge_default_subquery_branch(other_branch);
+
+        // After merge:
+        // - default subquery should be other's (no path, so it applies broadly)
+        assert_eq!(self_query.default_subquery_branch.subquery_path, None);
+        assert_eq!(
+            self_query.default_subquery_branch.subquery,
+            Some(Box::new(other_subquery.clone())),
+            "default subquery should be other's subquery"
+        );
+
+        // - conditional branch at key "a" should have self's ORIGINAL subquery
+        let conditionals = self_query
+            .conditional_subquery_branches
+            .expect("should have conditional branches");
+        let branch_a = conditionals
+            .get(&QueryItem::Key(b"a".to_vec()))
+            .expect("should have conditional branch for key 'a'");
+
+        // This is the critical assertion: the conditional branch must contain
+        // self's original subquery (selecting "self_key"), NOT other's subquery.
+        assert_eq!(
+            branch_a.subquery,
+            Some(Box::new(self_subquery)),
+            "conditional branch should preserve self's original subquery, not other's"
+        );
+    }
+}

--- a/grovedb-query/src/merge.rs
+++ b/grovedb-query/src/merge.rs
@@ -380,6 +380,9 @@ impl Query {
 
                 let mut our_subquery_path = our_subquery_path.clone();
 
+                // Save our subquery before overwriting with theirs
+                let our_subquery = self.default_subquery_branch.subquery.clone();
+
                 self.default_subquery_branch.subquery_path = None;
                 self.default_subquery_branch.subquery =
                     other_default_subquery_branch.subquery.clone();
@@ -398,7 +401,7 @@ impl Query {
                     QueryItem::Key(our_top_key),
                     SubqueryBranch {
                         subquery_path: maybe_our_subquery_path,
-                        subquery: other_default_subquery_branch.subquery.clone(),
+                        subquery: our_subquery,
                     },
                 );
             }


### PR DESCRIPTION
## Summary

Fixes audit finding **M4** (reclassified to **H4** — high severity): `merge_default_subquery_branch` overwrites self subquery before capturing it, silently losing the original subquery during query merging. This causes incorrect query results when merging complex path queries.

### Problem

In `Query::merge_default_subquery_branch`, the `(Some(our_subquery_path), None)` case (where our query has a subquery path but theirs does not):

```rust
// Line 384: overwrites self's subquery with other's
self.default_subquery_branch.subquery = other_default_subquery_branch.subquery.clone();

// ...later at line 401: uses other's subquery AGAIN instead of the original self subquery
subquery: other_default_subquery_branch.subquery.clone(),
```

The original self subquery was lost because it was overwritten before being saved. Compare with the correct pattern at line 332 which properly saves the subquery first:

```rust
let left_subquery = self.default_subquery_branch.subquery.clone(); // save first
self.default_subquery_branch.subquery = other_default_subquery_branch.subquery.clone(); // then overwrite
// ...later uses left_subquery (the saved original)
```

### Impact

When merging two queries where one has a subquery path and the other doesn't, the resulting merged query contains the other query's subquery in both the default and conditional branches instead of preserving self's original subquery. This causes **silently incorrect query results** — no error is raised, the wrong data is simply returned. This is a data integrity issue affecting any code path that merges path queries with differing subquery_path presence.

### Fix

Save `self.default_subquery_branch.subquery` before overwriting it, and use the saved value in the conditional subquery branch. This is a 3-line change that follows the existing correct pattern in the same function.

### Regression test

A unit test `merge_default_subquery_branch_preserves_self_subquery` was added that:
- Fails without the fix (conditional branch gets `other_key` instead of `self_key`)
- Passes with the fix (conditional branch correctly preserves `self_key`)

## Test plan

- [x] New regression test demonstrates the bug and verifies the fix
- [x] All grovedb-query tests pass (`cargo test -p grovedb-query`)
- [x] All 1274 grovedb lib tests pass (`cargo test -p grovedb --lib`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)