### PR TITLE
fix: include segments_count bytes in worst_case_body_size (M8)

### DIFF
--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -195,7 +195,11 @@ impl RocksDbStorage {
     }
 
     fn worst_case_body_size<L: WorstKeyLength>(path: &[L]) -> usize {
-        path.len() + path.iter().map(|a| a.max_length() as usize).sum::<usize>()
+        // body = segment_bytes + segments_count.to_ne_bytes() + lengths
+        // segments_count.to_ne_bytes() contributes size_of::<usize>() bytes
+        path.iter().map(|a| a.max_length() as usize).sum::<usize>()
+            + std::mem::size_of::<usize>()
+            + path.len()
     }
 
     /// Returns the write batch, with costs and pending costs


### PR DESCRIPTION
## Summary

Fixes audit finding **M8**: `worst_case_body_size` underestimates prefix hash input by 8 bytes (on 64-bit platforms).

### Problem

`build_prefix_body` constructs a body consisting of:
1. All segment bytes concatenated
2. `segments_count.to_ne_bytes()` — a `usize` (8 bytes on 64-bit)
3. One `u8` length byte per segment

But `worst_case_body_size` only accounted for #1 and #3:
```rust
path.len() + path.iter().map(|a| a.max_length() as usize).sum::<usize>()
// = segments_count + sum(segment_bytes)
// Missing: size_of::<usize>() for segments_count.to_ne_bytes()
```

This underestimate means a path with body size in [57, 64] would be estimated as needing 1 Blake3 block (≤64 bytes) when it actually requires 2 blocks (>64 bytes), causing fee cost estimation to undercharge.

### Fix

Add `std::mem::size_of::<usize>()` to the computation:
```rust
path.iter().map(|a| a.max_length() as usize).sum::<usize>()
    + std::mem::size_of::<usize>()
    + path.len()
```

## Test plan

- [x] All storage tests pass (`cargo test -p grovedb-storage`)
- [x] All 1274 grovedb lib tests pass (`cargo test -p grovedb --lib`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)