### PR TITLE
fix: reject proofs with unconsumed trailing bytes

### DIFF
--- a/grovedb-query/src/proofs/encoding.rs
+++ b/grovedb-query/src/proofs/encoding.rs
@@ -906,6 +906,11 @@ impl<'a> Decoder<'a> {
             bytes: proof_bytes,
         }
     }
+
+    /// Returns the number of bytes not yet consumed by the decoder.
+    pub const fn remaining_bytes(&self) -> usize {
+        self.bytes.len() - self.offset
+    }
 }
 
 impl Iterator for Decoder<'_> {
@@ -1677,5 +1682,42 @@ mod test {
         let decoder = Decoder::new(&encoded);
         let decoded_ops: Result<Vec<Op>, _> = decoder.collect();
         assert_eq!(decoded_ops.expect("decode failed"), ops);
+    }
+
+    #[test]
+    fn decoder_remaining_bytes_zero_after_full_consumption() {
+        let ops = vec![
+            Op::Push(Node::Hash([1; HASH_LENGTH])),
+            Op::Push(Node::KV(vec![2, 3], vec![4, 5])),
+            Op::Parent,
+        ];
+
+        let mut encoded = vec![];
+        for op in &ops {
+            op.encode_into(&mut encoded).unwrap();
+        }
+
+        let mut decoder = Decoder::new(&encoded);
+        let decoded: Vec<Op> = decoder.by_ref().collect::<Result<_, _>>().unwrap();
+        assert_eq!(decoded, ops);
+        assert_eq!(decoder.remaining_bytes(), 0);
+    }
+
+    #[test]
+    fn decoder_remaining_bytes_detects_trailing_data() {
+        let op = Op::Push(Node::Hash([1; HASH_LENGTH]));
+
+        let mut encoded = vec![];
+        op.encode_into(&mut encoded).unwrap();
+        // Append trailing garbage bytes
+        encoded.extend_from_slice(&[0xFF, 0xFE, 0xFD]);
+
+        let mut decoder = Decoder::new(&encoded);
+        // First op decodes fine
+        let first = decoder.next().unwrap().unwrap();
+        assert_eq!(first, op);
+        // Remaining bytes include the trailing garbage (and possibly the next
+        // attempted decode will fail, but remaining_bytes is nonzero either way)
+        assert!(decoder.remaining_bytes() > 0);
     }
 }

--- a/grovedb-query/src/proofs/encoding.rs
+++ b/grovedb-query/src/proofs/encoding.rs
@@ -909,7 +909,7 @@ impl<'a> Decoder<'a> {
 
     /// Returns the number of bytes not yet consumed by the decoder.
     pub const fn remaining_bytes(&self) -> usize {
-        self.bytes.len() - self.offset
+        self.bytes.len().saturating_sub(self.offset)
     }
 }
 

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -1984,10 +1984,17 @@ impl GroveDb {
             .map_err(|e| Error::CorruptedData(format!("invalid chunk depth parameters: {}", e)))?;
 
         // Now we're at the target layer - decode and execute the trunk proof
-        let decoder = Decoder::new(&current_layer.merk_proof);
+        let mut decoder = Decoder::new(&current_layer.merk_proof);
         let ops: Vec<Op> = decoder
+            .by_ref()
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| Error::CorruptedData(format!("Failed to decode trunk proof: {}", e)))?;
+        if decoder.remaining_bytes() > 0 {
+            return Err(Error::CorruptedData(format!(
+                "Trunk proof has {} unconsumed trailing bytes",
+                decoder.remaining_bytes()
+            )));
+        }
 
         // Execute the proof to build the tree structure and get its root hash
         // Use collapse=false to preserve the full tree structure for element extraction
