### PR TITLE
fix: validate version byte in Query::borrow_decode (L1)

### DIFF
--- a/grovedb-query/src/query.rs
+++ b/grovedb-query/src/query.rs
@@ -118,7 +118,10 @@ impl<'de, Context> BorrowDecode<'de, Context> for Query {
     fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
-        let _version = u8::borrow_decode(decoder)?;
+        let version = u8::borrow_decode(decoder)?;
+        if version != 1 {
+            return Err(DecodeError::Other("unsupported Query encoding version"));
+        }
         // Borrow-decode the items vector
         let items = Vec::<QueryItem>::borrow_decode(decoder)?;
 

--- a/grovedb-query/tests/query_api_and_serialization.rs
+++ b/grovedb-query/tests/query_api_and_serialization.rs
@@ -82,6 +82,14 @@ fn query_decode_rejects_unsupported_version() {
 }
 
 #[test]
+fn query_borrow_decode_rejects_unsupported_version() {
+    let err = borrow_decode_from_slice::<Query, _>(&[2_u8], standard()).expect_err("must fail");
+    assert!(err
+        .to_string()
+        .contains("unsupported Query encoding version"));
+}
+
+#[test]
 fn query_decode_rejects_too_many_conditional_branches() {
     let mut bytes = Vec::new();
     let cfg = standard();


### PR DESCRIPTION
## Summary

**Audit Finding L1**: `BorrowDecode` for `Query` read and discarded the version byte without validating it. Future v2+ encodings would be silently accepted and decoded incorrectly instead of producing a clean error.

- Added `version != 1` check matching the existing `Decode` impl (line 75)
- Returns `DecodeError::Other("unsupported Query encoding version")` on mismatch

## Test plan

- [x] `cargo build -p grovedb-query` compiles clean
- [x] `cargo test -p grovedb-query` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently validate query encoding version across all processing paths; unsupported formats are now rejected with clear error messages.
* **Tests**
  * Added a test to ensure borrow-decoding rejects unsupported query encoding versions and surfaces the appropriate error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->