### PR TITLE
fix: propagate write errors in ChunkOp::encode_into

### DIFF
--- a/merk/src/proofs/chunk/chunk_op.rs
+++ b/merk/src/proofs/chunk/chunk_op.rs
@@ -48,7 +48,7 @@ impl Encode for ChunkOp {
         match self {
             Self::ChunkId(instruction) => {
                 // write the marker then the len
-                let _ = dest.write_all(&[0_u8]);
+                dest.write_all(&[0_u8])?;
                 dest.write_all(instruction.len().encode_var_vec().as_slice())?;
                 let instruction_as_binary: Vec<u8> = instruction
                     .iter()
@@ -57,7 +57,7 @@ impl Encode for ChunkOp {
                 dest.write_all(&instruction_as_binary)?;
             }
             Self::Chunk(chunk) => {
-                let _ = dest.write_all(&[1_u8]);
+                dest.write_all(&[1_u8])?;
                 // chunk len represents the number of ops not the total encoding len of ops
                 dest.write_all(chunk.len().encode_var_vec().as_slice())?;
                 for op in chunk {


### PR DESCRIPTION
## Summary

**Audit finding E-NEW-1**: `ChunkOp::encode_into` silently discarded write errors for the discriminant tag byte via `let _ = dest.write_all(&[0_u8])`.

If the tag write failed but subsequent writes succeeded, the encoded chunk would be missing its type discriminant, causing deserialization failures during state sync/replication.

## Fix

Replace `let _ =` with `?` on both tag writes (ChunkId tag `0x00` and Chunk tag `0x01`).

## Test plan

- [x] `cargo test -p grovedb-merk --lib chunk` — all 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)