### PR TITLE
fix: return accumulated costs from commit_batch (M9)

### DIFF
--- a/storage/src/rocksdb_storage/storage_context/context_immediate.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_immediate.rs
@@ -228,7 +228,7 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
         self.transaction
             .rebuild_from_writebatch(&batch.batch)
             .map_err(RocksDBError)
-            .wrap_with_cost(Default::default())
+            .wrap_with_cost(batch.cost_acc)
     }
 
     fn raw_iter(&self) -> Self::RawIterator {


### PR DESCRIPTION
## Summary

Fixes audit finding **M9**: `PrefixedRocksDbImmediateStorageContext::commit_batch` discards all accumulated costs.

### Problem

`commit_batch` was returning `Default::default()` as its cost context, which is a zero-cost `OperationCost`. The batch's `cost_acc` field (containing seek counts, storage costs accumulated during batch operations) was silently dropped. This caused cost tracking to underestimate actual resource usage during replication.

### Fix

One-line change: use `batch.cost_acc` instead of `Default::default()` in the `wrap_with_cost` call.

## Test plan

- [x] All storage tests pass (`cargo test -p grovedb-storage`)
- [x] All 1274 grovedb lib tests pass (`cargo test -p grovedb --lib`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)