### PR TITLE
fix: use parent tree type for DeleteTree batch operations (L3)

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1895,13 +1895,13 @@ where
                         )
                     );
                 }
-                GroveOp::DeleteTree(tree_type) => {
+                GroveOp::DeleteTree(_tree_type) => {
                     cost_return_on_error_into!(
                         &mut cost,
                         Element::delete_into_batch_operations(
                             key_info.get_key(),
                             true,
-                            tree_type,
+                            in_tree_type, /* use parent tree type, not the deleted subtree's type */
                             &mut batch_operations,
                             grove_version
                         )


### PR DESCRIPTION
## Summary

**Audit Finding L3**: `GroveOp::DeleteTree(tree_type)` passed the deleted subtree's `tree_type` to `Element::delete_into_batch_operations()` instead of `in_tree_type` (the parent tree type). The `in_tree_type` parameter determines whether to emit `DeleteLayered` vs `DeleteLayeredMaybeSpecialized` merk operations.

- Changed from `tree_type` to `in_tree_type`, matching the `GroveOp::Delete` arm
- Currently non-exploitable since both code paths are handled identically downstream, but semantically incorrect

## Test plan

- [x] `cargo build -p grovedb` compiles clean
- [x] `cargo test -p grovedb --lib -- batch` — all 298 batch tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)