### PR TITLE
fix: enforce set_new_transaction precondition in release builds

### DIFF
--- a/grovedb/src/replication/state_sync_session.rs
+++ b/grovedb/src/replication/state_sync_session.rs
@@ -281,10 +281,11 @@ impl<'db> MultiStateSyncSession<'db> {
     unsafe fn set_new_transaction(
         self: &mut Pin<Box<MultiStateSyncSession<'db>>>,
     ) -> Result<(), Error> {
-        debug_assert!(
-            self.current_prefixes.is_empty(),
-            "current_prefixes must be empty before replacing transaction"
-        );
+        if !self.current_prefixes.is_empty() {
+            return Err(Error::InternalError(
+                "current_prefixes must be empty before replacing transaction".to_string(),
+            ));
+        }
         let this = unsafe { Pin::as_mut(self).get_unchecked_mut() };
         let old_tx = mem::replace(&mut this.transaction, this.db.start_transaction());
         self.db.commit_transaction(old_tx).value.map_err(|e| {


### PR DESCRIPTION
## Summary

**Audit finding E-NEW-8**: The safety-critical precondition in `set_new_transaction` that `current_prefixes` must be empty before replacing the transaction was only enforced by `debug_assert!`, which is stripped in release builds.

This is an unsafe function where violating the precondition could cause use-after-free: if storage contexts in `current_prefixes` still hold references to the old transaction when it's replaced, those references become dangling.

## Fix

Replace `debug_assert!` with a runtime check that returns `Err(Error::InternalError(...))`.

## Test plan

- [x] `cargo build -p grovedb`
- [x] Existing replication tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)