@@ -2235,10 +2242,17 @@ impl GroveDb {
         grove_version: &GroveVersion,
     ) -> Result<crate::query::GroveBranchQueryResult, Error> {
         // Decode the proof ops
-        let decoder = Decoder::new(proof);
+        let mut decoder = Decoder::new(proof);
         let ops: Vec<Op> = decoder
+            .by_ref()
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| Error::CorruptedData(format!("Failed to decode branch proof: {}", e)))?;
+        if decoder.remaining_bytes() > 0 {
+            return Err(Error::CorruptedData(format!(
+                "Branch proof has {} unconsumed trailing bytes",
+                decoder.remaining_bytes()
+            )));
+        }
 
         // Execute the proof to build the tree structure and get its root hash
         // Use collapse=false to preserve the full tree structure for element extraction

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -469,9 +469,9 @@ pub(crate) mod utils {
     /// - `Ok(Vec<Op>)`: A vector of decoded `Op` operations.
     /// - `Err(Error)`: An error if the decoding process fails.
     pub fn decode_vec_ops(chunk: &[u8]) -> Result<Vec<Op>, Error> {
-        let decoder = Decoder::new(chunk);
+        let mut decoder = Decoder::new(chunk);
         let mut res = vec![];
-        for op in decoder {
+        for op in decoder.by_ref() {
             match op {
                 Ok(op) => res.push(op),
                 Err(e) => {
@@ -481,6 +481,12 @@ pub(crate) mod utils {
                     )));
                 }
             }
+        }
+        if decoder.remaining_bytes() > 0 {
+            return Err(Error::CorruptedData(format!(
+                "chunk has {} unconsumed trailing bytes",
+                decoder.remaining_bytes()
+            )));
         }
         Ok(res)
     }

--- a/grovedb/src/tests/chunk_branch_proof_tests.rs
+++ b/grovedb/src/tests/chunk_branch_proof_tests.rs
@@ -335,4 +335,95 @@ mod tests {
             overlap
         );
     }
+
+    /// Verify that branch proof verification rejects proofs with trailing bytes.
+    #[test]
+    fn test_branch_proof_rejects_trailing_bytes() {
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        let mut rng = StdRng::seed_from_u64(77777);
+
+        db.insert(
+            EMPTY_PATH,
+            b"count_sum_tree",
+            Element::empty_count_sum_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert count_sum_tree");
+
+        for i in 0u32..50 {
+            let key_num: u8 = rng.random_range(0..=10);
+            let mut key = vec![key_num];
+            key.extend_from_slice(&i.to_be_bytes());
+            db.insert(
+                &[b"count_sum_tree"],
+                &key,
+                Element::new_sum_item(rng.random_range(0..=5)),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert sum_item");
+        }
+
+        // Get a branch proof via trunk
+        let trunk_query = PathTrunkChunkQuery::new(vec![b"count_sum_tree".to_vec()], 3);
+        let trunk_proof = db
+            .prove_trunk_chunk(&trunk_query, grove_version)
+            .unwrap()
+            .expect("prove trunk");
+
+        let (_root_hash, trunk_result) =
+            GroveDb::verify_trunk_chunk_proof(&trunk_proof, &trunk_query, grove_version)
+                .expect("verify trunk");
+
+        // Pick the first leaf key to generate a branch proof
+        let (first_leaf_key, first_leaf_info) = trunk_result
+            .leaf_keys
+            .iter()
+            .next()
+            .expect("should have at least one leaf key");
+
+        use crate::query::PathBranchChunkQuery;
+
+        let branch_query = PathBranchChunkQuery::new(
+            vec![b"count_sum_tree".to_vec()],
+            first_leaf_key.clone(),
+            trunk_result.chunk_depths[1],
+        );
+
+        let mut branch_proof = db
+            .prove_branch_chunk(&branch_query, grove_version)
+            .unwrap()
+            .expect("prove branch");
+
+        // Sanity: valid proof verifies
+        GroveDb::verify_branch_chunk_proof(
+            &branch_proof,
+            &branch_query,
+            first_leaf_info.hash,
+            grove_version,
+        )
+        .expect("valid branch proof should verify");
+
+        // Append trailing garbage
+        branch_proof.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+
+        let result = GroveDb::verify_branch_chunk_proof(
+            &branch_proof,
+            &branch_query,
+            first_leaf_info.hash,
+            grove_version,
+        );
+
+        assert!(
+            result.is_err(),
+            "branch proof with trailing bytes should be rejected"
+        );
+    }
 }

--- a/grovedb/src/tests/replication_utils_tests.rs
+++ b/grovedb/src/tests/replication_utils_tests.rs
@@ -415,6 +415,19 @@ mod tests {
         }
     }
 
