### PR TITLE
fix: remove eprintln in commit_session (L8)

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -44,9 +44,7 @@ impl GroveDb {
 
     /// Commits a completed state synchronization session.
     pub fn commit_session(&self, session: Pin<Box<MultiStateSyncSession>>) -> Result<(), Error> {
-        session
-            .commit()
-            .inspect_err(|e| eprintln!("Failed to commit session: {:?}", e))
+        session.commit()
     }
 
     /// Fetches a chunk of data from the database based on the given global


### PR DESCRIPTION
## Summary

**Audit Finding L8**: `commit_session` used `inspect_err(|e| eprintln!(...))` to print errors to stderr. This leaks error details in production and is redundant since the error is already returned via `Result` for the caller to handle.

- Removed the `.inspect_err()` call, keeping the clean `session.commit()` return

## Test plan

- [x] `cargo build -p grovedb` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)