### PR TITLE
fix: enforce validate_insertion_does_not_override_tree in batch path (M6)

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1664,252 +1664,179 @@ where
                 GroveOp::InsertOnly { element }
                 | GroveOp::InsertOrReplace { element }
                 | GroveOp::Replace { element }
-                | GroveOp::Patch { element, .. } => match &element {
-                    Element::Reference(path_reference, element_max_reference_hop, _) => {
-                        let merk_feature_type = cost_return_on_error_into!(
+                | GroveOp::Patch { element, .. } => {
+                    // Check tree-override protection for all non-reference elements.
+                    if batch_apply_options.validate_insertion_does_not_override_tree
+                        && !matches!(&element, Element::Reference(..))
+                    {
+                        let merk = self.merks.get_mut(path).expect("the Merk is cached");
+                        let maybe_existing = cost_return_on_error_into!(
                             &mut cost,
-                            element
-                                .get_feature_type(in_tree_type)
-                                .wrap_with_cost(OperationCost::default())
-                        );
-                        let path_reference = cost_return_on_error_into!(
-                            &mut cost,
-                            path_from_reference_path_type(
-                                path_reference.clone(),
-                                path,
-                                Some(key_info.as_slice())
-                            )
-                            .wrap_with_cost(OperationCost::default())
-                        );
-                        if path_reference.is_empty() {
-                            return Err(Error::InvalidBatchOperation(
-                                "attempting to insert an empty reference",
-                            ))
-                            .wrap_with_cost(cost);
-                        }
-
-                        let referenced_element_value_hash = cost_return_on_error!(
-                            &mut cost,
-                            self.follow_reference_get_value_hash(
-                                path_reference.as_slice(),
-                                ops_by_qualified_paths,
-                                element_max_reference_hop.unwrap_or(MAX_REFERENCE_HOPS as u8),
-                                flags_update,
-                                split_removal_bytes,
+                            merk.get(
+                                key_info.get_key_clone().as_slice(),
+                                true,
+                                Some(&Element::value_defined_cost_for_serialized_value,),
                                 grove_version,
                             )
+                            .map_err(|e| {
+                                Error::CorruptedData(format!(
+                                    "unable to check for existing tree: {e}"
+                                ))
+                            })
                         );
-
-                        cost_return_on_error_into!(
-                            &mut cost,
-                            element.insert_reference_into_batch_operations(
-                                key_info.get_key_clone(),
-                                referenced_element_value_hash,
-                                &mut batch_operations,
-                                merk_feature_type,
-                                grove_version,
-                            )
-                        );
-                    }
-                    Element::Tree(..)
-                    | Element::SumTree(..)
-                    | Element::BigSumTree(..)
-                    | Element::CountTree(..)
-                    | Element::CountSumTree(..)
-                    | Element::ProvableCountTree(..)
-                    | Element::ProvableCountSumTree(..)
-                    | Element::MmrTree(..)
-                    | Element::BulkAppendTree(..)
-                    | Element::DenseAppendOnlyFixedSizeTree(..) => {
-                        if batch_apply_options.validate_insertion_does_not_override_tree {
-                            let merk = self.merks.get_mut(path).expect("the Merk is cached");
-                            let maybe_existing = cost_return_on_error_into!(
-                                &mut cost,
-                                merk.get(
-                                    key_info.get_key_clone().as_slice(),
-                                    true,
-                                    Some(&Element::value_defined_cost_for_serialized_value,),
-                                    grove_version,
-                                )
-                                .map_err(|e| {
-                                    Error::CorruptedData(format!(
-                                        "unable to check for existing tree: {e}"
-                                    ))
-                                })
+                        if let Some(existing_bytes) = maybe_existing {
+                            let existing_element = cost_return_on_error_no_add!(
+                                cost,
+                                Element::deserialize(existing_bytes.as_slice(), grove_version)
+                                    .map_err(|_| {
+                                        Error::CorruptedData(
+                                            "unable to deserialize existing element".to_string(),
+                                        )
+                                    })
                             );
-                            if let Some(existing_bytes) = maybe_existing {
-                                let existing_element = cost_return_on_error_no_add!(
-                                    cost,
-                                    Element::deserialize(existing_bytes.as_slice(), grove_version)
-                                        .map_err(|_| {
-                                            Error::CorruptedData(
-                                                "unable to deserialize existing element"
-                                                    .to_string(),
-                                            )
-                                        })
-                                );
-                                if existing_element.is_any_tree() {
-                                    return Err(Error::InvalidBatchOperation(
-                                        "attempting to overwrite a tree",
-                                    ))
-                                    .wrap_with_cost(cost);
-                                }
-                            }
-                        }
-                        let merk_feature_type = cost_return_on_error_into!(
-                            &mut cost,
-                            element
-                                .get_feature_type(in_tree_type)
-                                .wrap_with_cost(OperationCost::default())
-                        );
-                        cost_return_on_error_into!(
-                            &mut cost,
-                            element.insert_subtree_into_batch_operations(
-                                key_info.get_key_clone(),
-                                NULL_HASH,
-                                false,
-                                &mut batch_operations,
-                                merk_feature_type,
-                                grove_version,
-                            )
-                        );
-                    }
-                    Element::CommitmentTree(..) => {
-                        if batch_apply_options.validate_insertion_does_not_override_tree {
-                            let merk = self.merks.get_mut(path).expect("the Merk is cached");
-                            let maybe_existing = cost_return_on_error_into!(
-                                &mut cost,
-                                merk.get(
-                                    key_info.get_key_clone().as_slice(),
-                                    true,
-                                    Some(&Element::value_defined_cost_for_serialized_value,),
-                                    grove_version,
-                                )
-                                .map_err(|e| {
-                                    Error::CorruptedData(format!(
-                                        "unable to check for existing tree: {e}"
-                                    ))
-                                })
-                            );
-                            if let Some(existing_bytes) = maybe_existing {
-                                let existing_element = cost_return_on_error_no_add!(
-                                    cost,
-                                    Element::deserialize(existing_bytes.as_slice(), grove_version)
-                                        .map_err(|_| {
-                                            Error::CorruptedData(
-                                                "unable to deserialize existing element"
-                                                    .to_string(),
-                                            )
-                                        })
-                                );
-                                if existing_element.is_any_tree() {
-                                    return Err(Error::InvalidBatchOperation(
-                                        "attempting to overwrite a tree",
-                                    ))
-                                    .wrap_with_cost(cost);
-                                }
-                            }
-                        }
-                        let merk_feature_type = cost_return_on_error_into!(
-                            &mut cost,
-                            element
-                                .get_feature_type(in_tree_type)
-                                .wrap_with_cost(OperationCost::default())
-                        );
-                        cost_return_on_error_into!(
-                            &mut cost,
-                            element.insert_subtree_into_batch_operations(
-                                key_info.get_key_clone(),
-                                grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT,
-                                false,
-                                &mut batch_operations,
-                                merk_feature_type,
-                                grove_version,
-                            )
-                        );
-                    }
-                    Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
-                        let merk_feature_type = cost_return_on_error_into!(
-                            &mut cost,
-                            element
-                                .get_feature_type(in_tree_type)
-                                .wrap_with_cost(OperationCost::default())
-                        );
-                        if batch_apply_options.validate_insertion_does_not_override {
-                            let merk = self.merks.get_mut(path).expect("the Merk is cached");
-
-                            let inserted = cost_return_on_error_into!(
-                                &mut cost,
-                                element.insert_if_not_exists_into_batch_operations(
-                                    merk,
-                                    key_info.get_key(),
-                                    &mut batch_operations,
-                                    merk_feature_type,
-                                    grove_version,
-                                )
-                            );
-                            if !inserted {
+                            if existing_element.is_any_tree() {
                                 return Err(Error::InvalidBatchOperation(
-                                    "attempting to overwrite an element",
+                                    "attempting to overwrite a tree",
                                 ))
                                 .wrap_with_cost(cost);
                             }
-                        } else if batch_apply_options.validate_insertion_does_not_override_tree {
-                            let merk = self.merks.get_mut(path).expect("the Merk is cached");
-                            let maybe_existing = cost_return_on_error_into!(
+                        }
+                    }
+
+                    match &element {
+                        Element::Reference(path_reference, element_max_reference_hop, _) => {
+                            let merk_feature_type = cost_return_on_error_into!(
                                 &mut cost,
-                                merk.get(
-                                    key_info.get_key_clone().as_slice(),
-                                    true,
-                                    Some(&Element::value_defined_cost_for_serialized_value,),
-                                    grove_version,
-                                )
-                                .map_err(|e| {
-                                    Error::CorruptedData(format!(
-                                        "unable to check for existing tree: {e}"
-                                    ))
-                                })
+                                element
+                                    .get_feature_type(in_tree_type)
+                                    .wrap_with_cost(OperationCost::default())
                             );
-                            if let Some(existing_bytes) = maybe_existing {
-                                let existing_element = cost_return_on_error_no_add!(
-                                    cost,
-                                    Element::deserialize(existing_bytes.as_slice(), grove_version)
-                                        .map_err(|_| {
-                                            Error::CorruptedData(
-                                                "unable to deserialize existing element"
-                                                    .to_string(),
-                                            )
-                                        })
-                                );
-                                if existing_element.is_any_tree() {
-                                    return Err(Error::InvalidBatchOperation(
-                                        "attempting to overwrite a tree",
-                                    ))
-                                    .wrap_with_cost(cost);
-                                }
+                            let path_reference = cost_return_on_error_into!(
+                                &mut cost,
+                                path_from_reference_path_type(
+                                    path_reference.clone(),
+                                    path,
+                                    Some(key_info.as_slice())
+                                )
+                                .wrap_with_cost(OperationCost::default())
+                            );
+                            if path_reference.is_empty() {
+                                return Err(Error::InvalidBatchOperation(
+                                    "attempting to insert an empty reference",
+                                ))
+                                .wrap_with_cost(cost);
                             }
-                            cost_return_on_error_into!(
+
+                            let referenced_element_value_hash = cost_return_on_error!(
                                 &mut cost,
-                                element.insert_into_batch_operations(
-                                    key_info.get_key(),
-                                    &mut batch_operations,
-                                    merk_feature_type,
+                                self.follow_reference_get_value_hash(
+                                    path_reference.as_slice(),
+                                    ops_by_qualified_paths,
+                                    element_max_reference_hop.unwrap_or(MAX_REFERENCE_HOPS as u8),
+                                    flags_update,
+                                    split_removal_bytes,
                                     grove_version,
                                 )
                             );
-                        } else {
+
                             cost_return_on_error_into!(
                                 &mut cost,
-                                element.insert_into_batch_operations(
-                                    key_info.get_key(),
+                                element.insert_reference_into_batch_operations(
+                                    key_info.get_key_clone(),
+                                    referenced_element_value_hash,
                                     &mut batch_operations,
                                     merk_feature_type,
                                     grove_version,
                                 )
                             );
                         }
+                        Element::Tree(..)
+                        | Element::SumTree(..)
+                        | Element::BigSumTree(..)
+                        | Element::CountTree(..)
+                        | Element::CountSumTree(..)
+                        | Element::ProvableCountTree(..)
+                        | Element::ProvableCountSumTree(..)
+                        | Element::MmrTree(..)
+                        | Element::BulkAppendTree(..)
+                        | Element::DenseAppendOnlyFixedSizeTree(..) => {
+                            let merk_feature_type = cost_return_on_error_into!(
+                                &mut cost,
+                                element
+                                    .get_feature_type(in_tree_type)
+                                    .wrap_with_cost(OperationCost::default())
+                            );
+                            cost_return_on_error_into!(
+                                &mut cost,
+                                element.insert_subtree_into_batch_operations(
+                                    key_info.get_key_clone(),
+                                    NULL_HASH,
+                                    false,
+                                    &mut batch_operations,
+                                    merk_feature_type,
+                                    grove_version,
+                                )
+                            );
+                        }
+                        Element::CommitmentTree(..) => {
+                            let merk_feature_type = cost_return_on_error_into!(
+                                &mut cost,
+                                element
+                                    .get_feature_type(in_tree_type)
+                                    .wrap_with_cost(OperationCost::default())
+                            );
+                            cost_return_on_error_into!(
+                                &mut cost,
+                                element.insert_subtree_into_batch_operations(
+                                    key_info.get_key_clone(),
+                                    grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT,
+                                    false,
+                                    &mut batch_operations,
+                                    merk_feature_type,
+                                    grove_version,
+                                )
+                            );
+                        }
+                        Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
+                            let merk_feature_type = cost_return_on_error_into!(
+                                &mut cost,
+                                element
+                                    .get_feature_type(in_tree_type)
+                                    .wrap_with_cost(OperationCost::default())
+                            );
+                            if batch_apply_options.validate_insertion_does_not_override {
+                                let merk = self.merks.get_mut(path).expect("the Merk is cached");
+
+                                let inserted = cost_return_on_error_into!(
+                                    &mut cost,
+                                    element.insert_if_not_exists_into_batch_operations(
+                                        merk,
+                                        key_info.get_key(),
+                                        &mut batch_operations,
+                                        merk_feature_type,
+                                        grove_version,
+                                    )
+                                );
+                                if !inserted {
+                                    return Err(Error::InvalidBatchOperation(
+                                        "attempting to overwrite an element",
+                                    ))
+                                    .wrap_with_cost(cost);
+                                }
+                            } else {
+                                cost_return_on_error_into!(
+                                    &mut cost,
+                                    element.insert_into_batch_operations(
+                                        key_info.get_key(),
+                                        &mut batch_operations,
+                                        merk_feature_type,
+                                        grove_version,
+                                    )
+                                );
+                            }
+                        }
                     }
-                },
+                }
                 GroveOp::RefreshReference {
                     reference_path_type,
                     max_reference_hop,

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1721,6 +1721,41 @@ where
                     | Element::MmrTree(..)
                     | Element::BulkAppendTree(..)
                     | Element::DenseAppendOnlyFixedSizeTree(..) => {
+                        if batch_apply_options.validate_insertion_does_not_override_tree {
+                            let merk = self.merks.get_mut(path).expect("the Merk is cached");
+                            let maybe_existing = cost_return_on_error_into!(
+                                &mut cost,
+                                merk.get(
+                                    key_info.get_key_clone().as_slice(),
+                                    true,
+                                    Some(&Element::value_defined_cost_for_serialized_value,),
+                                    grove_version,
+                                )
+                                .map_err(|e| {
+                                    Error::CorruptedData(format!(
+                                        "unable to check for existing tree: {e}"
+                                    ))
+                                })
+                            );
+                            if let Some(existing_bytes) = maybe_existing {
+                                let existing_element = cost_return_on_error_no_add!(
+                                    cost,
+                                    Element::deserialize(existing_bytes.as_slice(), grove_version)
+                                        .map_err(|_| {
+                                            Error::CorruptedData(
+                                                "unable to deserialize existing element"
+                                                    .to_string(),
+                                            )
+                                        })
+                                );
+                                if existing_element.is_any_tree() {
+                                    return Err(Error::InvalidBatchOperation(
+                                        "attempting to overwrite a tree",
+                                    ))
+                                    .wrap_with_cost(cost);
+                                }
+                            }
+                        }
                         let merk_feature_type = cost_return_on_error_into!(
                             &mut cost,
                             element
@@ -1740,6 +1775,41 @@ where
                         );
                     }
                     Element::CommitmentTree(..) => {
+                        if batch_apply_options.validate_insertion_does_not_override_tree {
+                            let merk = self.merks.get_mut(path).expect("the Merk is cached");
+                            let maybe_existing = cost_return_on_error_into!(
+                                &mut cost,
+                                merk.get(
+                                    key_info.get_key_clone().as_slice(),
+                                    true,
+                                    Some(&Element::value_defined_cost_for_serialized_value,),
+                                    grove_version,
+                                )
+                                .map_err(|e| {
+                                    Error::CorruptedData(format!(
+                                        "unable to check for existing tree: {e}"
+                                    ))
+                                })
+                            );
+                            if let Some(existing_bytes) = maybe_existing {
+                                let existing_element = cost_return_on_error_no_add!(
+                                    cost,
+                                    Element::deserialize(existing_bytes.as_slice(), grove_version)
+                                        .map_err(|_| {
+                                            Error::CorruptedData(
+                                                "unable to deserialize existing element"
+                                                    .to_string(),
+                                            )
+                                        })
+                                );
+                                if existing_element.is_any_tree() {
+                                    return Err(Error::InvalidBatchOperation(
+                                        "attempting to overwrite a tree",
+                                    ))
+                                    .wrap_with_cost(cost);
+                                }
+                            }
+                        }
                         let merk_feature_type = cost_return_on_error_into!(
                             &mut cost,
                             element
@@ -1780,10 +1850,53 @@ where
                             );
                             if !inserted {
                                 return Err(Error::InvalidBatchOperation(
-                                    "attempting to overwrite a tree",
+                                    "attempting to overwrite an element",
                                 ))
                                 .wrap_with_cost(cost);
                             }
+                        } else if batch_apply_options.validate_insertion_does_not_override_tree {
+                            let merk = self.merks.get_mut(path).expect("the Merk is cached");
+                            let maybe_existing = cost_return_on_error_into!(
+                                &mut cost,
+                                merk.get(
+                                    key_info.get_key_clone().as_slice(),
+                                    true,
+                                    Some(&Element::value_defined_cost_for_serialized_value,),
+                                    grove_version,
+                                )
+                                .map_err(|e| {
+                                    Error::CorruptedData(format!(
+                                        "unable to check for existing tree: {e}"
+                                    ))
+                                })
+                            );
+                            if let Some(existing_bytes) = maybe_existing {
+                                let existing_element = cost_return_on_error_no_add!(
+                                    cost,
+                                    Element::deserialize(existing_bytes.as_slice(), grove_version)
+                                        .map_err(|_| {
+                                            Error::CorruptedData(
+                                                "unable to deserialize existing element"
+                                                    .to_string(),
+                                            )
+                                        })
+                                );
+                                if existing_element.is_any_tree() {
+                                    return Err(Error::InvalidBatchOperation(
+                                        "attempting to overwrite a tree",
+                                    ))
+                                    .wrap_with_cost(cost);
+                                }
+                            }
+                            cost_return_on_error_into!(
+                                &mut cost,
+                                element.insert_into_batch_operations(
+                                    key_info.get_key(),
+                                    &mut batch_operations,
+                                    merk_feature_type,
+                                    grove_version,
+                                )
+                            );
                         } else {
                             cost_return_on_error_into!(
                                 &mut cost,

--- a/grovedb/src/tests/batch_coverage_tests.rs
+++ b/grovedb/src/tests/batch_coverage_tests.rs
@@ -2526,8 +2526,8 @@ mod tests {
 
         // Try to insert a non-tree element at the same key with
         // validate_insertion_does_not_override_tree = true.
-        // This should succeed because we're replacing with an item, not
-        // overriding a tree with a tree.
+        // This should fail because an existing tree cannot be overwritten
+        // when this validation is enabled (matching the non-batch insert path).
         let ops = vec![QualifiedGroveDbOp::insert_or_replace_op(
             vec![TEST_LEAF.to_vec()],
             b"subtree".to_vec(),
@@ -2539,11 +2539,27 @@ mod tests {
             ..Default::default()
         });
 
-        // The validation only prevents overriding a tree with another tree,
-        // so replacing a tree with an item should succeed.
+        let result = db.apply_batch(ops, options, None, grove_version).unwrap();
+        assert!(
+            result.is_err(),
+            "overwriting a tree should fail when validate_insertion_does_not_override_tree is set"
+        );
+
+        // Without the validation, it should succeed
+        let ops = vec![QualifiedGroveDbOp::insert_or_replace_op(
+            vec![TEST_LEAF.to_vec()],
+            b"subtree".to_vec(),
+            Element::new_item(b"new_item".to_vec()),
+        )];
+
+        let options = Some(BatchApplyOptions {
+            validate_insertion_does_not_override_tree: false,
+            ..Default::default()
+        });
+
         db.apply_batch(ops, options, None, grove_version)
             .unwrap()
-            .expect("replacing a tree with an item should succeed even with validation enabled");
+            .expect("replacing a tree should succeed without validation");
 
         let result = db
             .get([TEST_LEAF].as_ref(), b"subtree", None, grove_version)


### PR DESCRIPTION
## Summary

Fixes audit finding **M6**: `validate_insertion_does_not_override_tree` was ignored in the batch execution path, allowing batch inserts to silently overwrite existing trees.

### Problem

The `validate_insertion_does_not_override_tree` option in `BatchApplyOptions` was defined and could be set to `true`, but the batch execution path (`execute_ops_on_path`) never checked it. Only `validate_insertion_does_not_override` was checked — and only for Item/SumItem insertions, not for tree element insertions.

This meant batch operations could overwrite existing trees even when the protection was explicitly enabled, while individual insert operations correctly blocked the overwrite.

### Fix

Added tree override validation in the batch path for three element categories:

1. **Tree elements** (Tree, SumTree, CountTree, etc.): When inserting a tree and `validate_insertion_does_not_override_tree` is set, checks if an existing tree element exists at the key and blocks the insertion if so.

2. **CommitmentTree elements**: Same check as regular tree elements.

3. **Item elements** (Item, SumItem, ItemWithSumItem): When `validate_insertion_does_not_override` is not set but `validate_insertion_does_not_override_tree` is, checks if the existing element is a tree before allowing the insertion. This matches the non-batch insert path behavior.

The validation follows the same pattern as the non-batch insert path: deserialize the existing element and check `is_any_tree()`.

### Test changes

Updated `test_batch_validate_insertion_does_not_override_tree` to correctly expect that overwriting a tree is blocked when the validation is enabled (previously the test incorrectly expected success). Added a second assertion verifying that the override succeeds when the validation is disabled.

## Test plan

- [x] All 1274 grovedb lib tests pass (`cargo test -p grovedb --lib`)
- [x] Updated test correctly validates both the blocking and non-blocking cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)