### PR TITLE
fix: propagate IO errors in Visualize for KeyInfoPath (L11)

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -430,10 +430,10 @@ impl Visualize for KeyInfoPath {
         let mut path_out = Vec::new();
         let mut path_drawer = Drawer::new(&mut path_out);
         for k in &self.0 {
-            path_drawer = k.visualize(path_drawer).unwrap();
-            path_drawer.write(b" ").unwrap();
+            path_drawer = k.visualize(path_drawer)?;
+            path_drawer.write(b" ")?;
         }
-        drawer.write(path_out.as_slice()).unwrap();
+        drawer.write(path_out.as_slice())?;
         Ok(drawer)
     }
 }


### PR DESCRIPTION
## Summary

**Audit Finding L11**: `Visualize for KeyInfoPath` used `.unwrap()` on fallible `Write` operations. Since the method already returns `std::io::Result`, these should use `?` to propagate errors instead of panicking.

- Changed 3 `.unwrap()` calls to `?` in `KeyInfoPath::visualize()`

## Test plan

- [x] `cargo build -p grovedb` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)