### PR TITLE
fix: add bounds checks to pack_nested_bytes and encode_global_chunk_id (L9, L16)

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -419,11 +419,10 @@ pub(crate) mod utils {
         res.extend(subtree_prefix);
 
         if let Some(root_key) = root_key_opt {
-            let key_len: u16 = root_key.len().try_into().map_err(|_| {
-                Error::InternalError(
-                    "encode_global_chunk_id: root_key length exceeds u16".to_string(),
-                )
-            })?;
+            let key_len: u16 = root_key
+                .len()
+                .try_into()
+                .map_err(|_| Error::InternalError("root_key length exceeds u16".to_string()))?;
             res.extend_from_slice(&key_len.to_be_bytes());
             res.extend(root_key);
         } else {
@@ -502,16 +501,18 @@ pub(crate) mod utils {
         let mut packed_data = Vec::new();
 
         // Store the number of elements (4 bytes)
-        let count: u32 = nested_bytes.len().try_into().map_err(|_| {
-            Error::InternalError("pack_nested_bytes: element count exceeds u32".to_string())
-        })?;
+        let count: u32 = nested_bytes
+            .len()
+            .try_into()
+            .map_err(|_| Error::InternalError("element count exceeds u32".to_string()))?;
         packed_data.extend_from_slice(&count.to_be_bytes());
 
         for bytes in nested_bytes {
             // Store length as 4 bytes (big-endian)
-            let len: u32 = bytes.len().try_into().map_err(|_| {
-                Error::InternalError("pack_nested_bytes: element length exceeds u32".to_string())
-            })?;
+            let len: u32 = bytes
+                .len()
+                .try_into()
+                .map_err(|_| Error::InternalError("element length exceeds u32".to_string()))?;
             packed_data.extend_from_slice(&len.to_be_bytes());
 
             // Append the actual byte sequence

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -175,9 +175,9 @@ impl GroveDb {
                     local_chunk_bytes.push(op_bytes);
                 }
             }
-            global_chunk_bytes.push(pack_nested_bytes(local_chunk_bytes));
+            global_chunk_bytes.push(pack_nested_bytes(local_chunk_bytes)?);
         }
-        Ok(pack_nested_bytes(global_chunk_bytes))
+        pack_nested_bytes(global_chunk_bytes)
     }
 
     /// Starts a state synchronization process for a snapshot with the given
@@ -413,13 +413,18 @@ pub(crate) mod utils {
         root_key_opt: Option<Vec<u8>>,
         tree_type: TreeType,
         chunk_ids: Vec<Vec<u8>>,
-    ) -> Vec<u8> {
+    ) -> Result<Vec<u8>, Error> {
         let mut res = vec![];
 
         res.extend(subtree_prefix);
 
         if let Some(root_key) = root_key_opt {
-            res.extend_from_slice(&(root_key.len() as u16).to_be_bytes());
+            let key_len: u16 = root_key.len().try_into().map_err(|_| {
+                Error::InternalError(
+                    "encode_global_chunk_id: root_key length exceeds u16".to_string(),
+                )
+            })?;
+            res.extend_from_slice(&key_len.to_be_bytes());
             res.extend(root_key);
         } else {
             res.extend_from_slice(&0u16.to_be_bytes());
@@ -427,9 +432,9 @@ pub(crate) mod utils {
 
         res.push(tree_type.discriminant());
 
-        res.extend(pack_nested_bytes(chunk_ids));
+        res.extend(pack_nested_bytes(chunk_ids)?);
 
-        res
+        Ok(res)
     }
 
     /// Encodes a vector of operations (`Vec<Op>`) into a byte vector.
@@ -493,21 +498,27 @@ pub(crate) mod utils {
     ///
     /// A `Vec<u8>` containing the encoded representation of the nested byte
     /// vectors.
-    pub fn pack_nested_bytes(nested_bytes: Vec<Vec<u8>>) -> Vec<u8> {
+    pub fn pack_nested_bytes(nested_bytes: Vec<Vec<u8>>) -> Result<Vec<u8>, Error> {
         let mut packed_data = Vec::new();
 
         // Store the number of elements (4 bytes)
-        packed_data.extend_from_slice(&(nested_bytes.len() as u32).to_be_bytes());
+        let count: u32 = nested_bytes.len().try_into().map_err(|_| {
+            Error::InternalError("pack_nested_bytes: element count exceeds u32".to_string())
+        })?;
+        packed_data.extend_from_slice(&count.to_be_bytes());
 
         for bytes in nested_bytes {
             // Store length as 4 bytes (big-endian)
-            packed_data.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+            let len: u32 = bytes.len().try_into().map_err(|_| {
+                Error::InternalError("pack_nested_bytes: element length exceeds u32".to_string())
+            })?;
+            packed_data.extend_from_slice(&len.to_be_bytes());
 
             // Append the actual byte sequence
             packed_data.extend(bytes);
         }
 
-        packed_data
+        Ok(packed_data)
     }
 
     /// Unpacks a byte vector into a vector of byte vectors (`Vec<Vec<u8>>`).

--- a/grovedb/src/replication/state_sync_session.rs
+++ b/grovedb/src/replication/state_sync_session.rs
@@ -314,12 +314,7 @@ impl<'db> MultiStateSyncSession<'db> {
             self.as_mut()
                 .current_prefixes()
                 .insert(chunk_prefix, sync_info);
-            Ok(encode_global_chunk_id(
-                chunk_prefix,
-                root_key,
-                tree_type,
-                vec![],
-            ))
+            encode_global_chunk_id(chunk_prefix, root_key, tree_type, vec![])
         } else {
             Err(Error::InternalError(
                 "Unable to open merk for replication".to_string(),
@@ -485,7 +480,7 @@ impl<'db> MultiStateSyncSession<'db> {
                         subtree_state_sync.root_key.clone(),
                         subtree_state_sync.tree_type,
                         grouped_ids.to_vec(),
-                    ));
+                    )?);
                 }
                 next_global_chunk_ids.extend(next_chunk_ids);
             } else if subtree_state_sync.pending_chunks.is_empty() {
@@ -570,7 +565,7 @@ impl<'db> MultiStateSyncSession<'db> {
         let mut res: Vec<Vec<u8>> = vec![];
         for grouped_next_global_chunk_ids in next_global_chunk_ids.chunks(CONST_GROUP_PACKING_SIZE)
         {
-            res.push(pack_nested_bytes(grouped_next_global_chunk_ids.to_vec()));
+            res.push(pack_nested_bytes(grouped_next_global_chunk_ids.to_vec())?);
         }
 
         Ok(res)

--- a/grovedb/src/tests/replication_utils_tests.rs
+++ b/grovedb/src/tests/replication_utils_tests.rs
@@ -94,7 +94,7 @@ mod tests {
             b"world".to_vec(),
             vec![0x00, 0x01, 0x02, 0xFF],
         ];
-        let packed = pack_nested_bytes(input.clone());
+        let packed = pack_nested_bytes(input.clone()).unwrap();
         let unpacked = unpack_nested_bytes(&packed).expect("should unpack valid packed data");
         assert_eq!(unpacked, input);
     }
@@ -102,7 +102,7 @@ mod tests {
     #[test]
     fn pack_unpack_nested_bytes_single_element() {
         let input = vec![b"only_one".to_vec()];
-        let packed = pack_nested_bytes(input.clone());
+        let packed = pack_nested_bytes(input.clone()).unwrap();
         let unpacked =
             unpack_nested_bytes(&packed).expect("should unpack single-element packed data");
         assert_eq!(unpacked, input);
@@ -112,7 +112,7 @@ mod tests {
     fn pack_unpack_nested_bytes_empty_inner_vecs() {
         // Packing a list that contains empty byte vectors
         let input = vec![vec![], vec![], b"data".to_vec()];
-        let packed = pack_nested_bytes(input.clone());
+        let packed = pack_nested_bytes(input.clone()).unwrap();
         let unpacked =
             unpack_nested_bytes(&packed).expect("should unpack data with empty inner vecs");
         assert_eq!(unpacked, input);
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn pack_unpack_empty() {
         let input: Vec<Vec<u8>> = vec![];
-        let packed = pack_nested_bytes(input.clone());
+        let packed = pack_nested_bytes(input.clone()).unwrap();
         let unpacked = unpack_nested_bytes(&packed).expect("should unpack empty nested bytes");
         assert_eq!(unpacked, input);
     }
@@ -181,7 +181,7 @@ mod tests {
     fn unpack_nested_bytes_extra_trailing_data_error() {
         // Valid packed data followed by extra trailing bytes should fail
         let input = vec![b"test".to_vec()];
-        let mut packed = pack_nested_bytes(input);
+        let mut packed = pack_nested_bytes(input).unwrap();
         packed.push(0xFF); // extra byte
         let result = unpack_nested_bytes(&packed);
         assert!(
@@ -221,7 +221,8 @@ mod tests {
         let tree_type = TreeType::NormalTree;
         let chunk_ids = vec![b"chunk1".to_vec(), b"chunk2".to_vec()];
 
-        let encoded = encode_global_chunk_id(subtree_prefix, None, tree_type, chunk_ids.clone());
+        let encoded =
+            encode_global_chunk_id(subtree_prefix, None, tree_type, chunk_ids.clone()).unwrap();
 
         let (dec_prefix, dec_root_key, dec_tree_type, dec_chunk_ids) =
             decode_global_chunk_id(&encoded, &app_hash)
@@ -246,7 +247,8 @@ mod tests {
             Some(root_key.clone()),
             tree_type,
             chunk_ids.clone(),
-        );
+        )
+        .unwrap();
 
         let (dec_prefix, dec_root_key, dec_tree_type, dec_chunk_ids) =
             decode_global_chunk_id(&encoded, &app_hash)
@@ -265,7 +267,7 @@ mod tests {
         let app_hash = [0x00u8; 32];
         let tree_type = TreeType::CountTree;
 
-        let encoded = encode_global_chunk_id(subtree_prefix, None, tree_type, vec![]);
+        let encoded = encode_global_chunk_id(subtree_prefix, None, tree_type, vec![]).unwrap();
 
         let (dec_prefix, dec_root_key, dec_tree_type, dec_chunk_ids) =
             decode_global_chunk_id(&encoded, &app_hash)
@@ -530,10 +532,11 @@ mod tests {
             root_key.clone(),
             tree_type,
             chunk_ids.clone(),
-        );
+        )
+        .unwrap();
 
         // Pack into a nested bytes structure
-        let packed = pack_nested_bytes(vec![encoded.clone()]);
+        let packed = pack_nested_bytes(vec![encoded.clone()]).unwrap();
         let unpacked = unpack_nested_bytes(&packed).expect("should unpack nested global chunk id");
         assert_eq!(unpacked.len(), 1);
         assert_eq!(unpacked[0], encoded);


### PR DESCRIPTION
## Summary

**Audit Findings L9 + L16**: `pack_nested_bytes` truncated element count and lengths via `as u32`, and `encode_global_chunk_id` truncated `root_key.len()` via `as u16`. On 64-bit systems, values exceeding u32/u16 range would silently wrap.

- Changed `pack_nested_bytes` return type to `Result<Vec<u8>, Error>` with `try_into()` bounds checks
- Changed `encode_global_chunk_id` return type to `Result<Vec<u8>, Error>` with `try_into()` for root_key length
- Updated all callers (3 production, 10 test) to propagate or unwrap the Result

## Test plan

- [x] `cargo build -p grovedb` compiles clean
- [x] `cargo test -p grovedb --lib -- replication` — all 39 replication tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)