### PR TITLE
fix: document balance_factor overflow impossibility (M7)

### DIFF
--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -740,9 +740,16 @@ impl TreeNode {
     /// subtree is 2 levels taller than the left subtree.
     #[inline]
     pub const fn balance_factor(&self) -> i8 {
-        let left_height = self.child_height(true) as i8;
-        let right_height = self.child_height(false) as i8;
-        right_height - left_height
+        let left_height = self.child_height(true) as i16;
+        let right_height = self.child_height(false) as i16;
+        let diff = right_height - left_height;
+        if diff > i8::MAX as i16 {
+            i8::MAX
+        } else if diff < i8::MIN as i16 {
+            i8::MIN
+        } else {
+            diff as i8
+        }
     }
 
     /// Attaches the child (if any) to the root node on the given side. Creates

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -740,16 +740,13 @@ impl TreeNode {
     /// subtree is 2 levels taller than the left subtree.
     #[inline]
     pub const fn balance_factor(&self) -> i8 {
-        let left_height = self.child_height(true) as i16;
-        let right_height = self.child_height(false) as i16;
-        let diff = right_height - left_height;
-        if diff > i8::MAX as i16 {
-            i8::MAX
-        } else if diff < i8::MIN as i16 {
-            i8::MIN
-        } else {
-            diff as i8
-        }
+        // Cast to i8 is safe: child_height() returns at most the tree height,
+        // which is O(log n). Even with 2^127 elements the height would be ~127,
+        // well within i8 range. An AVL tree that could overflow u8 child heights
+        // (>255) is physically impossible.
+        let left_height = self.child_height(true) as i8;
+        let right_height = self.child_height(false) as i8;
+        right_height - left_height
     }
 
     /// Attaches the child (if any) to the root node on the given side. Creates


### PR DESCRIPTION
## Summary

**Audit Finding M7**: The original audit flagged a potential arithmetic overflow in `TreeNode::balance_factor()` when casting `u8` child heights to `i8`.

After review, this overflow is **impossible in practice**: AVL tree heights are O(log n), so even with 2^127 elements the height would be ~127, well within `i8` range. A tree that could overflow `u8` child heights (>255) is physically impossible.

- Reverted the `i16` promotion approach
- Added a comment documenting why the `u8 as i8` cast is safe

## Test plan

- [x] `cargo build -p grovedb-merk` — compiles clean
- [x] `cargo test -p grovedb-merk` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **No user-facing changes**
  * Internal code improvements with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->