### PR TITLE
docs: clarify clear() only affects default column family (L7)

### DIFF
--- a/storage/src/rocksdb_storage/storage_context/context_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_tx.rs
@@ -68,7 +68,8 @@ impl<'db> PrefixedRocksDbTransactionContext<'db> {
         }
     }
 
-    /// Clears all the data in the tree at the storage level
+    /// Clears all data in the default (data) column family for this prefix.
+    /// Auxiliary, roots, and meta column families are **not** affected.
     pub fn clear(&mut self) -> CostResult<(), Error> {
         let mut cost = OperationCost::default();
 


### PR DESCRIPTION
## Summary

**Audit Finding L7**: `PrefixedRocksDbTransactionContext::clear()` doc comment said "clears all the data in the tree" but the method only iterates and deletes from the default (data) column family. Auxiliary, roots, and meta CFs are not touched.

- Updated doc comment to accurately describe the scope of the operation
- No behavior change — documentation only

## Test plan

- [x] `cargo build -p grovedb-storage` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)