### PR TITLE
fix: preserve query flags in merge operations (M5)

### DIFF
--- a/grovedb-query/src/merge.rs
+++ b/grovedb-query/src/merge.rs
@@ -444,8 +444,13 @@ impl Query {
                 mut items,
                 default_subquery_branch,
                 conditional_subquery_branches,
-                ..
+                left_to_right: _,
+                add_parent_tree_on_subquery,
             } = query;
+            // Preserve add_parent_tree_on_subquery if any query requests it
+            if add_parent_tree_on_subquery {
+                merged_query.add_parent_tree_on_subquery = true;
+            }
             // the searched for items are the union of all items
             merged_query.insert_items(items.clone());
 
@@ -505,8 +510,13 @@ impl Query {
             mut items,
             default_subquery_branch,
             conditional_subquery_branches,
-            ..
+            left_to_right: _,
+            add_parent_tree_on_subquery,
         } = other;
+        // Preserve add_parent_tree_on_subquery if either query requests it
+        if add_parent_tree_on_subquery {
+            self.add_parent_tree_on_subquery = true;
+        }
         self.insert_items(items.clone());
 
         // let intersection_result = QueryItem::intersect_many_ordered(&mut self.items,

--- a/grovedb-query/tests/merge_coverage.rs
+++ b/grovedb-query/tests/merge_coverage.rs
@@ -762,6 +762,36 @@ fn merge_conditional_branches_incoming_spans_multiple_existing() {
 // ───────────────────────────────────────────────────────────────────────
 
 #[test]
+fn merge_multiple_preserves_add_parent_tree_on_subquery() {
+    let mut q1 = Query::new_single_key(k(1));
+    q1.add_parent_tree_on_subquery = false;
+
+    let mut q2 = Query::new_single_key(k(2));
+    q2.add_parent_tree_on_subquery = true;
+
+    let merged = Query::merge_multiple(vec![q1, q2]);
+    assert!(
+        merged.add_parent_tree_on_subquery,
+        "merge_multiple should preserve add_parent_tree_on_subquery when any query sets it"
+    );
+}
+
+#[test]
+fn merge_with_preserves_add_parent_tree_on_subquery() {
+    let mut q1 = Query::new_single_key(k(1));
+    q1.add_parent_tree_on_subquery = false;
+
+    let mut q2 = Query::new_single_key(k(2));
+    q2.add_parent_tree_on_subquery = true;
+
+    q1.merge_with(q2);
+    assert!(
+        q1.add_parent_tree_on_subquery,
+        "merge_with should preserve add_parent_tree_on_subquery when other query sets it"
+    );
+}
+
+#[test]
 fn merge_with_both_have_conditional_branches() {
     let mut q1 = Query::new();
     q1.insert_key(k(1));


### PR DESCRIPTION
## Summary

Fixes audit finding **M5**: `Query::merge_multiple` and `merge_with` silently discard `left_to_right` and `add_parent_tree_on_subquery` flags from merged queries.

### Problem

Both `merge_multiple` and `merge_with` destructured the `Query` struct using `..`, which silently dropped the `left_to_right` and `add_parent_tree_on_subquery` fields. Only the first query's flags were preserved; all subsequent queries' flags were ignored.

This is particularly problematic for `add_parent_tree_on_subquery` (a v2 feature that includes parent tree elements like CountTree/SumTree in query results). If query A doesn't request parent trees but query B does, the merged result would incorrectly exclude parent trees.

### Fix

- Explicitly destructure all fields (no `..`) to ensure nothing is silently dropped
- `add_parent_tree_on_subquery`: Use OR semantics — if any merged query requests parent tree inclusion, the merged result does too
- `left_to_right`: Explicitly bound to `_` since the merged query can only iterate in one direction (the first query's direction is kept)

This makes the flag handling explicit rather than relying on a catch-all that silently discards fields. If new fields are added to `Query` in the future, the destructuring will produce a compile error rather than silently dropping the new field.

## Test plan

- [x] All grovedb-query tests pass (`cargo test -p grovedb-query`)
- [x] All 1274 grovedb lib tests pass (`cargo test -p grovedb --lib`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)