### PR TITLE
fix: enforce InsertOnly semantics in batch execution path

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1674,6 +1674,7 @@ where
 
         let mut batch_operations: Vec<(Vec<u8>, Op)> = vec![];
         for (key_info, op) in ops_at_path_by_key.into_iter() {
+            let is_insert_only = matches!(&op, GroveOp::InsertOnly { .. });
             match op {
                 GroveOp::InsertOnly { element }
                 | GroveOp::InsertOrReplace { element }
@@ -1819,7 +1820,9 @@ where
                                     .get_feature_type(in_tree_type)
                                     .wrap_with_cost(OperationCost::default())
                             );
-                            if batch_apply_options.validate_insertion_does_not_override {
+                            if is_insert_only
+                                || batch_apply_options.validate_insertion_does_not_override
+                            {
                                 let merk = self.merks.get_mut(path).expect("the Merk is cached");
 
                                 let inserted = cost_return_on_error_into!(

--- a/grovedb/src/tests/batch_coverage_tests.rs
+++ b/grovedb/src/tests/batch_coverage_tests.rs
@@ -1520,6 +1520,49 @@ mod tests {
     }
 
     // ===================================================================
+    // 30b. InsertOnly enforces no-overwrite even without batch option
+    // ===================================================================
+
+    #[test]
+    fn test_batch_insert_only_rejects_overwrite_without_explicit_validation_option() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert an item first
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"existing",
+            Element::new_item(b"original".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert existing item");
+
+        // InsertOnly should reject overwrite even with default batch options
+        // (validate_insertion_does_not_override = false)
+        let ops = vec![QualifiedGroveDbOp::insert_only_op(
+            vec![TEST_LEAF.to_vec()],
+            b"existing".to_vec(),
+            Element::new_item(b"should_fail".to_vec()),
+        )];
+
+        let result = db.apply_batch(ops, None, None, grove_version).unwrap();
+        assert!(
+            result.is_err(),
+            "InsertOnly should reject overwrite regardless of batch options"
+        );
+
+        // Verify original value is preserved
+        let val = db
+            .get([TEST_LEAF].as_ref(), b"existing", None, grove_version)
+            .unwrap()
+            .expect("should get element");
+        assert_eq!(val, Element::new_item(b"original".to_vec()));
+    }
+
+    // ===================================================================
     // 31. Batch: RefreshReference with trust_refresh_reference = false
     // ===================================================================
 


### PR DESCRIPTION
## Summary

**Audit finding M-NEW-1**: `InsertOnly` did not enforce insert-only semantics in the batch execution path.

- In `execute_ops_on_path`, `InsertOnly` was grouped with `InsertOrReplace`/`Replace`/`Patch` in a single match arm
- The check to use `insert_if_not_exists_into_batch_operations` depended solely on `batch_apply_options.validate_insertion_does_not_override`
- The non-batch fallback path (`apply_operations_without_batching`) correctly forced `validate_insertion_does_not_override = true` for `InsertOnly`
- **Result**: Batch `InsertOnly` silently overwrote existing elements unless the caller explicitly set the batch option

## Fix

Capture whether the op is `InsertOnly` before entering the match, and always use `insert_if_not_exists_into_batch_operations` for `InsertOnly` ops regardless of the batch option.

## Test plan

- [x] New test: `test_batch_insert_only_rejects_overwrite_without_explicit_validation_option` — verifies InsertOnly rejects overwrites with default batch options
- [x] All 10 existing InsertOnly tests pass
- [x] `cargo test -p grovedb --lib insert_only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)