### PR TITLE
fix: replace .expect() with error propagation in visualize (L12)

### DIFF
--- a/grovedb/src/visualize.rs
+++ b/grovedb/src/visualize.rs
@@ -39,7 +39,7 @@ impl GroveDb {
         while let Some((key, element)) = iter
             .next_element(grove_version)
             .unwrap() // unwraps CostContext (discards cost)
-            .map_err(|e| std::io::Error::other(e.to_string()))?
+            .map_err(|e| std::io::Error::other(format!("cannot get next element: {e}")))?
         {
             drawer.write(b"\n[key: ")?;
             drawer = key.visualize(drawer)?;

--- a/grovedb/src/visualize.rs
+++ b/grovedb/src/visualize.rs
@@ -33,13 +33,13 @@ impl GroveDb {
         let storage = self
             .db
             .get_transactional_storage_context((&path).into(), None, tx.as_ref())
-            .unwrap();
+            .unwrap(); // unwraps CostContext (infallible — discards cost)
 
-        let mut iter = Element::iterator(storage.raw_iter()).unwrap();
+        let mut iter = Element::iterator(storage.raw_iter()).unwrap(); // CostContext unwrap
         while let Some((key, element)) = iter
             .next_element(grove_version)
-            .unwrap()
-            .expect("cannot get next element")
+            .unwrap() // unwraps CostContext (discards cost)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?
         {
             drawer.write(b"\n[key: ")?;
             drawer = key.visualize(drawer)?;

--- a/grovedb/src/visualize.rs
+++ b/grovedb/src/visualize.rs
@@ -39,7 +39,7 @@ impl GroveDb {
         while let Some((key, element)) = iter
             .next_element(grove_version)
             .unwrap() // unwraps CostContext (discards cost)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?
+            .map_err(|e| std::io::Error::other(e.to_string()))?
         {
             drawer.write(b"\n[key: ")?;
             drawer = key.visualize(drawer)?;


### PR DESCRIPTION
## Summary

**Audit Finding L12**: `visualize.rs` used `.expect("cannot get next element")` on fallible storage iteration, which would panic on corrupted storage data.

- Replaced `.expect()` with `.map_err(|e| io::Error::new(...))?` to propagate storage errors through the `io::Result` return type
- Added comments clarifying the existing `.unwrap()` calls are CostContext unwraps (infallible, just discard cost tracking)

## Test plan

- [x] `cargo build -p grovedb` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code documentation with clarifying comments.

---

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->