### PR TITLE
fix: use saturating_add in StorageCost and StorageRemovedBytes

### DIFF
--- a/costs/src/storage_cost/mod.rs
+++ b/costs/src/storage_cost/mod.rs
@@ -56,8 +56,8 @@ impl Add for StorageCost {
 
     fn add(self, rhs: Self) -> Self::Output {
         Self {
-            added_bytes: self.added_bytes + rhs.added_bytes,
-            replaced_bytes: self.replaced_bytes + rhs.replaced_bytes,
+            added_bytes: self.added_bytes.saturating_add(rhs.added_bytes),
+            replaced_bytes: self.replaced_bytes.saturating_add(rhs.replaced_bytes),
             removed_bytes: self.removed_bytes + rhs.removed_bytes,
         }
     }
@@ -65,8 +65,8 @@ impl Add for StorageCost {
 
 impl AddAssign for StorageCost {
     fn add_assign(&mut self, rhs: Self) {
-        self.added_bytes += rhs.added_bytes;
-        self.replaced_bytes += rhs.replaced_bytes;
+        self.added_bytes = self.added_bytes.saturating_add(rhs.added_bytes);
+        self.replaced_bytes = self.replaced_bytes.saturating_add(rhs.replaced_bytes);
         self.removed_bytes += rhs.removed_bytes;
     }
 }

--- a/costs/src/storage_cost/removal.rs
+++ b/costs/src/storage_cost/removal.rs
@@ -72,7 +72,7 @@ impl Add for StorageRemovedBytes {
             },
             BasicStorageRemoval(s) => match rhs {
                 NoStorageRemoval => BasicStorageRemoval(s),
-                BasicStorageRemoval(r) => BasicStorageRemoval(s + r),
+                BasicStorageRemoval(r) => BasicStorageRemoval(s.saturating_add(r)),
                 SectionedStorageRemoval(mut map) => {
                     let default = Identifier::default();
                     if let std::collections::btree_map::Entry::Vacant(e) = map.entry(default) {
@@ -82,7 +82,7 @@ impl Add for StorageRemovedBytes {
                     } else {
                         let mut old_section_map = map.remove(&default).unwrap_or_default();
                         if let Some(old_value) = old_section_map.remove(UNKNOWN_EPOCH) {
-                            old_section_map.insert(UNKNOWN_EPOCH, old_value + s);
+                            old_section_map.insert(UNKNOWN_EPOCH, old_value.saturating_add(s));
                         } else {
                             old_section_map.insert(UNKNOWN_EPOCH, s);
                         }
@@ -101,7 +101,7 @@ impl Add for StorageRemovedBytes {
                     } else {
                         let mut old_section_map = smap.remove(&default).unwrap_or_default();
                         if let Some(old_value) = old_section_map.remove(UNKNOWN_EPOCH) {
-                            old_section_map.insert(UNKNOWN_EPOCH, old_value + r);
+                            old_section_map.insert(UNKNOWN_EPOCH, old_value.saturating_add(r));
                         } else {
                             old_section_map.insert(UNKNOWN_EPOCH, r);
                         }
@@ -116,7 +116,7 @@ impl Add for StorageRemovedBytes {
                                 .into_iter()
                                 .map(|(k, v)| {
                                     let combined = if let Some(value_b) = int_map_b.remove(k) {
-                                        v + value_b
+                                        v.saturating_add(value_b)
                                     } else {
                                         v
                                     };
@@ -142,13 +142,13 @@ impl AddAssign for StorageRemovedBytes {
             NoStorageRemoval => *self = rhs,
             BasicStorageRemoval(s) => match rhs {
                 NoStorageRemoval => {}
-                BasicStorageRemoval(r) => *s += r,
+                BasicStorageRemoval(r) => *s = s.saturating_add(r),
                 SectionedStorageRemoval(mut map) => {
                     let default = Identifier::default();
                     if let Some(mut old_int_map) = map.remove(&default) {
                         if old_int_map.contains_key(UNKNOWN_EPOCH) {
                             let old_value = old_int_map.remove(UNKNOWN_EPOCH).unwrap_or_default();
-                            old_int_map.insert(UNKNOWN_EPOCH, old_value + *s);
+                            old_int_map.insert(UNKNOWN_EPOCH, old_value.saturating_add(*s));
                         } else {
                             old_int_map.insert(UNKNOWN_EPOCH, *s);
                         }
@@ -167,7 +167,7 @@ impl AddAssign for StorageRemovedBytes {
                     let map_to_insert = if let Some(mut old_int_map) = smap.remove(&default) {
                         if old_int_map.contains_key(UNKNOWN_EPOCH) {
                             let old_value = old_int_map.remove(UNKNOWN_EPOCH).unwrap_or_default();
-                            old_int_map.insert(UNKNOWN_EPOCH, old_value + r);
+                            old_int_map.insert(UNKNOWN_EPOCH, old_value.saturating_add(r));
                         } else {
                             old_int_map.insert(UNKNOWN_EPOCH, r);
                         }
@@ -187,7 +187,7 @@ impl AddAssign for StorageRemovedBytes {
                                 .into_iter()
                                 .map(|(k, v)| {
                                     let combined = if let Some(value_b) = int_map_b.remove(k) {
-                                        v + value_b
+                                        v.saturating_add(value_b)
                                     } else {
                                         v
                                     };


### PR DESCRIPTION
## Summary

**Audit finding M-NEW-4**: `StorageCost` and `StorageRemovedBytes` used plain `+` arithmetic which panics in debug builds or wraps in release, while `OperationCost` correctly uses `saturating_add`.

Changed all `u32` additions in:
- `StorageCost::Add` and `AddAssign` (`added_bytes`, `replaced_bytes`)
- `StorageRemovedBytes::Add` and `AddAssign` (`BasicStorageRemoval` values and `SectionedStorageRemoval` epoch map merges)

## Test plan

- [x] `cargo test -p grovedb-costs` — all 10 tests pass
- [x] `cargo build -p grovedb-costs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)