+    #[test]
+    fn decode_vec_ops_rejects_trailing_bytes() {
+        let ops = vec![Op::Push(Node::Hash([0x42u8; 32])), Op::Parent, Op::Child];
+        let mut encoded = encode_vec_ops(ops).expect("should encode ops");
+        // Append trailing garbage
+        encoded.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        let result = decode_vec_ops(&encoded);
+        assert!(
+            result.is_err(),
+            "chunk with trailing bytes should be rejected"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // fetch_chunk
     // -----------------------------------------------------------------------

--- a/grovedb/src/tests/trunk_proof_tests.rs
+++ b/grovedb/src/tests/trunk_proof_tests.rs
@@ -442,4 +442,84 @@ mod tests {
         );
         assert_eq!(result.max_tree_depth, 0, "empty tree should have depth 0");
     }
+
+    /// Verify that trunk proof verification rejects proofs whose target layer
+    /// merk_proof has trailing bytes appended.
+    #[test]
+    fn test_trunk_proof_rejects_trailing_bytes_in_target_layer() {
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        let mut rng = StdRng::seed_from_u64(99999);
+
+        // Insert a CountSumTree with enough items to generate a trunk proof
+        db.insert(
+            EMPTY_PATH,
+            b"cst",
+            Element::empty_count_sum_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert count_sum_tree");
+
+        for i in 0u32..50 {
+            let key_num: u8 = rng.random_range(0..=10);
+            let mut key = vec![key_num];
+            key.extend_from_slice(&i.to_be_bytes());
+            db.insert(
+                &[b"cst"],
+                &key,
+                Element::new_sum_item(rng.random_range(0..=5)),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert sum_item");
+        }
+
+        let query = PathTrunkChunkQuery::new(vec![b"cst".to_vec()], 3);
+        let proof = db
+            .prove_trunk_chunk(&query, grove_version)
+            .unwrap()
+            .expect("prove trunk chunk");
+
+        // Sanity: valid proof verifies
+        GroveDb::verify_trunk_chunk_proof(&proof, &query, grove_version)
+            .expect("valid proof should verify");
+
+        // Decode the proof, tamper the target layer's merk_proof, re-encode
+        let config = bincode::config::standard()
+            .with_big_endian()
+            .with_no_limit();
+        let (decoded_proof, _): (GroveDBProof, _) =
+            bincode::decode_from_slice(&proof, config).expect("decode proof");
+
+        let GroveDBProof::V0(mut proof_v0) = decoded_proof else {
+            panic!("expected V0 proof");
+        };
+
+        // The target layer is the lower_layers entry for key "cst"
+        let target_layer = proof_v0
+            .root_layer
+            .lower_layers
+            .get_mut(b"cst".as_slice())
+            .expect("should have cst layer");
+        target_layer
+            .merk_proof
+            .extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+
+        // Re-encode the tampered proof
+        let tampered_proof =
+            bincode::encode_to_vec(&GroveDBProof::V0(proof_v0), config).expect("re-encode");
+
+        // Verification should fail due to trailing bytes
+        let result = GroveDb::verify_trunk_chunk_proof(&tampered_proof, &query, grove_version);
+        assert!(
+            result.is_err(),
+            "trunk proof with trailing bytes in target layer should be rejected"
+        );
+    }
 }

--- a/merk/src/proofs/mod.rs
+++ b/merk/src/proofs/mod.rs
@@ -39,6 +39,11 @@ impl<'a> Decoder<'a> {
             inner: grovedb_query::proofs::Decoder::new(proof_bytes),
         }
     }
+
+    /// Returns the number of bytes not yet consumed by the decoder.
+    pub const fn remaining_bytes(&self) -> usize {
+        self.inner.remaining_bytes()
+    }
 }
 
 #[cfg(any(feature = "minimal", feature = "verify"))]

--- a/merk/src/proofs/query/merk_integration_tests.rs
+++ b/merk/src/proofs/query/merk_integration_tests.rs
@@ -4233,3 +4233,52 @@ fn test_kvvaluehash_still_used_for_tree_discriminants() {
         panic!("Unexpected: root hash changed for KVValueHash node");
     }
 }
