### PR TITLE
fix: re-enable merk AVL fuzz tests (L13)

### DIFF
--- a/merk/src/tree/fuzz_tests.rs
+++ b/merk/src/tree/fuzz_tests.rs
@@ -1,6 +1,10 @@
 //! Fuzz tests
 
-#![cfg(tests)] // NB: intentionally `tests` (not `test`) to disable these broken fuzz tests
+// NB: `cfg(tests)` (plural, not `test`) intentionally prevents compilation.
+// These fuzz tests are broken: `fuzz_case` signature mismatches (2 params vs 1
+// arg at call sites), missing `grove_version` binding, and outdated APIs.
+// They need a full rewrite to be re-enabled.
+#![cfg(tests)]
 
 #[cfg(feature = "minimal")]
 use std::{cell::RefCell, collections::BTreeMap};

--- a/merk/src/tree/fuzz_tests.rs
+++ b/merk/src/tree/fuzz_tests.rs
@@ -1,171 +1,173 @@
-//! Fuzz tests
+//! Fuzz tests for AVL tree operations.
+//!
+//! These tests verify that the AVL tree maintains consistency with a reference
+//! BTreeMap implementation across random insert, update, and delete operations.
 
-// NB: `cfg(tests)` (plural, not `test`) intentionally prevents compilation.
-// These fuzz tests are broken: `fuzz_case` signature mismatches (2 params vs 1
-// arg at call sites), missing `grove_version` binding, and outdated APIs.
-// They need a full rewrite to be re-enabled.
-#![cfg(tests)]
-
+#[cfg(test)]
 #[cfg(feature = "minimal")]
