### PR TITLE
fix: preserve original error details in map_err closures

### DIFF
--- a/grovedb/src/operations/delete/mod.rs
+++ b/grovedb/src/operations/delete/mod.rs
@@ -799,8 +799,10 @@ impl GroveDb {
                         Some(&Element::value_defined_cost_for_serialized_value),
                         grove_version,
                     )
-                    .map_err(|_| {
-                        Error::CorruptedData("cannot open a subtree with given root key".to_owned())
+                    .map_err(|e| {
+                        Error::CorruptedData(format!(
+                            "cannot open a subtree with given root key: {e}"
+                        ))
                     })
                 );
                 // We are deleting a tree, a tree uses 3 bytes

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -384,7 +384,7 @@ pub(crate) mod utils {
 
         let subtree_prefix: crate::SubtreePrefix = chunk_prefix_key
             .try_into()
-            .map_err(|_| Error::CorruptedData("unable to construct subtree".to_string()))?;
+            .map_err(|e| Error::CorruptedData(format!("unable to construct subtree: {e}")))?;
 
         if !root_key.is_empty() {
             Ok((
@@ -429,7 +429,7 @@ pub(crate) mod utils {
             let key_len: u16 = root_key
                 .len()
                 .try_into()
-                .map_err(|_| Error::InternalError("root_key length exceeds u16".to_string()))?;
+                .map_err(|e| Error::InternalError(format!("root_key length exceeds u16: {e}")))?;
             res.extend_from_slice(&key_len.to_be_bytes());
             res.extend(root_key);
         } else {

--- a/merk/src/element/get.rs
+++ b/merk/src/element/get.rs
@@ -172,8 +172,8 @@ impl ElementFetchFromStorageExtensions for Element {
             cost,
             value_opt
                 .map(|value| {
-                    Self::deserialize(value.as_slice(), grove_version).map_err(|_| {
-                        Error::CorruptedData(String::from("unable to deserialize element"))
+                    Self::deserialize(value.as_slice(), grove_version).map_err(|e| {
+                        Error::CorruptedData(format!("unable to deserialize element: {e}"))
                     })
                 })
                 .transpose()
@@ -364,7 +364,7 @@ impl ElementFetchFromStorageExtensions for Element {
         };
 
         Self::deserialize(value.as_slice(), grove_version)
-            .map_err(|_| Error::CorruptedData(String::from("unable to deserialize element")))
+            .map_err(|e| Error::CorruptedData(format!("unable to deserialize element: {e}")))
             .map(|e| (e, value_hash))
             .wrap_with_cost(cost)
     }
@@ -402,8 +402,8 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
             value
                 .as_ref()
                 .map(|value| {
-                    Self::deserialize(value.as_slice(), grove_version).map_err(|_| {
-                        Error::CorruptedData(String::from("unable to deserialize element"))
+                    Self::deserialize(value.as_slice(), grove_version).map_err(|e| {
+                        Error::CorruptedData(format!("unable to deserialize element: {e}"))
                     })
                 })
                 .transpose()
@@ -502,8 +502,8 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
         let node_type = tree_feature_type.node_type();
         let element = cost_return_on_error_no_add!(
             cost,
-            Self::deserialize(value.as_slice(), grove_version).map_err(|_| {
-                Error::CorruptedData(String::from("unable to deserialize element"))
+            Self::deserialize(value.as_slice(), grove_version).map_err(|e| {
+                Error::CorruptedData(format!("unable to deserialize element: {e}"))
             })
         );
         match &element {


### PR DESCRIPTION
## Summary

**Audit findings E-NEW-2 through E-NEW-5**: Several `map_err(|_| ...)` closures discarded the original error, making production debugging difficult.

Changed `|_|` to `|e|` with `format!("context: {e}")` in:
- `merk/src/element/get.rs` — 4 element deserialization errors
- `grovedb/src/operations/delete/mod.rs` — subtree open error
- `grovedb/src/replication.rs` — subtree construction and key length errors

Note: `merk/src/merk/restore.rs` has similar patterns but uses `ChunkError::InternalError(&'static str)` which can't take dynamic strings without changing the error type. Left unchanged.

## Test plan

- [x] `cargo build -p grovedb -p grovedb-merk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)