### PR TITLE
test: strengthen cost assertions and extract magic constant

### DIFF
--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -464,11 +464,14 @@ mod tests {
     };
     use grovedb_version::version::GroveVersion;
 
+    use grovedb_merk::tree::AggregateData;
+
     use crate::{
         batch::{
-            estimated_costs::EstimatedCostsType::AverageCaseCostsType, key_info::KeyInfo,
-            KeyInfoPath, QualifiedGroveDbOp,
+            estimated_costs::EstimatedCostsType::AverageCaseCostsType, key_info::KeyInfo, GroveOp,
+            KeyInfoPath, NonMerkTreeMeta, QualifiedGroveDbOp,
         },
+        reference_path::ReferencePathType,
         tests::{common::EMPTY_PATH, make_empty_grovedb},
         Element, GroveDb,
     };
@@ -1028,6 +1031,456 @@ mod tests {
         assert_eq!(
             cost.storage_cost.added_bytes,
             average_case_cost.storage_cost.added_bytes
+        );
+    }
+
+    #[test]
+    fn test_refresh_reference_average_case_cost() {
+        let grove_version = GroveVersion::latest();
+        let ops = vec![QualifiedGroveDbOp::refresh_reference_op(
+            vec![vec![7]],
+            b"ref_key".to_vec(),
+            ReferencePathType::AbsolutePathReference(vec![b"target".to_vec()]),
+            Some(5),
+            None,
+            true,
+        )];
+        let mut paths = HashMap::new();
+        paths.insert(
+            KeyInfoPath(vec![]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: EstimatedLevel(1, false),
+                estimated_layer_sizes: AllSubtrees(1, NoSumTrees, None),
+            },
+        );
+        paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![vec![7]]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: PotentiallyAtMaxElements,
+                estimated_layer_sizes: AllItems(32, 64, None),
+            },
+        );
+        let result = GroveDb::estimated_case_operations_for_batch(
+            AverageCaseCostsType(paths),
+            ops,
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("expected to get average case costs for refresh reference");
+        // RefreshReference delegates to average_case_merk_replace_element, so there
+        // should be seeks for getting the merk and replacing the element plus
+        // hash calls for propagation.
+        assert!(
+            result.seek_count > 0,
+            "expected seek_count > 0, got {}",
+            result.seek_count
+        );
+        assert!(
+            result.hash_node_calls > 0,
+            "expected hash_node_calls > 0, got {}",
+            result.hash_node_calls
+        );
+    }
+
+    #[test]
+    fn test_patch_average_case_cost() {
+        let grove_version = GroveVersion::latest();
+        let ops = vec![QualifiedGroveDbOp::patch_op(
+            vec![vec![7]],
+            b"patch_key".to_vec(),
+            Element::new_item(b"patched_value".to_vec()),
+            5, // change_in_bytes
+        )];
+        let mut paths = HashMap::new();
+        paths.insert(
+            KeyInfoPath(vec![]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: EstimatedLevel(1, false),
+                estimated_layer_sizes: AllSubtrees(1, NoSumTrees, None),
+            },
+        );
+        paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![vec![7]]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: PotentiallyAtMaxElements,
+                estimated_layer_sizes: AllItems(32, 64, None),
+            },
+        );
+        let result = GroveDb::estimated_case_operations_for_batch(
+            AverageCaseCostsType(paths),
+            ops,
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("expected to get average case costs for patch");
+        // Patch delegates to average_case_merk_patch_element which performs
+        // seeks and hash calls.
+        assert!(
+            result.seek_count > 0,
+            "expected seek_count > 0, got {}",
+            result.seek_count
+        );
+        assert!(
+            result.hash_node_calls > 0,
+            "expected hash_node_calls > 0, got {}",
+            result.hash_node_calls
+        );
+    }
+
+    #[test]
+    fn test_delete_average_case_cost() {
+        let grove_version = GroveVersion::latest();
+        let ops = vec![QualifiedGroveDbOp::delete_op(
+            vec![vec![7]],
+            b"del_key".to_vec(),
+        )];
+        let mut paths = HashMap::new();
+        paths.insert(
+            KeyInfoPath(vec![]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: EstimatedLevel(1, false),
+                estimated_layer_sizes: AllSubtrees(1, NoSumTrees, None),
+            },
+        );
+        paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![vec![7]]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: PotentiallyAtMaxElements,
+                estimated_layer_sizes: AllItems(32, 64, None),
+            },
+        );
+        let result = GroveDb::estimated_case_operations_for_batch(
+            AverageCaseCostsType(paths),
+            ops,
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("expected to get average case costs for delete");
+        // Delete delegates to average_case_merk_delete_element which requires
+        // seeks to find and remove the element.
+        assert!(
+            result.seek_count > 0,
+            "expected seek_count > 0, got {}",
+            result.seek_count
+        );
+        assert!(
+            result.hash_node_calls > 0,
+            "expected hash_node_calls > 0, got {}",
+            result.hash_node_calls
+        );
+    }
+
+    #[test]
+    fn test_delete_tree_average_case_cost() {
+        let grove_version = GroveVersion::latest();
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![vec![7]],
+            b"tree_key".to_vec(),
+            TreeType::NormalTree,
+        )];
+        let mut paths = HashMap::new();
+        paths.insert(
+            KeyInfoPath(vec![]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: EstimatedLevel(1, false),
+                estimated_layer_sizes: AllSubtrees(1, NoSumTrees, None),
+            },
+        );
+        paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![vec![7]]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: PotentiallyAtMaxElements,
+                estimated_layer_sizes: AllSubtrees(32, NoSumTrees, None),
+            },
+        );
+        let result = GroveDb::estimated_case_operations_for_batch(
+            AverageCaseCostsType(paths),
+            ops,
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("expected to get average case costs for delete tree");
+        // DeleteTree delegates to average_case_merk_delete_tree which requires
+        // seeks and hash calls.
+        assert!(
+            result.seek_count > 0,
+            "expected seek_count > 0, got {}",
+            result.seek_count
+        );
+        assert!(
+            result.hash_node_calls > 0,
+            "expected hash_node_calls > 0, got {}",
+            result.hash_node_calls
+        );
+    }
+
+    // Direct average_case_cost tests for keyless/internal GroveOp variants.
+    // These ops are either skipped by from_ops (key=None) or are internal-only,
+    // so we call average_case_cost() directly on the GroveOp instance.
+
+    #[test]
+    fn test_commitment_tree_insert_average_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::CommitmentTreeInsert {
+            cmx: [1u8; 32],
+            rho: [2u8; 32],
+            payload: vec![0u8; 100],
+        };
+        let key = KeyInfo::KnownKey(b"tree_key".to_vec());
+        let layer_info = EstimatedLayerInformation {
+            tree_type: TreeType::NormalTree,
+            estimated_layer_count: ApproximateElements(10),
+            estimated_layer_sizes: AllSubtrees(4, NoSumTrees, None),
+        };
+        let cost = op
+            .average_case_cost(&key, &layer_info, false, grove_version)
+            .cost_as_result()
+            .expect("expected cost for commitment tree insert");
+        // CommitmentTreeInsert includes frontier I/O and buffer writes plus
+        // Sinsemilla hashing for the commitment tree anchor.
+        assert!(
+            cost.seek_count > 0,
+            "expected seek_count > 0, got {}",
+            cost.seek_count
+        );
+        assert!(
+            cost.sinsemilla_hash_calls > 0,
+            "expected sinsemilla_hash_calls > 0, got {}",
+            cost.sinsemilla_hash_calls
+        );
+        assert!(
+            cost.hash_node_calls > 0,
+            "expected hash_node_calls > 0, got {}",
+            cost.hash_node_calls
+        );
+        // Buffer entry size = 32 + payload.len() = 132
+        // Frontier replaced bytes = 554
+        assert!(
+            cost.storage_cost.added_bytes > 0,
+            "expected added_bytes > 0, got {}",
+            cost.storage_cost.added_bytes
+        );
+        assert!(
+            cost.storage_cost.replaced_bytes > 0,
+            "expected replaced_bytes > 0, got {}",
+            cost.storage_cost.replaced_bytes
+        );
+    }
+
+    #[test]
+    fn test_mmr_tree_append_average_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::MmrTreeAppend {
+            value: vec![42u8; 64],
+        };
+        let key = KeyInfo::KnownKey(b"mmr_key".to_vec());
+        let layer_info = EstimatedLayerInformation {
+            tree_type: TreeType::NormalTree,
+            estimated_layer_count: ApproximateElements(5),
+            estimated_layer_sizes: AllSubtrees(4, NoSumTrees, None),
+        };
+        let cost = op
+            .average_case_cost(&key, &layer_info, false, grove_version)
+            .cost_as_result()
+            .expect("expected cost for mmr tree append");
+        // MmrTreeAppend includes parent replace cost plus MMR node I/O.
+        assert!(
+            cost.seek_count > 0,
+            "expected seek_count > 0, got {}",
+            cost.seek_count
+        );
+        assert!(
+            cost.hash_node_calls > 0,
+            "expected hash_node_calls > 0, got {}",
+            cost.hash_node_calls
+        );
+        // Leaf node + internal node writes
+        assert!(
+            cost.storage_cost.added_bytes > 0,
+            "expected added_bytes > 0, got {}",
+            cost.storage_cost.added_bytes
+        );
+        // Sibling read for merging
+        assert!(
+            cost.storage_loaded_bytes > 0,
+            "expected storage_loaded_bytes > 0, got {}",
+            cost.storage_loaded_bytes
+        );
+    }
+
+    #[test]
+    fn test_bulk_append_average_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::BulkAppend {
+            value: vec![99u8; 50],
+        };
+        let key = KeyInfo::KnownKey(b"bulk_key".to_vec());
+        let layer_info = EstimatedLayerInformation {
+            tree_type: TreeType::NormalTree,
+            estimated_layer_count: ApproximateElements(5),
+            estimated_layer_sizes: AllSubtrees(4, NoSumTrees, None),
+        };
+        let cost = op
+            .average_case_cost(&key, &layer_info, false, grove_version)
+            .cost_as_result()
+            .expect("expected cost for bulk append");
+        // BulkAppend includes parent replace cost plus buffer write + running
+        // hash.
+        assert!(
+            cost.seek_count > 0,
+            "expected seek_count > 0, got {}",
+            cost.seek_count
+        );
+        assert!(
+            cost.hash_node_calls > 0,
+            "expected hash_node_calls > 0, got {}",
+            cost.hash_node_calls
+        );
+        // Buffer entry write adds bytes equal to value length
+        assert!(
+            cost.storage_cost.added_bytes > 0,
+            "expected added_bytes > 0, got {}",
+            cost.storage_cost.added_bytes
+        );
+    }
+
+    #[test]
+    fn test_dense_tree_insert_average_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::DenseTreeInsert {
+            value: vec![77u8; 32],
+        };
+        let key = KeyInfo::KnownKey(b"dense_key".to_vec());
+        let layer_info = EstimatedLayerInformation {
+            tree_type: TreeType::NormalTree,
+            estimated_layer_count: ApproximateElements(5),
+            estimated_layer_sizes: AllSubtrees(4, NoSumTrees, None),
+        };
+        let cost = op
+            .average_case_cost(&key, &layer_info, false, grove_version)
+            .cost_as_result()
+            .expect("expected cost for dense tree insert");
+        // DenseTreeInsert includes parent replace cost plus value write and
+        // full root recomputation (AVG_COUNT reads + hashes).
+        assert!(
+            cost.seek_count > 0,
+            "expected seek_count > 0, got {}",
+            cost.seek_count
+        );
+        assert!(
+            cost.hash_node_calls > 0,
+            "expected hash_node_calls > 0, got {}",
+            cost.hash_node_calls
+        );
+        assert!(
+            cost.storage_cost.added_bytes > 0,
+            "expected added_bytes > 0, got {}",
+            cost.storage_cost.added_bytes
+        );
+        assert!(
+            cost.storage_loaded_bytes > 0,
+            "expected storage_loaded_bytes > 0, got {}",
+            cost.storage_loaded_bytes
+        );
+    }
+
+    #[test]
+    fn test_replace_non_merk_tree_root_average_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::ReplaceNonMerkTreeRoot {
+            hash: [0xABu8; 32],
+            meta: NonMerkTreeMeta::CommitmentTree {
+                total_count: 100,
+                chunk_power: 4,
+            },
+        };
+        let key = KeyInfo::KnownKey(b"nmerk_key".to_vec());
+        let layer_info = EstimatedLayerInformation {
+            tree_type: TreeType::NormalTree,
+            estimated_layer_count: ApproximateElements(5),
+            estimated_layer_sizes: AllSubtrees(4, NoSumTrees, None),
+        };
+        let cost = op
+            .average_case_cost(&key, &layer_info, false, grove_version)
+            .cost_as_result()
+            .expect("expected cost for replace non-merk tree root");
+        // ReplaceNonMerkTreeRoot delegates to average_case_merk_replace_tree.
+        assert!(
+            cost.seek_count > 0,
+            "expected seek_count > 0, got {}",
+            cost.seek_count
+        );
+        assert!(
+            cost.hash_node_calls > 0,
+            "expected hash_node_calls > 0, got {}",
+            cost.hash_node_calls
+        );
+    }
+
+    #[test]
+    fn test_insert_non_merk_tree_average_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::InsertNonMerkTree {
+            hash: [0xCDu8; 32],
+            root_key: None,
+            flags: None,
+            aggregate_data: AggregateData::NoAggregateData,
+            meta: NonMerkTreeMeta::MmrTree { mmr_size: 50 },
+        };
+        let key = KeyInfo::KnownKey(b"inmerk_key".to_vec());
+        let layer_info = EstimatedLayerInformation {
+            tree_type: TreeType::NormalTree,
+            estimated_layer_count: ApproximateElements(0),
+            estimated_layer_sizes: AllSubtrees(4, NoSumTrees, None),
+        };
+        let cost = op
+            .average_case_cost(&key, &layer_info, false, grove_version)
+            .cost_as_result()
+            .expect("expected cost for insert non-merk tree");
+        // InsertNonMerkTree delegates to average_case_merk_insert_tree.
+        assert!(
+            cost.seek_count > 0,
+            "expected seek_count > 0, got {}",
+            cost.seek_count
+        );
+        assert!(
+            cost.hash_node_calls > 0,
+            "expected hash_node_calls > 0, got {}",
+            cost.hash_node_calls
+        );
+        // Inserting a new tree adds bytes.
+        assert!(
+            cost.storage_cost.added_bytes > 0,
+            "expected added_bytes > 0, got {}",
+            cost.storage_cost.added_bytes
         );
     }
 }

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -1322,6 +1322,8 @@ mod tests {
             "expected hash_node_calls > 0, got {}",
             cost.hash_node_calls
         );