-use std::{cell::RefCell, collections::BTreeMap};
+mod tests {
+    use std::{cell::RefCell, collections::BTreeMap};
 
-#[cfg(feature = "minimal")]
-use rand::prelude::*;
+    use grovedb_version::version::GroveVersion;
+    use rand::prelude::*;
 
-#[cfg(feature = "minimal")]
-use crate::{test_utils::*, tree::*};
+    use crate::{
+        test_utils::*,
+        tree::{BatchEntry, Op, TreeNode},
+        tree_type::TreeType,
+        TreeFeatureType::BasicMerkNode,
+    };
 
-#[cfg(feature = "minimal")]
-const ITERATIONS: usize = 2_000;
-#[cfg(feature = "minimal")]
-type Map = BTreeMap<Vec<u8>, Vec<u8>>;
+    const ITERATIONS: usize = 2_000;
+    type Map = BTreeMap<Vec<u8>, Vec<u8>>;
 
-#[cfg(feature = "minimal")]
-#[test]
-fn fuzz() {
-    let mut rng = rand::rng();
+    #[test]
+    fn fuzz() {
+        let mut rng = rand::rng();
 
-    for _ in 0..ITERATIONS {
-        let seed = rng.random::<u64>();
-        fuzz_case(seed);
-    }
-}
-
-#[cfg(feature = "minimal")]
-#[test]
-fn fuzz_17391518417409062786() {
-    fuzz_case(17391518417409062786);
-}
-
-#[cfg(feature = "minimal")]
-#[test]
-fn fuzz_396148930387069749() {
-    fuzz_case(396148930387069749);
-}
-
-#[cfg(feature = "minimal")]
-fn fuzz_case(seed: u64, using_sum_trees: bool) {
-    let mut rng: SmallRng = SeedableRng::seed_from_u64(seed);
-    let initial_size = (rng.random::<u64>() % 10) + 1;
-    let tree = make_tree_rand(
-        initial_size,
-        initial_size,
-        seed,
-        using_sum_trees,
-        grove_version,
-    );
-    let mut map = Map::from_iter(tree.iter());
-    let mut maybe_tree = Some(tree);
-    println!("====== MERK FUZZ ======");
-    println!("SEED: {}", seed);
-    println!("{:?}", maybe_tree.as_ref().unwrap());
-
-    for j in 0..3 {
-        let batch_size = (rng.random::<u64>() % 3) + 1;
-        let batch = make_batch(maybe_tree.as_ref(), batch_size, rng.random::<u64>());
-        println!("BATCH {}", j);
-        println!("{:?}", batch);
-        maybe_tree = apply_to_memonly(maybe_tree, &batch, using_sum_trees, grove_version);
-        apply_to_map(&mut map, &batch);
-        assert_map(maybe_tree.as_ref(), &map);
-        if let Some(tree) = &maybe_tree {
-            println!("{:?}", &tree);
-        } else {
-            println!("(Empty tree)");
+        for _ in 0..ITERATIONS {
+            let seed = rng.random::<u64>();
+            fuzz_case(seed, false);
         }
     }
-}
 
-#[cfg(feature = "minimal")]
-fn make_batch(maybe_tree: Option<&TreeNode>, size: u64, seed: u64) -> Vec<BatchEntry> {
-    let rng: RefCell<SmallRng> = RefCell::new(SeedableRng::seed_from_u64(seed));
-    let mut batch = Vec::with_capacity(size as usize);
+    #[test]
+    fn fuzz_17391518417409062786() {
+        fuzz_case(17391518417409062786, false);
+    }
 
-    let get_random_key = || {
-        let tree = maybe_tree.as_ref().unwrap();
-        let entries: Vec<_> = tree.iter().collect();
-        let index = rng.borrow_mut().random::<u64>() as usize % entries.len();
-        entries[index].0.clone()
-    };
+    #[test]
+    fn fuzz_396148930387069749() {
+        fuzz_case(396148930387069749, false);
+    }
 
-    let random_value = |size| {
-        let mut value = vec![0; size];
-        rng.borrow_mut().fill_bytes(&mut value[..]);
-        value
-    };
-
-    let insert = || (random_value(2), Op::Put(random_value(2)));
-    let update = || {
-        let key = get_random_key();
-        (key.to_vec(), Op::Put(random_value(2)))
-    };
-    let delete = || {
-        let key = get_random_key();
-        (key.to_vec(), Op::Delete)
-    };
-
-    for _ in 0..size {
-        let entry = if maybe_tree.is_some() {
-            let kind = rng.borrow_mut().random::<u64>() % 3;
-            if kind == 0 {
-                insert()
-            } else if kind == 1 {
-                update()
-            } else {
-                delete()
-            }
+    fn fuzz_case(seed: u64, using_sum_trees: bool) {
+        let grove_version = GroveVersion::latest();
+        let mut rng: SmallRng = SeedableRng::seed_from_u64(seed);
+        let initial_size = (rng.random::<u64>() % 10) + 1;
+        let tree_type = if using_sum_trees {
+            TreeType::SumTree
         } else {
-            insert()
+            TreeType::NormalTree
         };
-        batch.push(entry);
-    }
-    batch.sort_by(|a, b| a.0.cmp(&b.0));
+        let tree = make_tree_rand(
+            initial_size,
+            initial_size,
+            seed,
+            using_sum_trees,
+            grove_version,
+        );
+        let mut map = Map::from_iter(tree.iter());
+        let mut maybe_tree = Some(tree);
+        println!("====== MERK FUZZ ======");
+        println!("SEED: {seed}");
+        println!("{:?}", maybe_tree.as_ref().unwrap());
 
-    // remove dupes
-    let mut maybe_prev_key: Option<Vec<u8>> = None;
-    let mut deduped_batch = Vec::with_capacity(batch.len());
-    for entry in batch {
-        if let Some(prev_key) = &maybe_prev_key {
-            if *prev_key == entry.0 {
-                continue;
-            }
-        }
-
-        maybe_prev_key = Some(entry.0.clone());
-        deduped_batch.push(entry);
-    }
-    deduped_batch
-}
-
-#[cfg(feature = "minimal")]
-fn apply_to_map(map: &mut Map, batch: &Batch) {
-    for entry in batch.iter() {
-        match entry {
-            (key, Op::Put(value)) => {
-                map.insert(key.to_vec(), value.to_vec());
-            }
-            (key, Op::Delete) => {
-                map.remove(key);
+        for j in 0..3 {
+            let batch_size = (rng.random::<u64>() % 3) + 1;
+            let batch = make_batch(maybe_tree.as_ref(), batch_size, rng.random::<u64>());
+            println!("BATCH {j}");
+            println!("{batch:?}");
+            maybe_tree = apply_to_memonly(maybe_tree, &batch, tree_type, grove_version);
+            apply_to_map(&mut map, &batch);
+            assert_map(maybe_tree.as_ref(), &map);
+            if let Some(tree) = &maybe_tree {
+                println!("{tree:?}");
+            } else {
+                println!("(Empty tree)");
             }
         }
     }
-}
 
-#[cfg(feature = "minimal")]
-fn assert_map(maybe_tree: Option<&TreeNode>, map: &Map) {
-    if map.is_empty() {
-        assert!(maybe_tree.is_none(), "expected tree to be None");
-        return;
+    fn make_batch(maybe_tree: Option<&TreeNode>, size: u64, seed: u64) -> Vec<BatchEntry<Vec<u8>>> {
+        let rng: RefCell<SmallRng> = RefCell::new(SeedableRng::seed_from_u64(seed));
+        let mut batch = Vec::with_capacity(size as usize);
+
+        let get_random_key = || {
+            let tree = maybe_tree.as_ref().unwrap();
+            let entries: Vec<_> = tree.iter().collect();
+            let index = rng.borrow_mut().random::<u64>() as usize % entries.len();
+            entries[index].0.clone()
+        };
+
+        let random_value = |size| {
+            let mut value = vec![0; size];
+            rng.borrow_mut().fill_bytes(&mut value[..]);
+            value
+        };
+
+        let insert = || (random_value(2), Op::Put(random_value(2), BasicMerkNode));
+        let update = || {
+            let key = get_random_key();
+            (key.to_vec(), Op::Put(random_value(2), BasicMerkNode))
+        };
+        let delete = || {
+            let key = get_random_key();
+            (key.to_vec(), Op::Delete)
+        };
+
+        for _ in 0..size {
+            let entry = if maybe_tree.is_some() {
+                let kind = rng.borrow_mut().random::<u64>() % 3;
+                if kind == 0 {
+                    insert()
+                } else if kind == 1 {
+                    update()
+                } else {
+                    delete()
+                }
+            } else {
+                insert()
+            };
+            batch.push(entry);
+        }
+        batch.sort_by(|a, b| a.0.cmp(&b.0));
+
+        // remove dupes
+        let mut maybe_prev_key: Option<Vec<u8>> = None;
+        let mut deduped_batch = Vec::with_capacity(batch.len());
+        for entry in batch {
+            if let Some(prev_key) = &maybe_prev_key {
+                if *prev_key == entry.0 {
+                    continue;
+                }
+            }
+
+            maybe_prev_key = Some(entry.0.clone());
+            deduped_batch.push(entry);
+        }
+        deduped_batch
     }
 
-    let tree = maybe_tree.expect("expected tree to be Some");
-
-    let map_iter = map.iter();
-    let tree_iter = tree.iter();
-    for (tree_kv, map_kv) in tree_iter.zip(map_iter) {
-        assert_eq!(tree_kv.0, *map_kv.0);
-        assert_eq!(tree_kv.1, *map_kv.1);
+    fn apply_to_map(map: &mut Map, batch: &[BatchEntry<Vec<u8>>]) {
+        for entry in batch.iter() {
+            match entry {
+                (key, Op::Put(value, _)) => {
+                    map.insert(key.to_vec(), value.to_vec());
+                }
+                (key, Op::Delete) => {
+                    map.remove(key);
+                }
+                _ => {}
+            }
+        }
     }
 
-    assert_eq!(tree.iter().count(), map.len());
+    fn assert_map(maybe_tree: Option<&TreeNode>, map: &Map) {
+        if map.is_empty() {
+            assert!(maybe_tree.is_none(), "expected tree to be None");
+            return;
+        }
+
+        let tree = maybe_tree.expect("expected tree to be Some");
+
+        let map_iter = map.iter();
+        let tree_iter = tree.iter();
+        for (tree_kv, map_kv) in tree_iter.zip(map_iter) {
+            assert_eq!(tree_kv.0, *map_kv.0);
+            assert_eq!(tree_kv.1, *map_kv.1);
+        }
+
+        assert_eq!(tree.iter().count(), map.len());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes audit finding **L13**: Fuzz tests in `merk/src/tree/fuzz_tests.rs` were permanently disabled by `#![cfg(tests)]` (plural instead of `test`).

Instead of just documenting the breakage, this PR fixes all issues and re-enables the tests:

- `#![cfg(tests)]` → `#[cfg(test)]` (module-level attribute, not crate-level)
- Fix `fuzz_case` callers to pass both arguments (`seed`, `using_sum_trees`)
- Add missing `grove_version` binding
- Update `Op::Put` to include `TreeFeatureType` (`BasicMerkNode`)
- Use `TreeType` instead of `bool` for `apply_to_memonly`
- Update `apply_to_map` to match current `Op::Put(value, feature_type)` signature
- Use explicit imports instead of glob `use crate::tree::*`

## Test plan

- [x] All 3 fuzz tests pass (`cargo test -p grovedb-merk --features minimal fuzz_tests`)
- [x] Main `fuzz` test runs 2000 random iterations successfully
- [x] `cargo clippy -p grovedb-merk -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)