### PR TITLE
fix: prevent u16 truncation in query limit tracking

### DIFF
--- a/grovedb/src/element/query.rs
+++ b/grovedb/src/element/query.rs
@@ -400,7 +400,8 @@ impl ElementQueryExtensions for Element {
                         // we should decrease by 1 in this case
                         *limit = limit.saturating_sub(1);
                     } else {
-                        *limit = limit.saturating_sub(sub_elements.len() as u16);
+                        *limit =
+                            limit.saturating_sub(sub_elements.len().min(u16::MAX as usize) as u16);
                     }
                 }
                 if let Some(offset) = offset {

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -1291,7 +1291,7 @@ impl GroveDb {
 
         // Update limit
         if let Some(limit) = overall_limit.as_mut() {
-            let count = mmr_proof.leaves().len() as u16;
+            let count = mmr_proof.leaves().len().min(u16::MAX as usize) as u16;
             *limit = limit.saturating_sub(count);
         }
 
@@ -1378,7 +1378,7 @@ impl GroveDb {
 
         // Update limit: count individual values in the queried range
         if let Some(limit) = overall_limit.as_mut() {
-            let count = (end.min(total_count) - start) as u16;
+            let count = (end.min(total_count) - start).min(u16::MAX as u64) as u16;
             *limit = limit.saturating_sub(count);
         }
 
@@ -1535,7 +1535,7 @@ impl GroveDb {
 
         // Update limit
         if let Some(limit) = overall_limit.as_mut() {
-            let count = dense_proof.entries.len() as u16;
+            let count = dense_proof.entries.len().min(u16::MAX as usize) as u16;
             *limit = limit.saturating_sub(count);
         }
 


### PR DESCRIPTION
## Summary

**Audit findings M-NEW-5 and M-NEW-6**: `usize`/`u64` values were cast to `u16` without bounds checking when decrementing query limits.

Affected locations:
- `grovedb/src/element/query.rs:403` — `sub_elements.len() as u16`
- `grovedb/src/operations/proof/generate.rs:1381` — BulkAppendTree range count `as u16`
- `grovedb/src/operations/proof/generate.rs:1294` — MMR proof leaves count `as u16`
- `grovedb/src/operations/proof/generate.rs:1538` — DenseTree proof entries count `as u16`

All now clamp to `u16::MAX` before casting, ensuring the limit is always decremented by at least `u16::MAX` (effectively zeroing it) rather than wrapping to a small value.

## Test plan

- [x] `cargo build -p grovedb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)