+        // MMR uses blake3, not sinsemilla
+        assert_eq!(cost.sinsemilla_hash_calls, 0);
         // Leaf node + internal node writes
         assert!(
             cost.storage_cost.added_bytes > 0,
@@ -1364,6 +1366,8 @@ mod tests {
             "expected hash_node_calls > 0, got {}",
             cost.hash_node_calls
         );
+        // BulkAppend uses blake3, not sinsemilla
+        assert_eq!(cost.sinsemilla_hash_calls, 0);
         // Buffer entry write adds bytes equal to value length
         assert!(
             cost.storage_cost.added_bytes > 0,
@@ -1400,6 +1404,8 @@ mod tests {
             "expected hash_node_calls > 0, got {}",
             cost.hash_node_calls
         );
+        // DenseTree uses blake3, not sinsemilla
+        assert_eq!(cost.sinsemilla_hash_calls, 0);
         assert!(
             cost.storage_cost.added_bytes > 0,
             "expected added_bytes > 0, got {}",

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -435,13 +435,15 @@ mod tests {
     };
     #[rustfmt::skip]
     use grovedb_merk::estimated_costs::worst_case_costs::WorstCaseLayerInformation::MaxElementsNumber;
+    use grovedb_merk::tree_type::TreeType;
     use grovedb_version::version::GroveVersion;
 
     use crate::{
         batch::{
-            estimated_costs::EstimatedCostsType::WorstCaseCostsType, key_info::KeyInfo,
-            KeyInfoPath, QualifiedGroveDbOp,
+            estimated_costs::EstimatedCostsType::WorstCaseCostsType, key_info::KeyInfo, GroveOp,
+            KeyInfoPath, NonMerkTreeMeta, QualifiedGroveDbOp,
         },
+        reference_path::ReferencePathType,
         tests::{common::EMPTY_PATH, make_empty_grovedb},
         Element, GroveDb,
     };
@@ -787,5 +789,382 @@ mod tests {
             worst_case_cost_result.cost.storage_cost.added_bytes,
             cost.storage_cost.added_bytes
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Tests for previously uncovered GroveOp match arms in worst_case_cost
+    // ---------------------------------------------------------------
+
+    // Approach 1: Tests via estimated_case_operations_for_batch (keyed ops)
+
+    #[test]
+    fn test_refresh_reference_worst_case_cost() {
+        let grove_version = GroveVersion::latest();
+        let ops = vec![QualifiedGroveDbOp::refresh_reference_op(
+            vec![vec![7]],
+            b"ref_key".to_vec(),
+            ReferencePathType::AbsolutePathReference(vec![b"target".to_vec()]),
+            Some(5),
+            None,
+            true,
+        )];
+        let mut paths = HashMap::new();
+        paths.insert(KeyInfoPath(vec![]), MaxElementsNumber(1));
+        paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![vec![7]]),
+            MaxElementsNumber(100),
+        );
+        let cost = GroveDb::estimated_case_operations_for_batch(
+            WorstCaseCostsType(paths),
+            ops,
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("expected worst case costs for refresh reference");
+        assert!(cost.seek_count > 0);
+        assert!(cost.hash_node_calls > 0);
+    }
+
+    #[test]
+    fn test_patch_worst_case_cost() {
+        let grove_version = GroveVersion::latest();
+        let ops = vec![QualifiedGroveDbOp::patch_op(
+            vec![vec![7]],
+            b"patch_key".to_vec(),
+            Element::new_item(b"patched_value".to_vec()),
+            5,
+        )];
+        let mut paths = HashMap::new();
+        paths.insert(KeyInfoPath(vec![]), MaxElementsNumber(1));
+        paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![vec![7]]),
+            MaxElementsNumber(100),
+        );
+        let cost = GroveDb::estimated_case_operations_for_batch(
+            WorstCaseCostsType(paths),
+            ops,
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("expected worst case costs for patch");
+        assert!(cost.seek_count > 0);
+        assert!(cost.hash_node_calls > 0);
+    }
+
+    #[test]
+    fn test_delete_worst_case_cost() {
+        let grove_version = GroveVersion::latest();
+        let ops = vec![QualifiedGroveDbOp::delete_op(
+            vec![vec![7]],
+            b"del_key".to_vec(),
+        )];
+        let mut paths = HashMap::new();
+        paths.insert(KeyInfoPath(vec![]), MaxElementsNumber(1));
+        paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![vec![7]]),
+            MaxElementsNumber(100),
+        );
+        let cost = GroveDb::estimated_case_operations_for_batch(
+            WorstCaseCostsType(paths),
+            ops,
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("expected worst case costs for delete");
+        assert!(cost.seek_count > 0);
+    }
+
+    #[test]
+    fn test_delete_tree_worst_case_cost() {
+        let grove_version = GroveVersion::latest();
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![vec![7]],
+            b"tree_key".to_vec(),
+            TreeType::NormalTree,
+        )];
+        let mut paths = HashMap::new();
+        paths.insert(KeyInfoPath(vec![]), MaxElementsNumber(1));
+        paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![vec![7]]),
+            MaxElementsNumber(100),
+        );
+        let cost = GroveDb::estimated_case_operations_for_batch(
+            WorstCaseCostsType(paths),
+            ops,
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("expected worst case costs for delete tree");
+        assert!(cost.seek_count > 0);
+    }
+
+    // Approach 2: Direct worst_case_cost() tests (keyless/internal ops)
+
+    #[test]
+    fn test_commitment_tree_insert_worst_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::CommitmentTreeInsert {
+            cmx: [1u8; 32],
+            rho: [2u8; 32],
+            payload: vec![0u8; 100],
+        };
+        let key = KeyInfo::KnownKey(b"tree_key".to_vec());
+        let cost = op
+            .worst_case_cost(
+                &key,
+                TreeType::NormalTree,
+                &MaxElementsNumber(100),
+                false,
+                grove_version,
+            )
+            .cost_as_result()
+            .expect("expected worst case cost for commitment tree insert");
+        assert!(cost.seek_count > 0);
+        assert!(cost.sinsemilla_hash_calls > 0);
+    }
+
+    #[test]
+    fn test_commitment_tree_insert_worst_case_cost_with_propagate() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::CommitmentTreeInsert {
+            cmx: [1u8; 32],
+            rho: [2u8; 32],
+            payload: vec![0u8; 50],
+        };
+        let key = KeyInfo::KnownKey(b"tree_key".to_vec());
+        let cost = op
+            .worst_case_cost(
+                &key,
+                TreeType::NormalTree,
+                &MaxElementsNumber(100),
+                true,
+                grove_version,
+            )
+            .cost_as_result()
+            .expect("expected worst case cost for commitment tree insert with propagate");
+        assert!(cost.seek_count > 0);
+        assert!(cost.sinsemilla_hash_calls > 0);
+        // propagate adds additional hash calls for merk propagation
+        assert!(cost.hash_node_calls > 0);
+    }
+
+    #[test]
+    fn test_mmr_tree_append_worst_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::MmrTreeAppend {
+            value: vec![0u8; 64],
+        };
+        let key = KeyInfo::KnownKey(b"mmr_key".to_vec());
+        let cost = op
+            .worst_case_cost(
+                &key,
+                TreeType::NormalTree,
+                &MaxElementsNumber(100),
+                false,
+                grove_version,
+            )
+            .cost_as_result()
+            .expect("expected worst case cost for mmr tree append");
+        assert!(cost.seek_count > 0);
+        assert!(cost.hash_node_calls > 0);
+        // MMR append uses blake3, not sinsemilla
+        assert_eq!(cost.sinsemilla_hash_calls, 0);
+    }
+
+    #[test]
+    fn test_bulk_append_worst_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::BulkAppend {
+            value: vec![0u8; 128],
+        };
+        let key = KeyInfo::KnownKey(b"bulk_key".to_vec());
+        let cost = op
+            .worst_case_cost(
+                &key,
+                TreeType::NormalTree,
+                &MaxElementsNumber(100),
+                false,
+                grove_version,
+            )
+            .cost_as_result()
+            .expect("expected worst case cost for bulk append");
+        assert!(cost.seek_count > 0);
+        assert!(cost.hash_node_calls > 0);
+        assert_eq!(cost.sinsemilla_hash_calls, 0);
+    }
+
+    #[test]
+    fn test_dense_tree_insert_worst_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::DenseTreeInsert {
+            value: vec![0u8; 32],
+        };
+        let key = KeyInfo::KnownKey(b"dense_key".to_vec());
+        let cost = op
+            .worst_case_cost(
+                &key,
+                TreeType::NormalTree,
+                &MaxElementsNumber(100),
+                false,
+                grove_version,
+            )
+            .cost_as_result()
+            .expect("expected worst case cost for dense tree insert");
+        assert!(cost.seek_count > 0);
+        assert!(cost.hash_node_calls > 0);
+        assert_eq!(cost.sinsemilla_hash_calls, 0);
+    }
+
+    #[test]
+    fn test_replace_non_merk_tree_root_worst_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::ReplaceNonMerkTreeRoot {
+            hash: [3u8; 32],
+            meta: NonMerkTreeMeta::CommitmentTree {
+                total_count: 10,
+                chunk_power: 4,
+            },
+        };
+        let key = KeyInfo::KnownKey(b"nmerk_key".to_vec());
+        let cost = op
+            .worst_case_cost(
+                &key,
+                TreeType::NormalTree,
+                &MaxElementsNumber(100),
+                true,
+                grove_version,
+            )
+            .cost_as_result()
+            .expect("expected worst case cost for replace non-merk tree root");
+        // With propagation the merk replace tree operation produces seeks
+        assert!(cost.seek_count > 0 || cost.hash_node_calls > 0);
+    }
+
+    #[test]
+    fn test_replace_non_merk_tree_root_mmr_worst_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        let op = GroveOp::ReplaceNonMerkTreeRoot {
+            hash: [4u8; 32],
+            meta: NonMerkTreeMeta::MmrTree { mmr_size: 100 },
+        };
+        let key = KeyInfo::KnownKey(b"nmerk_mmr".to_vec());
+        let cost = op
+            .worst_case_cost(
+                &key,
+                TreeType::NormalTree,
+                &MaxElementsNumber(50),
+                true,
+                grove_version,
+            )
+            .cost_as_result()
+            .expect("expected worst case cost for replace non-merk mmr tree root");
+        assert!(cost.seek_count > 0);
+    }
+
+    #[test]
+    fn test_insert_non_merk_tree_worst_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        use grovedb_merk::tree::AggregateData;
+        let op = GroveOp::InsertNonMerkTree {
+            hash: [5u8; 32],
+            root_key: None,
+            flags: None,
+            aggregate_data: AggregateData::NoAggregateData,
+            meta: NonMerkTreeMeta::DenseTree {
+                count: 0,
+                height: 8,
+            },
+        };
+        let key = KeyInfo::KnownKey(b"new_dense".to_vec());
+        let cost = op
+            .worst_case_cost(
+                &key,
+                TreeType::NormalTree,
+                &MaxElementsNumber(100),
+                false,
+                grove_version,
+            )
+            .cost_as_result()
+            .expect("expected worst case cost for insert non-merk tree");
+        assert!(cost.seek_count > 0);
+    }
+
+    #[test]
+    fn test_insert_non_merk_tree_with_flags_worst_case_cost_direct() {
+        let grove_version = GroveVersion::latest();
+        use grovedb_merk::tree::AggregateData;
+        let op = GroveOp::InsertNonMerkTree {
+            hash: [6u8; 32],
+            root_key: Some(b"rk".to_vec()),
+            flags: Some(b"flag_data".to_vec()),
+            aggregate_data: AggregateData::NoAggregateData,
+            meta: NonMerkTreeMeta::BulkAppendTree {
+                total_count: 0,
+                chunk_power: 3,
+            },
+        };
+        let key = KeyInfo::KnownKey(b"new_bulk".to_vec());
+        let cost = op
+            .worst_case_cost(
+                &key,
+                TreeType::NormalTree,
+                &MaxElementsNumber(100),
+                true,
+                grove_version,
+            )
+            .cost_as_result()
+            .expect("expected worst case cost for insert non-merk tree with flags");
+        assert!(cost.seek_count > 0);
+        assert!(cost.hash_node_calls > 0);
+    }
+
+    #[test]
+    fn test_replace_worst_case_cost() {
+        let grove_version = GroveVersion::latest();
+        let ops = vec![QualifiedGroveDbOp::replace_op(
+            vec![vec![7]],
+            b"key1".to_vec(),
+            Element::new_item(b"val".to_vec()),
+        )];
+        let mut paths = HashMap::new();
+        paths.insert(KeyInfoPath(vec![]), MaxElementsNumber(1));
+        paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![vec![7]]),
+            MaxElementsNumber(100),
+        );
+        let cost = GroveDb::estimated_case_operations_for_batch(
+            WorstCaseCostsType(paths),
+            ops,
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("expected worst case costs for replace");
+        assert!(cost.seek_count > 0);
+        assert!(cost.hash_node_calls > 0);
     }
 }

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -887,6 +887,8 @@ mod tests {
         .cost_as_result()
         .expect("expected worst case costs for delete");
         assert!(cost.seek_count > 0);
+        // Delete involves tree rebalancing which requires hash calls
+        assert!(cost.hash_node_calls > 0);
     }
 
     #[test]
