### PR TITLE
fix: add InsertOnly and DeleteTree to apply_operations_without_batching (L5)

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -2720,7 +2720,33 @@ impl GroveDb {
                         )
                     );
                 }
-                GroveOp::Delete => {
+                GroveOp::InsertOnly { element } => {
+                    let path_slices: Vec<&[u8]> =
+                        op.path.iterator().map(|p| p.as_slice()).collect();
+                    let key = cost_return_on_error_no_add!(
+                        cost,
+                        op.key.as_ref().ok_or(Error::InvalidBatchOperation(
+                            "insert_only op is missing a key",
+                        ))
+                    );
+                    let mut insert_options = options
+                        .clone()
+                        .map(|o| o.as_insert_options())
+                        .unwrap_or_default();
+                    insert_options.validate_insertion_does_not_override = true;
+                    cost_return_on_error!(
+                        &mut cost,
+                        self.insert(
+                            path_slices.as_slice(),
+                            key.as_slice(),
+                            element.to_owned(),
+                            Some(insert_options),
+                            transaction,
+                            grove_version,
+                        )
+                    );
+                }
+                GroveOp::Delete | GroveOp::DeleteTree(_) => {
                     let path_slices: Vec<&[u8]> =
                         op.path.iterator().map(|p| p.as_slice()).collect();
                     let key = cost_return_on_error_no_add!(
@@ -2822,9 +2848,19 @@ impl GroveDb {
                         )
                     );
                 }
-                _ => {
+                GroveOp::Patch { .. } | GroveOp::RefreshReference { .. } => {
                     return Err(Error::NotSupported(
-                        "operation not supported in apply_operations_without_batching".to_string(),
+                        "Patch and RefreshReference are batch-only operations".to_string(),
+                    ))
+                    .wrap_with_cost(cost);
+                }
+                GroveOp::ReplaceTreeRootKey { .. }
+                | GroveOp::InsertTreeWithRootHash { .. }
+                | GroveOp::ReplaceNonMerkTreeRoot { .. }
+                | GroveOp::InsertNonMerkTree { .. } => {
+                    return Err(Error::NotSupported(
+                        "internal tree ops not supported in apply_operations_without_batching"
+                            .to_string(),
                     ))
                     .wrap_with_cost(cost);
                 }

--- a/grovedb/src/tests/batch_coverage_tests.rs
+++ b/grovedb/src/tests/batch_coverage_tests.rs
@@ -364,6 +364,88 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_apply_operations_without_batching_insert_only() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // InsertOnly should succeed when key does not exist
+        let ops = vec![QualifiedGroveDbOp::insert_only_op(
+            vec![TEST_LEAF.to_vec()],
+            b"insert_only_key".to_vec(),
+            Element::new_item(b"val".to_vec()),
+        )];
+
+        db.apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap()
+            .expect("insert_only should succeed for new key");
+
+        let result = db
+            .get(
+                [TEST_LEAF].as_ref(),
+                b"insert_only_key",
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("element should exist");
+        assert_eq!(result, Element::new_item(b"val".to_vec()));
+
+        // InsertOnly should fail when key already exists
+        let ops = vec![QualifiedGroveDbOp::insert_only_op(
+            vec![TEST_LEAF.to_vec()],
+            b"insert_only_key".to_vec(),
+            Element::new_item(b"val2".to_vec()),
+        )];
+
+        let result = db
+            .apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap();
+        assert!(
+            result.is_err(),
+            "insert_only should fail when key already exists"
+        );
+    }
+
+    #[test]
+    fn test_apply_operations_without_batching_delete_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Create a subtree
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"subtree_to_delete",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert subtree");
+
+        // DeleteTree via unbatched ops
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![TEST_LEAF.to_vec()],
+            b"subtree_to_delete".to_vec(),
+            TreeType::NormalTree,
+        )];
+
+        db.apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap()
+            .expect("delete_tree should succeed");
+
+        let result = db
+            .get(
+                [TEST_LEAF].as_ref(),
+                b"subtree_to_delete",
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(result.is_err(), "subtree should be gone after delete_tree");
+    }
+
     // ===================================================================
     // 7. batch_structure.rs validation (from_ops)
     // ===================================================================


### PR DESCRIPTION
## Summary

**Audit Finding L5**: `apply_operations_without_batching` returned `NotSupported` for `InsertOnly`, `Patch`, `RefreshReference`, and `DeleteTree` operations, even though `apply_batch` accepts them all.

- **InsertOnly**: Now supported — calls `self.insert()` with `validate_insertion_does_not_override = true`
- **DeleteTree**: Now supported — merged with the `Delete` arm since `self.delete()` handles both items and trees
- **Patch / RefreshReference**: Kept as `NotSupported` with an explicit error message — these are batch-only operations with no non-batch equivalent method
- Replaced the wildcard `_` catch-all with explicit match arms for remaining internal tree ops (`ReplaceTreeRootKey`, `InsertTreeWithRootHash`, etc.)

## Test plan

- [x] `cargo build -p grovedb` compiles clean
- [x] `cargo test -p grovedb --lib -- batch` — all 298 batch tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)