### PR TITLE
docs: round 4 audit findings and inline documentation

### DIFF
--- a/grovedb-query/src/proofs/encoding.rs
+++ b/grovedb-query/src/proofs/encoding.rs
@@ -908,6 +908,11 @@ impl<'a> Decoder<'a> {
     }
 }
 
+// NOTE: The Decoder does not verify that all input bytes are consumed after
+// yielding the last Op. Trailing bytes after valid operations are silently
+// ignored. This does not affect proof security (the execute function validates
+// the proof structure via stack depth and key ordering), but means proofs
+// could contain dead bytes that waste space.
 impl Iterator for Decoder<'_> {
     type Item = Result<Op, Error>;
 

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1952,6 +1952,11 @@ where
                     );
                 }
                 GroveOp::DeleteTree(_tree_type) => {
+                    // NOTE: This only deletes the tree element from its parent.
+                    // Unlike the non-batch delete path, it does NOT recursively
+                    // clean up nested subtrees' storage. Callers must include
+                    // explicit DeleteTree ops for all nested subtrees in the
+                    // same batch to avoid orphaned data on disk.
                     cost_return_on_error_into!(
                         &mut cost,
                         Element::delete_into_batch_operations(


### PR DESCRIPTION
## Summary

Documents the results of the 2026-03-07 comprehensive audit (5 parallel auditors covering security, error handling, logic, storage/concurrency, and API edge cases).

### Audit doc
- `docs/audit/2026-03-07-codebase-audit-round4.md` — complete findings table with severities, PR links for fixed issues, and rationale for informational items

### Inline comments
- `grovedb/src/batch/mod.rs`: Document that batch `DeleteTree` does not recursively clean up nested subtrees (callers must include explicit DeleteTree ops for all nested subtrees)
- `grovedb-query/src/proofs/encoding.rs`: Document that the proof Decoder ignores trailing bytes after valid operations (does not affect security)

### Related fix PRs
- #586 — M-NEW-1: InsertOnly batch semantics
- #587 — M-NEW-4: StorageCost saturating_add
- #588 — M-NEW-5/6: u16 truncation in limit tracking
- #589 — E-NEW-1: ChunkOp write error propagation
- #590 — E-NEW-2-5: Preserve error details in map_err
- #591 — E-NEW-8: Runtime assert for set_new_transaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Documentation**
  * Clarified batch delete operation behavior for nested tree structures, specifying that nested cleanup requires explicit delete operations in the same batch.

* **Improvements**
  * Enhanced decoder iteration support for improved usability when processing sequential operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->