@@ -916,6 +918,8 @@ mod tests {
         .cost_as_result()
         .expect("expected worst case costs for delete tree");
         assert!(cost.seek_count > 0);
+        // DeleteTree involves tree rebalancing which requires hash calls
+        assert!(cost.hash_node_calls > 0);
     }
 
     // Approach 2: Direct worst_case_cost() tests (keyless/internal ops)
@@ -1056,8 +1060,10 @@ mod tests {
             )
             .cost_as_result()
             .expect("expected worst case cost for replace non-merk tree root");
-        // With propagation the merk replace tree operation produces seeks
-        assert!(cost.seek_count > 0 || cost.hash_node_calls > 0);
+        // With propagation the merk replace tree operation produces seeks and
+        // hash calls for tree rebalancing
+        assert!(cost.seek_count > 0);
+        assert!(cost.hash_node_calls > 0);
     }
 
     #[test]
@@ -1079,6 +1085,8 @@ mod tests {
             .cost_as_result()
             .expect("expected worst case cost for replace non-merk mmr tree root");
         assert!(cost.seek_count > 0);
+        // With propagation, hash calls are produced for tree rebalancing
+        assert!(cost.hash_node_calls > 0);
     }
 
     #[test]

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -4788,13 +4788,14 @@ mod tests {
         .expect("insert commitment tree");
 
         // Write actual data to populate data storage (frontier + bulk data).
-        // Payload must be ciphertext_payload_size::<DashMemo>() = 32+104+80 = 216 bytes.
+        // Payload must match ciphertext_payload_size::<DashMemo>() = 32+104+80.
+        const DASH_MEMO_PAYLOAD_SIZE: usize = 216;
         db.commitment_tree_insert_raw(
             EMPTY_PATH,
             b"ct",
             [1u8; 32],
             [2u8; 32],
-            vec![0u8; 216],
+            vec![0u8; DASH_MEMO_PAYLOAD_SIZE],
             Some(&tx),
             grove_version,
         )
@@ -4838,7 +4839,7 @@ mod tests {
             b"ct",
             [3u8; 32],
             [4u8; 32],
-            vec![0u8; 216],
+            vec![0u8; DASH_MEMO_PAYLOAD_SIZE],
             Some(&tx),
             grove_version,
         )

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -4687,4 +4687,197 @@ mod tests {
             Err(Error::ReferenceLimit)
         ));
     }
