### PR TITLE
fix: distinguish sync-never-started from sync-completed (L14)

### DIFF
--- a/grovedb/src/replication/state_sync_session.rs
+++ b/grovedb/src/replication/state_sync_session.rs
@@ -208,7 +208,12 @@ impl<'db> MultiStateSyncSession<'db> {
     }
 
     /// Returns true if all subtrees have been fully synchronized.
+    /// Returns false if sync has never started (no prefixes processed).
     pub fn is_sync_completed(&self) -> bool {
+        if self.current_prefixes.is_empty() && self.processed_prefixes.is_empty() {
+            return false;
+        }
+
         for (_, subtree_state_info) in self.current_prefixes.iter() {
             if !subtree_state_info.pending_chunks.is_empty() {
                 return false;

--- a/grovedb/src/tests/replication_session_tests.rs
+++ b/grovedb/src/tests/replication_session_tests.rs
@@ -583,6 +583,17 @@ mod tests {
     }
 
     #[test]
+    fn is_sync_completed_returns_false_before_any_sync() {
+        let grove_version = GroveVersion::latest();
+        let dest = make_empty_grovedb();
+        let session = crate::replication::MultiStateSyncSession::new(&dest, [0u8; 32], 64);
+        assert!(
+            !session.is_sync_completed(),
+            "is_sync_completed should return false when no sync has ever started"
+        );
+    }
+
+    #[test]
     fn fetch_chunk_unsupported_version_error() {
         let grove_version = GroveVersion::latest();
         let source = make_test_grovedb(grove_version);


### PR DESCRIPTION
## Summary

**Audit Finding L14**: `is_sync_completed()` returned `true` when `current_prefixes` was empty, making it impossible to distinguish "sync completed" from "sync never started."

- Added early return `false` when both `current_prefixes` and `processed_prefixes` are empty
- A freshly created `MultiStateSyncSession` (before any `apply_chunk`) now correctly reports sync as not completed

## Test plan

- [x] `cargo build -p grovedb` compiles clean
- [x] `cargo test -p grovedb --lib -- replication` — all 39 replication tests pass
- [x] `is_sync_completed_transitions` test verifies the full lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)