### PR TITLE
fix: add depth guard to terminal_keys recursion (L2)

### DIFF
--- a/grovedb-query/src/query.rs
+++ b/grovedb-query/src/query.rs
@@ -279,6 +279,11 @@ impl Query {
         false
     }
 
+    /// Maximum subquery nesting depth for `terminal_keys`. GroveDB paths
+    /// rarely exceed a handful of levels; 64 is generous and prevents stack
+    /// overflow from adversarial queries.
+    const MAX_TERMINAL_KEYS_DEPTH: usize = 64;
+
     /// Pushes terminal key paths and keys to `result`, no more than
     /// `max_results`. Returns the number of terminal keys added.
     ///
@@ -291,6 +296,21 @@ impl Query {
         max_results: usize,
         result: &mut Vec<(Vec<Vec<u8>>, Vec<u8>)>,
     ) -> Result<usize, Error> {
+        self.terminal_keys_inner(current_path, max_results, result, 0)
+    }
+
+    fn terminal_keys_inner(
+        &self,
+        current_path: Vec<Vec<u8>>,
+        max_results: usize,
+        result: &mut Vec<(Vec<Vec<u8>>, Vec<u8>)>,
+        depth: usize,
+    ) -> Result<usize, Error> {
+        if depth >= Self::MAX_TERMINAL_KEYS_DEPTH {
+            return Err(Error::NotSupported(
+                "terminal_keys subquery nesting depth exceeded".to_string(),
+            ));
+        }
         let mut current_len = result.len();
         let mut added = 0;
         let mut already_added_keys = HashSet::new();
@@ -321,7 +341,12 @@ impl Query {
                             // push the subquery path to the path
                             path.extend(subquery_path.iter().cloned());
                             // recurse onto the lower level
-                            let added_here = subquery.terminal_keys(path, max_results, result)?;
+                            let added_here = subquery.terminal_keys_inner(
+                                path,
+                                max_results,
+                                result,
+                                depth + 1,
+                            )?;
                             added += added_here;
                             current_len += added_here;
                         } else {
@@ -354,7 +379,8 @@ impl Query {
                         // push the key to the path
                         path.push(key);
                         // recurse onto the lower level
-                        let added_here = subquery.terminal_keys(path, max_results, result)?;
+                        let added_here =
+                            subquery.terminal_keys_inner(path, max_results, result, depth + 1)?;
                         added += added_here;
                         current_len += added_here;
                     }
@@ -388,7 +414,8 @@ impl Query {
                         // push the subquery path to the path
                         path.extend(subquery_path.iter().cloned());
                         // recurse onto the lower level
-                        let added_here = subquery.terminal_keys(path, max_results, result)?;
+                        let added_here =
+                            subquery.terminal_keys_inner(path, max_results, result, depth + 1)?;
                         added += added_here;
                         current_len += added_here;
                     } else {
@@ -419,7 +446,8 @@ impl Query {
                     // push the key to the path
                     path.push(key);
                     // recurse onto the lower level
-                    let added_here = subquery.terminal_keys(path, max_results, result)?;
+                    let added_here =
+                        subquery.terminal_keys_inner(path, max_results, result, depth + 1)?;
                     added += added_here;
                     current_len += added_here;
                 } else {

--- a/grovedb-query/tests/query_terminal_and_merge.rs
+++ b/grovedb-query/tests/query_terminal_and_merge.rs
@@ -94,6 +94,22 @@ fn terminal_keys_error_paths_are_reported() {
 }
 
 #[test]
+fn terminal_keys_rejects_excessive_nesting_depth() {
+    // Build a chain of 65 nested subqueries (limit is 64)
+    let mut inner = Query::new_single_key(k(1));
+    for _ in 0..65 {
+        let mut outer = Query::new_single_key(k(1));
+        outer.set_subquery(inner);
+        inner = outer;
+    }
+    let mut out = vec![];
+    let err = inner
+        .terminal_keys(vec![], 1000, &mut out)
+        .expect_err("must fail on excessive depth");
+    assert!(matches!(err, Error::NotSupported(_)));
+}
+
+#[test]
 fn merge_apis_cover_default_and_conditional_paths() {
     let mut base = Query::new();
     base.insert_key(k(1));


### PR DESCRIPTION
## Summary

**Audit Finding L2**: `Query::terminal_keys()` recurses into nested subqueries without any depth limit. A deeply nested query (e.g., from proof verification `PathQuery`) could cause a stack overflow.

- Added `MAX_TERMINAL_KEYS_DEPTH = 64` constant
- Refactored into public `terminal_keys()` wrapper + private `terminal_keys_inner()` with depth tracking
- Returns `Error::NotSupported` when nesting exceeds 64 levels
- 64 is generous — GroveDB paths rarely exceed a handful of levels

## Test plan

- [x] `cargo build -p grovedb-query` compiles clean
- [x] `cargo test -p grovedb-query` — all tests pass
- [x] `cargo test --test query_terminal_and_merge` — all 5 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added depth protection for nested query operations to prevent stack overflow errors in complex query structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->