### PR TITLE
fix: add visited-set cycle detection to batch reference resolution (L4)

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -28,7 +28,7 @@ mod single_sum_item_insert_cost_tests;
 use core::fmt;
 use std::{
     cmp::Ordering,
-    collections::{btree_map::Entry, hash_map::Entry as HashMapEntry, BTreeMap, HashMap},
+    collections::{btree_map::Entry, hash_map::Entry as HashMapEntry, BTreeMap, HashMap, HashSet},
     hash::{Hash, Hasher},
     ops::{Add, AddAssign},
     slice::Iter,
@@ -1073,6 +1073,7 @@ where
         intermediate_reference_info: Option<&'a ReferencePathType>,
         flags_update: &mut G,
         split_removal_bytes: &mut SR,
+        visited: &mut HashSet<Vec<Vec<u8>>>,
         grove_version: &GroveVersion,
     ) -> CostResult<CryptoHash, Error>
     where
@@ -1142,6 +1143,7 @@ where
                 recursions_allowed - 1,
                 flags_update,
                 split_removal_bytes,
+                visited,
                 grove_version,
             )
         } else {
@@ -1157,6 +1159,7 @@ where
                 recursions_allowed,
                 flags_update,
                 split_removal_bytes,
+                visited,
                 grove_version,
             )
         }
@@ -1294,6 +1297,7 @@ where
         recursions_allowed: u8,
         flags_update: &mut G,
         split_removal_bytes: &mut SR,
+        visited: &mut HashSet<Vec<Vec<u8>>>,
         grove_version: &GroveVersion,
     ) -> CostResult<CryptoHash, Error>
     where
@@ -1341,6 +1345,7 @@ where
                     recursions_allowed - 1,
                     flags_update,
                     split_removal_bytes,
+                    visited,
                     grove_version,
                 )
             }
@@ -1378,6 +1383,7 @@ where
         recursions_allowed: u8,
         flags_update: &mut G,
         split_removal_bytes: &mut SR,
+        visited: &mut HashSet<Vec<Vec<u8>>>,
         grove_version: &GroveVersion,
     ) -> CostResult<CryptoHash, Error>
     where
@@ -1391,6 +1397,10 @@ where
         let mut cost = OperationCost::default();
         if recursions_allowed == 0 {
             return Err(Error::ReferenceLimit).wrap_with_cost(cost);
+        }
+        let path_vec = qualified_path.to_vec();
+        if !visited.insert(path_vec) {
+            return Err(Error::CyclicReference).wrap_with_cost(cost);
         }
         // If the element being referenced changes in the same batch
         // we need to set the value_hash based on the new change and not the old state.
@@ -1478,6 +1488,7 @@ where
                                 recursions_allowed - 1,
                                 flags_update,
                                 split_removal_bytes,
+                                visited,
                                 grove_version,
                             )
                         }
@@ -1519,6 +1530,7 @@ where
                             recursions_allowed - 1,
                             flags_update,
                             split_removal_bytes,
+                            visited,
                             grove_version,
                         )
                     }
@@ -1557,6 +1569,7 @@ where
                         reference_info,
                         flags_update,
                         split_removal_bytes,
+                        visited,
                         grove_version,
                     )
                 }
@@ -1573,6 +1586,7 @@ where
                 None,
                 flags_update,
                 split_removal_bytes,
+                visited,
                 grove_version,
             )
         }
@@ -1696,6 +1710,7 @@ where
                                 element_max_reference_hop.unwrap_or(MAX_REFERENCE_HOPS as u8),
                                 flags_update,
                                 split_removal_bytes,
+                                &mut HashSet::new(),
                                 grove_version,
                             )
                         );
@@ -1867,6 +1882,7 @@ where
                             max_reference_hop.unwrap_or(MAX_REFERENCE_HOPS as u8),
                             flags_update,
                             split_removal_bytes,
+                            &mut HashSet::new(),
                             grove_version
                         )
                     );


### PR DESCRIPTION
## Summary

**Audit Finding L4**: Batch reference resolution used only a hop counter (max 10) to detect reference cycles, unlike the non-batch path which uses both a hop counter and a visited-path set. Short cycles (e.g., A→B→A) would waste up to 10 hops of I/O before detection.

- Added `HashSet<Vec<Vec<u8>>>` visited set threaded through `follow_reference_get_value_hash`, `process_reference`, and `process_reference_with_hop_count_greater_than_one`
- Returns `Error::CyclicReference` immediately when a previously visited path is encountered, matching the non-batch behavior
- Each external entry point (2 call sites in `execute_ops_on_path`) creates a fresh `HashSet`

## Test plan

- [x] `cargo build -p grovedb` compiles clean
- [x] `cargo test -p grovedb --lib -- batch` — all 298 batch tests pass
- [x] `cargo test -p grovedb --lib -- reference` — all 93 reference tests pass (including `test_cyclic_reference_detected`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)