+
+/// Verify that `execute_proof` rejects proofs with trailing bytes appended
+/// after valid operations.
+#[test]
+fn test_execute_proof_rejects_trailing_bytes() {
+    let grove_version = GroveVersion::latest();
+    let mut tree = make_3_node_tree();
+    let mut walker = RefWalker::new(&mut tree, PanicSource {});
+
+    let keys = vec![vec![3], vec![5], vec![7]];
+    let (proof, ..) = walker
+        .create_proof(
+            keys.iter()
+                .cloned()
+                .map(QueryItem::Key)
+                .collect::<Vec<_>>()
+                .as_slice(),
+            None,
+            true,
+            grove_version,
+        )
+        .unwrap()
+        .expect("failed to create proof");
+
+    let mut bytes = vec![];
+    encode_into(proof.iter(), &mut bytes);
+
+    // Sanity: valid proof verifies fine
+    let mut query = Query::new();
+    for key in &keys {
+        query.insert_key(key.clone());
+    }
+    let expected_hash = tree.hash().unwrap();
+    query
+        .verify_proof(bytes.as_slice(), None, true, expected_hash)
+        .unwrap()
+        .expect("valid proof should verify");
+
+    // Append trailing garbage bytes
+    bytes.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+
+    let result = query.execute_proof(bytes.as_slice(), None, true).unwrap();
+
+    assert!(
+        result.is_err(),
+        "proof with trailing bytes should be rejected, got: {:?}",
+        result.as_ref().unwrap()
+    );
+}

--- a/merk/src/proofs/query/verify.rs
+++ b/merk/src/proofs/query/verify.rs
@@ -16,10 +16,18 @@ use crate::{
 #[deprecated]
 #[allow(unused)]
 pub fn verify(bytes: &[u8], expected_hash: MerkHash) -> CostResult<Map, Error> {
-    let ops = Decoder::new(bytes);
+    let mut decoder = Decoder::new(bytes);
     let mut map_builder = MapBuilder::new();
 
-    execute(ops, true, |node| map_builder.insert(node)).flat_map_ok(|root| {
+    execute(decoder.by_ref(), true, |node| map_builder.insert(node)).flat_map_ok(|root| {
+        if decoder.remaining_bytes() > 0 {
+            return Err(Error::InvalidProofError(format!(
+                "Proof has {} unconsumed trailing bytes",
+                decoder.remaining_bytes()
+            )))
+            .wrap_with_cost(Default::default());
+        }
+
         root.hash().map(|hash| {
             if hash != expected_hash {
                 Err(Error::InvalidProofError(format!(
@@ -123,9 +131,9 @@ impl QueryProofVerify for Query {
         let original_limit = limit;
         let mut current_limit = limit;
 
-        let ops = Decoder::new(bytes);
+        let mut decoder = Decoder::new(bytes);
 
-        let root_wrapped = execute(ops, true, |node| {
+        let root_wrapped = execute(decoder.by_ref(), true, |node| {
             let mut execute_node = |key: &Vec<u8>,
                                     value: Option<&Vec<u8>>,
                                     value_hash: CryptoHash|
@@ -393,6 +401,14 @@ impl QueryProofVerify for Query {
         });
 
         let root = cost_return_on_error!(&mut cost, root_wrapped);
+
+        if decoder.remaining_bytes() > 0 {
+            return Err(Error::InvalidProofError(format!(
+                "Proof has {} unconsumed trailing bytes",
+                decoder.remaining_bytes()
+            )))
+            .wrap_with_cost(cost);
+        }
 
         // we have remaining query items, check absence proof against right edge of
         // tree


### PR DESCRIPTION
## Summary

- Add `remaining_bytes()` method to `Decoder` in both `grovedb-query` and `merk` crates
- Check that all proof bytes are consumed after decoding at every verification call site:
  - `merk::proofs::query::verify` — `execute_proof` and deprecated `verify`
  - `grovedb::operations::proof::verify` — trunk and branch proof verification
  - `grovedb::replication` — chunk decoding
- Previously, trailing bytes after valid proof operations were silently ignored, allowing proofs to carry arbitrary amounts of dead data with no size limit at the GroveDB layer

## Test plan

- [x] New unit tests verify `remaining_bytes()` returns 0 after full consumption and detects trailing data
- [x] All existing tests pass (1279 grovedb, 336 merk, 57 grovedb-query)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced proof validation to detect and reject proofs with unconsumed trailing bytes, strengthening data integrity checks.
  * Improved error handling for corrupted or malformed proof data.

* **Tests**
  * Added comprehensive test coverage for trailing byte validation across proof verification and decoding paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->