### PR TITLE
docs: document put-wins semantics in StorageBatch::delete (L6)

### DIFF
--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -407,7 +407,12 @@ impl StorageBatch {
         );
     }
 
-    /// Add deferred `delete` operation
+    /// Add deferred `delete` operation.
+    ///
+    /// If a `put` for the same key already exists in this batch, the delete is
+    /// silently dropped — the put always wins within a single batch. This is
+    /// intentional: during tree rebalancing, a node may be deleted from one
+    /// position and re-inserted at another within the same commit.
     pub(crate) fn delete(&self, key: Vec<u8>, cost_info: Option<KeyValueStorageCost>) {
         let operations = &mut self.operations.borrow_mut().data;
         if operations.get(&key).is_none() {
@@ -418,7 +423,9 @@ impl StorageBatch {
         }
     }
 
-    /// Add deferred `delete` operation for aux storage_cost
+    /// Add deferred `delete` operation for aux storage.
+    ///
+    /// Same put-wins semantics as [`Self::delete`].
     pub(crate) fn delete_aux(&self, key: Vec<u8>, cost_info: Option<KeyValueStorageCost>) {
         let operations = &mut self.operations.borrow_mut().aux;
         if operations.get(&key).is_none() {
@@ -429,7 +436,9 @@ impl StorageBatch {
         }
     }
 
-    /// Add deferred `delete` operation for subtree roots storage_cost
+    /// Add deferred `delete` operation for subtree roots storage.
+    ///
+    /// Same put-wins semantics as [`Self::delete`].
     pub(crate) fn delete_root(&self, key: Vec<u8>, cost_info: Option<KeyValueStorageCost>) {
         let operations = &mut self.operations.borrow_mut().roots;
         if operations.get(&key).is_none() {


### PR DESCRIPTION
## Summary

**Audit Finding L6**: `StorageBatch::delete` silently drops delete operations when a put for the same key already exists in the batch. This behavior is tested and intentional (during tree rebalancing, a node may be deleted from one position and re-inserted at another within the same commit), but was undocumented.

- Added doc comments to `delete()`, `delete_aux()`, and `delete_root()` explaining the put-wins semantics
- No behavior change — documentation only

## Test plan

- [x] `cargo build -p grovedb-storage` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)