+
+    #[test]
+    fn test_batch_replace_item_with_sum_item_flags_update() {
+        // Exercises the Element::ItemWithSumItem branch in MerkCache's
+        // flags update closure (line ~2136).
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        // Create a sum tree that can hold ItemWithSumItem elements.
+        db.insert(
+            EMPTY_PATH,
+            b"sum_tree",
+            Element::empty_sum_tree(),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert sum tree");
+
+        // Insert an ItemWithSumItem with flags.
+        db.insert(
+            [b"sum_tree".as_ref()].as_ref(),
+            b"key1",
+            Element::new_item_with_sum_item_with_flags(b"hello".to_vec(), 42, Some(b"f1".to_vec())),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert item_with_sum_item");
+
+        // Replace via batch with flags update returning true.
+        let ops = vec![QualifiedGroveDbOp::replace_op(
+            vec![b"sum_tree".to_vec()],
+            b"key1".to_vec(),
+            Element::new_item_with_sum_item_with_flags(
+                b"world".to_vec(),
+                100,
+                Some(b"f2".to_vec()),
+            ),
+        )];
+
+        db.apply_batch_with_element_flags_update(
+            ops,
+            None,
+            |_cost, _old_flags, _new_flags| Ok(true),
+            |_flags, removed_key_bytes, removed_value_bytes| {
+                Ok((
+                    StorageRemovedBytes::BasicStorageRemoval(removed_key_bytes),
+                    StorageRemovedBytes::BasicStorageRemoval(removed_value_bytes),
+                ))
+            },
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("batch replace item_with_sum_item");
+
+        // Verify the element was updated.
+        let elem = db
+            .get(
+                [b"sum_tree".as_ref()].as_ref(),
+                b"key1",
+                Some(&tx),
+                grove_version,
+            )
+            .unwrap()
+            .expect("get replaced element");
+        assert_eq!(
+            elem,
+            Element::new_item_with_sum_item_with_flags(
+                b"world".to_vec(),
+                100,
+                Some(b"f2".to_vec()),
+            )
+        );
+    }
+
+    #[test]
+    fn test_batch_delete_non_merk_tree_cleans_data_storage() {
+        // Exercises the non-Merk delete path collection (line ~3057)
+        // and data storage cleanup (line ~3101).
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        // Insert a CommitmentTree.
+        db.insert(
+            EMPTY_PATH,
+            b"ct",
+            Element::empty_commitment_tree(4),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert commitment tree");
+
+        // Delete it via batch.
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"ct".to_vec(),
+            grovedb_merk::tree_type::TreeType::CommitmentTree(4),
+        )];
+
+        db.apply_batch(ops, None, Some(&tx), grove_version)
+            .unwrap()
+            .expect("batch delete non-merk tree");
+
+        // Verify it's gone.
+        assert!(db
+            .get(EMPTY_PATH, b"ct", Some(&tx), grove_version)
+            .unwrap()
+            .is_err());
+    }
+
+    #[test]
+    fn test_batch_delete_mmr_tree_cleans_data_storage() {
+        // Same as above but with MmrTree.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        db.insert(
+            EMPTY_PATH,
+            b"mmr",
+            Element::empty_mmr_tree(),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert mmr tree");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"mmr".to_vec(),
+            grovedb_merk::tree_type::TreeType::MmrTree,
+        )];
+
+        db.apply_batch(ops, None, Some(&tx), grove_version)
+            .unwrap()
+            .expect("batch delete mmr tree");
+
+        assert!(db
+            .get(EMPTY_PATH, b"mmr", Some(&tx), grove_version)
+            .unwrap()
+            .is_err());
+    }
+
+    #[test]
+    fn test_partial_batch_delete_non_merk_tree_cleans_data_storage() {
+        // Exercises the non-Merk delete cleanup in
+        // apply_partial_batch_with_element_flags_update (line ~3239, ~3337).
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        // Insert a DenseAppendOnlyFixedSizeTree.
+        db.insert(
+            EMPTY_PATH,
+            b"dense",
+            Element::empty_dense_tree(3),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert dense tree");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"dense".to_vec(),
+            grovedb_merk::tree_type::TreeType::DenseAppendOnlyFixedSizeTree(3),
+        )];
+
+        db.apply_partial_batch(
+            ops,
+            None,
+            |_cost, _left_over_ops| Ok(vec![]),
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("partial batch delete non-merk tree");
+
+        assert!(db
+            .get(EMPTY_PATH, b"dense", Some(&tx), grove_version)
+            .unwrap()
+            .is_err());
+    }
 }

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -4787,6 +4787,20 @@ mod tests {
         .unwrap()
         .expect("insert commitment tree");
 
+        // Write actual data to populate data storage (frontier + bulk data).
+        // Payload must be ciphertext_payload_size::<DashMemo>() = 32+104+80 = 216 bytes.
+        db.commitment_tree_insert_raw(
+            EMPTY_PATH,
+            b"ct",
+            [1u8; 32],
+            [2u8; 32],
+            vec![0u8; 216],
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert commitment tree data");
+
         // Delete it via batch.
         let ops = vec![QualifiedGroveDbOp::delete_tree_op(
             vec![],
@@ -4798,16 +4812,55 @@ mod tests {
             .unwrap()
             .expect("batch delete non-merk tree");
 
-        // Verify it's gone.
+        // Verify element is gone.
         assert!(db
             .get(EMPTY_PATH, b"ct", Some(&tx), grove_version)
             .unwrap()
             .is_err());
+
+        // Recreate the tree and insert fresh data. CommitmentTree::open
+        // validates that the stored frontier's tree_size matches total_count.
+        // If cleanup failed, stale frontier (tree_size=1) would conflict with
+        // total_count=0 and cause an error — proving data-storage cleanup.
+        db.insert(
+            EMPTY_PATH,
+            b"ct",
+            Element::empty_commitment_tree(4),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("recreate commitment tree");
+
+        db.commitment_tree_insert_raw(
+            EMPTY_PATH,
+            b"ct",
+            [3u8; 32],
+            [4u8; 32],
+            vec![0u8; 216],
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert into recreated commitment tree");
+
+        // Verify the recreated tree has exactly 1 note (fresh start).
+        let elem = db
+            .get(EMPTY_PATH, b"ct", Some(&tx), grove_version)
+            .unwrap()
+            .expect("get recreated ct");
+        match elem {
+            Element::CommitmentTree(count, _, _) => {
+                assert_eq!(count, 1, "recreated tree should have count 1");
+            }
+            _ => panic!("expected CommitmentTree element"),
+        }
     }
 
     #[test]
     fn test_batch_delete_mmr_tree_cleans_data_storage() {
-        // Same as above but with MmrTree.
+        // Exercises non-Merk data-storage cleanup for MmrTree.
         let grove_version = GroveVersion::latest();
         let db = make_empty_grovedb();
         let tx = db.start_transaction();
@@ -4823,6 +4876,13 @@ mod tests {
         .unwrap()
         .expect("insert mmr tree");
 
+        // Populate data storage with MMR nodes.
+        for i in 0..3u8 {
+            db.mmr_tree_append(EMPTY_PATH, b"mmr", vec![i], Some(&tx), grove_version)
+                .unwrap()
+                .expect("append mmr value");
+        }
+
         let ops = vec![QualifiedGroveDbOp::delete_tree_op(
             vec![],
             b"mmr".to_vec(),
@@ -4833,10 +4893,39 @@ mod tests {
             .unwrap()
             .expect("batch delete mmr tree");
 
+        // Verify element is gone.
         assert!(db
             .get(EMPTY_PATH, b"mmr", Some(&tx), grove_version)
             .unwrap()
             .is_err());
+
+        // Recreate and verify fresh start.
+        db.insert(
+            EMPTY_PATH,
+            b"mmr",
+            Element::empty_mmr_tree(),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("recreate mmr tree");
+
+        db.mmr_tree_append(
+            EMPTY_PATH,
+            b"mmr",
+            b"fresh".to_vec(),
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("append to recreated mmr");
+
+        let count = db
+            .mmr_tree_leaf_count(EMPTY_PATH, b"mmr", Some(&tx), grove_version)
+            .unwrap()
+            .expect("leaf count");
+        assert_eq!(count, 1, "recreated MMR should have 1 leaf");
     }
 
     #[test]
@@ -4859,6 +4948,13 @@ mod tests {
         .unwrap()
         .expect("insert dense tree");
 
+        // Populate data storage with dense tree values.
+        for i in 0..3u8 {
+            db.dense_tree_insert(EMPTY_PATH, b"dense", vec![i; 32], Some(&tx), grove_version)
+                .unwrap()
+                .expect("insert dense tree value");
+        }
+
         let ops = vec![QualifiedGroveDbOp::delete_tree_op(
             vec![],
             b"dense".to_vec(),
@@ -4875,9 +4971,43 @@ mod tests {
         .unwrap()
         .expect("partial batch delete non-merk tree");
 
+        // Verify element is gone.
         assert!(db
             .get(EMPTY_PATH, b"dense", Some(&tx), grove_version)
             .unwrap()
             .is_err());
+
+        // Recreate and verify fresh start.
+        db.insert(
+            EMPTY_PATH,
+            b"dense",
+            Element::empty_dense_tree(3),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("recreate dense tree");
+
+        db.dense_tree_insert(
+            EMPTY_PATH,
+            b"dense",
+            vec![99u8; 32],
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert into recreated dense tree");
+
+        let elem = db
+            .get(EMPTY_PATH, b"dense", Some(&tx), grove_version)
+            .unwrap()
+            .expect("get recreated dense tree");
+        match elem {
+            Element::DenseAppendOnlyFixedSizeTree(count, _, _) => {
+                assert_eq!(count, 1, "recreated dense tree should have count 1");
+            }
+            _ => panic!("expected DenseAppendOnlyFixedSizeTree element"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #490 — addresses CodeRabbit review feedback on the batch estimated-cost tests.

## Changes

- **Extract magic number:** Replace hard-coded `216` payload size with a named `DASH_MEMO_PAYLOAD_SIZE` constant
- **Strengthen worst-case assertions:**
  - Add `hash_node_calls > 0` checks to delete and delete_tree tests
  - Split weak `seek_count > 0 || hash_node_calls > 0` into two separate assertions in `replace_non_merk_tree_root`
  - Add `hash_node_calls > 0` to MMR replace test
- **Add sinsemilla guards:** Assert `sinsemilla_hash_calls == 0` in MMR, BulkAppend, and DenseTree average-case tests (these ops use blake3, not sinsemilla)

Intentionally skipped the suggestion to assert exact cost values (like `added_bytes == 32 + payload.len()`) — coupling tests to implementation arithmetic makes them fragile without improving confidence.

## Validation

```
cargo test -p grovedb --lib batch -- --test-threads=1   # all pass
cargo clippy -p grovedb -- -D warnings                  # clean
```
