### PR TITLE
refactor: split InsertOnly into InsertOnlyKnownToNotExist and InsertIfNotExists

### DIFF
--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -148,7 +148,8 @@ where
 
             let op_cost = OperationCost::default();
             let op_result = match &grove_op {
-                GroveOp::InsertOnly { element }
+                GroveOp::InsertOnlyKnownToNotExist { element }
+                | GroveOp::InsertIfNotExists { element }
                 | GroveOp::InsertOrReplace { element }
                 | GroveOp::Replace { element }
                 | GroveOp::Patch { element, .. } => {

--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -149,7 +149,7 @@ where
             let op_cost = OperationCost::default();
             let op_result = match &grove_op {
                 GroveOp::InsertWithKnownToNotAlreadyExist { element }
-                | GroveOp::InsertIfNotExists { element }
+                | GroveOp::InsertIfNotExists { element, .. }
                 | GroveOp::InsertOrReplace { element }
                 | GroveOp::Replace { element }
                 | GroveOp::Patch { element, .. } => {

--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -148,7 +148,7 @@ where
 
             let op_cost = OperationCost::default();
             let op_result = match &grove_op {
-                GroveOp::InsertOnlyKnownToNotExist { element }
+                GroveOp::InsertWithKnownToNotAlreadyExist { element }
                 | GroveOp::InsertIfNotExists { element }
                 | GroveOp::InsertOrReplace { element }
                 | GroveOp::Replace { element }

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -84,7 +84,7 @@ impl GroveOp {
                     grove_version,
                 )
             }
-            GroveOp::InsertIfNotExists { element } => {
+            GroveOp::InsertIfNotExists { element, .. } => {
                 // Same insert cost as InsertWithKnownToNotAlreadyExist, plus an
                 // additional seek to check whether the key already exists.
                 let estimated_element_size = match element.serialized_size(grove_version) {

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -73,7 +73,7 @@ impl GroveOp {
                 grove_version,
             ),
             GroveOp::InsertOrReplace { element }
-            | GroveOp::InsertOnlyKnownToNotExist { element } => {
+            | GroveOp::InsertWithKnownToNotAlreadyExist { element } => {
                 GroveDb::average_case_merk_insert_element(
                     key,
                     element,
@@ -83,7 +83,7 @@ impl GroveOp {
                 )
             }
             GroveOp::InsertIfNotExists { element } => {
-                // Same insert cost as InsertOnlyKnownToNotExist, plus an
+                // Same insert cost as InsertWithKnownToNotAlreadyExist, plus an
                 // additional seek to check whether the key already exists.
                 use grovedb_storage::worst_case_costs::WorstKeyLength;
                 GroveDb::average_case_merk_insert_element(

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -17,6 +17,8 @@ use grovedb_merk::estimated_costs::average_case_costs::{
 use grovedb_merk::{tree::AggregateData, tree_type::TreeType, RootHashKeyAndAggregateData};
 #[cfg(feature = "minimal")]
 use grovedb_storage::rocksdb_storage::RocksDbStorage;
+#[cfg(feature = "minimal")]
+use grovedb_storage::worst_case_costs::WorstKeyLength;
 use grovedb_version::version::GroveVersion;
 #[cfg(feature = "minimal")]
 use itertools::Itertools;
@@ -85,7 +87,6 @@ impl GroveOp {
             GroveOp::InsertIfNotExists { element } => {
                 // Same insert cost as InsertWithKnownToNotAlreadyExist, plus an
                 // additional seek to check whether the key already exists.
-                use grovedb_storage::worst_case_costs::WorstKeyLength;
                 GroveDb::average_case_merk_insert_element(
                     key,
                     element,

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -12,7 +12,7 @@ use grovedb_costs::{
 };
 #[cfg(feature = "minimal")]
 use grovedb_merk::estimated_costs::average_case_costs::{
-    average_case_merk_propagate, EstimatedLayerInformation,
+    add_average_case_merk_has_value, average_case_merk_propagate, EstimatedLayerInformation,
 };
 use grovedb_merk::{tree::AggregateData, tree_type::TreeType, RootHashKeyAndAggregateData};
 #[cfg(feature = "minimal")]
@@ -87,6 +87,21 @@ impl GroveOp {
             GroveOp::InsertIfNotExists { element } => {
                 // Same insert cost as InsertWithKnownToNotAlreadyExist, plus an
                 // additional seek to check whether the key already exists.
+                let estimated_element_size = match element.serialized_size(grove_version) {
+                    Ok(size) => size as u32,
+                    Err(e) => {
+                        return Err(Error::InternalError(format!(
+                            "unable to estimate element size: {e}"
+                        )))
+                        .wrap_with_cost(OperationCost::default())
+                    }
+                };
+                let mut has_cost = OperationCost::default();
+                add_average_case_merk_has_value(
+                    &mut has_cost,
+                    key.max_length() as u32,
+                    estimated_element_size,
+                );
                 GroveDb::average_case_merk_insert_element(
                     key,
                     element,
@@ -94,11 +109,7 @@ impl GroveOp {
                     propagate_if_input(),
                     grove_version,
                 )
-                .add_cost(OperationCost {
-                    seek_count: 1,
-                    storage_loaded_bytes: key.max_length() as u64,
-                    ..Default::default()
-                })
+                .add_cost(has_cost)
             }
             GroveOp::RefreshReference {
                 reference_path_type,

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -72,7 +72,8 @@ impl GroveOp {
                 propagate_if_input(),
                 grove_version,
             ),
-            GroveOp::InsertOrReplace { element } | GroveOp::InsertOnly { element } => {
+            GroveOp::InsertOrReplace { element }
+            | GroveOp::InsertOnlyKnownToNotExist { element } => {
                 GroveDb::average_case_merk_insert_element(
                     key,
                     element,
@@ -80,6 +81,23 @@ impl GroveOp {
                     propagate_if_input(),
                     grove_version,
                 )
+            }
+            GroveOp::InsertIfNotExists { element } => {
+                // Same insert cost as InsertOnlyKnownToNotExist, plus an
+                // additional seek to check whether the key already exists.
+                use grovedb_storage::worst_case_costs::WorstKeyLength;
+                GroveDb::average_case_merk_insert_element(
+                    key,
+                    element,
+                    in_tree_type,
+                    propagate_if_input(),
+                    grove_version,
+                )
+                .add_cost(OperationCost {
+                    seek_count: 1,
+                    storage_loaded_bytes: key.max_length() as u64,
+                    ..Default::default()
+                })
             }
             GroveOp::RefreshReference {
                 reference_path_type,

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -12,7 +12,7 @@ use grovedb_costs::{
 };
 #[cfg(feature = "minimal")]
 use grovedb_merk::estimated_costs::worst_case_costs::{
-    worst_case_merk_propagate, WorstCaseLayerInformation,
+    add_worst_case_merk_has_value, worst_case_merk_propagate, WorstCaseLayerInformation,
 };
 use grovedb_merk::{tree::AggregateData, tree_type::TreeType, RootHashKeyAndAggregateData};
 #[cfg(feature = "minimal")]
@@ -85,6 +85,21 @@ impl GroveOp {
             GroveOp::InsertIfNotExists { element } => {
                 // Same insert cost as InsertWithKnownToNotAlreadyExist, plus an
                 // additional seek to check whether the key already exists.
+                let max_element_size = match element.serialized_size(grove_version) {
+                    Ok(size) => size as u32,
+                    Err(e) => {
+                        return Err(Error::InternalError(format!(
+                            "unable to estimate element size: {e}"
+                        )))
+                        .wrap_with_cost(OperationCost::default())
+                    }
+                };
+                let mut has_cost = OperationCost::default();
+                add_worst_case_merk_has_value(
+                    &mut has_cost,
+                    key.max_length() as u32,
+                    max_element_size,
+                );
                 GroveDb::worst_case_merk_insert_element(
                     key,
                     element,
@@ -92,11 +107,7 @@ impl GroveOp {
                     propagate_if_input(),
                     grove_version,
                 )
-                .add_cost(OperationCost {
-                    seek_count: 1,
-                    storage_loaded_bytes: key.max_length() as u64,
-                    ..Default::default()
-                })
+                .add_cost(has_cost)
             }
             GroveOp::RefreshReference {
                 reference_path_type,

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -17,6 +17,8 @@ use grovedb_merk::estimated_costs::worst_case_costs::{
 use grovedb_merk::{tree::AggregateData, tree_type::TreeType, RootHashKeyAndAggregateData};
 #[cfg(feature = "minimal")]
 use grovedb_storage::rocksdb_storage::RocksDbStorage;
+#[cfg(feature = "minimal")]
+use grovedb_storage::worst_case_costs::WorstKeyLength;
 use grovedb_version::version::GroveVersion;
 #[cfg(feature = "minimal")]
 use itertools::Itertools;
@@ -83,7 +85,6 @@ impl GroveOp {
             GroveOp::InsertIfNotExists { element } => {
                 // Same insert cost as InsertWithKnownToNotAlreadyExist, plus an
                 // additional seek to check whether the key already exists.
-                use grovedb_storage::worst_case_costs::WorstKeyLength;
                 GroveDb::worst_case_merk_insert_element(
                     key,
                     element,

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -71,7 +71,7 @@ impl GroveOp {
                 grove_version,
             ),
             GroveOp::InsertOrReplace { element }
-            | GroveOp::InsertOnlyKnownToNotExist { element } => {
+            | GroveOp::InsertWithKnownToNotAlreadyExist { element } => {
                 GroveDb::worst_case_merk_insert_element(
                     key,
                     element,
@@ -81,7 +81,7 @@ impl GroveOp {
                 )
             }
             GroveOp::InsertIfNotExists { element } => {
-                // Same insert cost as InsertOnlyKnownToNotExist, plus an
+                // Same insert cost as InsertWithKnownToNotAlreadyExist, plus an
                 // additional seek to check whether the key already exists.
                 use grovedb_storage::worst_case_costs::WorstKeyLength;
                 GroveDb::worst_case_merk_insert_element(

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -70,7 +70,8 @@ impl GroveOp {
                 propagate_if_input(),
                 grove_version,
             ),
-            GroveOp::InsertOrReplace { element } | GroveOp::InsertOnly { element } => {
+            GroveOp::InsertOrReplace { element }
+            | GroveOp::InsertOnlyKnownToNotExist { element } => {
                 GroveDb::worst_case_merk_insert_element(
                     key,
                     element,
@@ -78,6 +79,23 @@ impl GroveOp {
                     propagate_if_input(),
                     grove_version,
                 )
+            }
+            GroveOp::InsertIfNotExists { element } => {
+                // Same insert cost as InsertOnlyKnownToNotExist, plus an
+                // additional seek to check whether the key already exists.
+                use grovedb_storage::worst_case_costs::WorstKeyLength;
+                GroveDb::worst_case_merk_insert_element(
+                    key,
+                    element,
+                    in_parent_tree_type,
+                    propagate_if_input(),
+                    grove_version,
+                )
+                .add_cost(OperationCost {
+                    seek_count: 1,
+                    storage_loaded_bytes: key.max_length() as u64,
+                    ..Default::default()
+                })
             }
             GroveOp::RefreshReference {
                 reference_path_type,

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -13,6 +13,7 @@ use grovedb_costs::{
 #[cfg(feature = "minimal")]
 use grovedb_merk::estimated_costs::worst_case_costs::{
     add_worst_case_merk_has_value, worst_case_merk_propagate, WorstCaseLayerInformation,
+    MERK_BIGGEST_VALUE_SIZE,
 };
 use grovedb_merk::{tree::AggregateData, tree_type::TreeType, RootHashKeyAndAggregateData};
 #[cfg(feature = "minimal")]
@@ -85,20 +86,14 @@ impl GroveOp {
             GroveOp::InsertIfNotExists { element, .. } => {
                 // Same insert cost as InsertWithKnownToNotAlreadyExist, plus an
                 // additional seek to check whether the key already exists.
-                let max_element_size = match element.serialized_size(grove_version) {
-                    Ok(size) => size as u32,
-                    Err(e) => {
-                        return Err(Error::InternalError(format!(
-                            "unable to estimate element size: {e}"
-                        )))
-                        .wrap_with_cost(OperationCost::default())
-                    }
-                };
+                // Use MERK_BIGGEST_VALUE_SIZE for the existing value size since
+                // the value already stored could be larger than the element
+                // being inserted.
                 let mut has_cost = OperationCost::default();
                 add_worst_case_merk_has_value(
                     &mut has_cost,
                     key.max_length() as u32,
-                    max_element_size,
+                    MERK_BIGGEST_VALUE_SIZE,
                 );
                 GroveDb::worst_case_merk_insert_element(
                     key,

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -82,7 +82,7 @@ impl GroveOp {
                     grove_version,
                 )
             }
-            GroveOp::InsertIfNotExists { element } => {
+            GroveOp::InsertIfNotExists { element, .. } => {
                 // Same insert cost as InsertWithKnownToNotAlreadyExist, plus an
                 // additional seek to check whether the key already exists.
                 let max_element_size = match element.serialized_size(grove_version) {

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -167,7 +167,7 @@ impl NonMerkTreeMeta {
 
 /// Operations for batch processing.
 ///
-/// User-facing variants: `InsertOnlyKnownToNotExist`, `InsertIfNotExists`,
+/// User-facing variants: `InsertWithKnownToNotAlreadyExist`, `InsertIfNotExists`,
 /// `InsertOrReplace`, `Replace`, `Patch`, `RefreshReference`, `Delete`,
 /// `DeleteTree`, `CommitmentTreeInsert`, `MmrTreeAppend`, `BulkAppend`,
 /// `DenseTreeInsert`.
@@ -199,7 +199,7 @@ pub enum GroveOp {
     /// Inserts an element that the caller knows does not yet exist.
     /// This is a performance optimization hint — no existence check is
     /// performed. The caller asserts the key is new.
-    InsertOnlyKnownToNotExist {
+    InsertWithKnownToNotAlreadyExist {
         /// Element
         element: Element,
     },
@@ -230,7 +230,7 @@ pub enum GroveOp {
     /// **Internal only — do not construct directly.**
     /// Insert tree with root hash for standard Merk trees.
     ///
-    /// Created during batch propagation from an `InsertOrReplace`/`InsertOnlyKnownToNotExist`/`InsertIfNotExists`
+    /// Created during batch propagation from an `InsertOrReplace`/`InsertWithKnownToNotAlreadyExist`/`InsertIfNotExists`
     /// occupied entry when a child subtree's root hash is propagated upward.
     /// For non-Merk trees, see `InsertNonMerkTree`.
     ///
@@ -340,7 +340,7 @@ impl GroveOp {
             GroveOp::Replace { .. } => 6,
             GroveOp::Patch { .. } => 7,
             GroveOp::InsertOrReplace { .. } => 8,
-            GroveOp::InsertOnlyKnownToNotExist { .. } => 9,
+            GroveOp::InsertWithKnownToNotAlreadyExist { .. } => 9,
             GroveOp::InsertIfNotExists { .. } => 10,
             GroveOp::CommitmentTreeInsert { .. } => 11,
             GroveOp::MmrTreeAppend { .. } => 12,
@@ -569,7 +569,7 @@ impl fmt::Debug for QualifiedGroveDbOp {
 
         let op_dbg = match &self.op {
             GroveOp::InsertOrReplace { element } => format!("Insert Or Replace {:?}", element),
-            GroveOp::InsertOnlyKnownToNotExist { element } => {
+            GroveOp::InsertWithKnownToNotAlreadyExist { element } => {
                 format!("Insert Only Known To Not Exist {:?}", element)
             }
             GroveOp::InsertIfNotExists { element } => {
@@ -622,13 +622,25 @@ impl QualifiedGroveDbOp {
     /// An insert op using a known owned path and known key.
     /// The caller asserts the key is new — no existence check is performed.
     /// This is a performance optimization hint.
-    pub fn insert_only_op(path: Vec<Vec<u8>>, key: Vec<u8>, element: Element) -> Self {
+    pub fn insert_only_known_to_not_already_exist_op(
+        path: Vec<Vec<u8>>,
+        key: Vec<u8>,
+        element: Element,
+    ) -> Self {
         let path = KeyInfoPath::from_known_owned_path(path);
         Self {
             path,
             key: Some(KnownKey(key)),
-            op: GroveOp::InsertOnlyKnownToNotExist { element },
+            op: GroveOp::InsertWithKnownToNotAlreadyExist { element },
         }
+    }
+
+    #[deprecated(
+        note = "use insert_only_known_to_not_already_exist_op or insert_if_not_exists_op instead"
+    )]
+    /// Deprecated: use `insert_only_known_to_not_already_exist_op` instead.
+    pub fn insert_only_op(path: Vec<Vec<u8>>, key: Vec<u8>, element: Element) -> Self {
+        Self::insert_only_known_to_not_already_exist_op(path, key, element)
     }
 
     /// An insert op that checks if the key already exists and rejects
@@ -948,7 +960,7 @@ impl QualifiedGroveDbOp {
         let mut conflicts: HashMap<KeyInfoPath, Vec<usize>> = HashMap::new();
         for (idx, op) in ops.iter().enumerate() {
             match op.op {
-                GroveOp::InsertOnlyKnownToNotExist { .. }
+                GroveOp::InsertWithKnownToNotAlreadyExist { .. }
                 | GroveOp::InsertIfNotExists { .. }
                 | GroveOp::InsertOrReplace { .. }
                 | GroveOp::Replace { .. }
@@ -1540,7 +1552,7 @@ where
                         }
                     }
                 }
-                GroveOp::InsertOnlyKnownToNotExist { element }
+                GroveOp::InsertWithKnownToNotAlreadyExist { element }
                 | GroveOp::InsertIfNotExists { element } => match element {
                     Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
                         let serialized = cost_return_on_error_into_no_add!(
@@ -1706,7 +1718,7 @@ where
         let mut batch_operations: Vec<(Vec<u8>, Op)> = vec![];
         for (key_info, op) in ops_at_path_by_key.into_iter() {
             match op {
-                op_ref @ (GroveOp::InsertOnlyKnownToNotExist { .. }
+                op_ref @ (GroveOp::InsertWithKnownToNotAlreadyExist { .. }
                 | GroveOp::InsertIfNotExists { .. }
                 | GroveOp::InsertOrReplace { .. }
                 | GroveOp::Replace { .. }
@@ -1714,7 +1726,7 @@ where
                     let is_insert_if_not_exists =
                         matches!(op_ref, GroveOp::InsertIfNotExists { .. });
                     let element = match op_ref {
-                        GroveOp::InsertOnlyKnownToNotExist { element }
+                        GroveOp::InsertWithKnownToNotAlreadyExist { element }
                         | GroveOp::InsertIfNotExists { element }
                         | GroveOp::InsertOrReplace { element }
                         | GroveOp::Replace { element }
@@ -2444,7 +2456,9 @@ impl GroveDb {
                                                     .wrap_with_cost(cost);
                                                 }
                                                 GroveOp::InsertOrReplace { element }
-                                                | GroveOp::InsertOnlyKnownToNotExist { element }
+                                                | GroveOp::InsertWithKnownToNotAlreadyExist {
+                                                    element,
+                                                }
                                                 | GroveOp::InsertIfNotExists { element }
                                                 | GroveOp::Replace { element }
                                                 | GroveOp::Patch { element, .. } => {
@@ -2822,7 +2836,7 @@ impl GroveDb {
                         )
                     );
                 }
-                GroveOp::InsertOnlyKnownToNotExist { element } => {
+                GroveOp::InsertWithKnownToNotAlreadyExist { element } => {
                     let path_slices: Vec<&[u8]> =
                         op.path.iterator().map(|p| p.as_slice()).collect();
                     let key = cost_return_on_error_no_add!(

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -570,7 +570,7 @@ impl fmt::Debug for QualifiedGroveDbOp {
         let op_dbg = match &self.op {
             GroveOp::InsertOrReplace { element } => format!("Insert Or Replace {:?}", element),
             GroveOp::InsertWithKnownToNotAlreadyExist { element } => {
-                format!("Insert Only Known To Not Exist {:?}", element)
+                format!("Insert With Known To Not Already Exist {:?}", element)
             }
             GroveOp::InsertIfNotExists { element } => {
                 format!("Insert If Not Exists {:?}", element)

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -167,9 +167,10 @@ impl NonMerkTreeMeta {
 
 /// Operations for batch processing.
 ///
-/// User-facing variants: `InsertOnly`, `InsertOrReplace`, `Replace`, `Patch`,
-/// `RefreshReference`, `Delete`, `DeleteTree`, `CommitmentTreeInsert`,
-/// `MmrTreeAppend`, `BulkAppend`, `DenseTreeInsert`.
+/// User-facing variants: `InsertOnlyKnownToNotExist`, `InsertIfNotExists`,
+/// `InsertOrReplace`, `Replace`, `Patch`, `RefreshReference`, `Delete`,
+/// `DeleteTree`, `CommitmentTreeInsert`, `MmrTreeAppend`, `BulkAppend`,
+/// `DenseTreeInsert`.
 ///
 /// Internal variants (`ReplaceTreeRootKey`, `InsertTreeWithRootHash`,
 /// `ReplaceNonMerkTreeRoot`, `InsertNonMerkTree`) are marked
@@ -195,8 +196,17 @@ pub enum GroveOp {
         /// Aggregate data
         aggregate_data: AggregateData,
     },
-    /// Inserts an element that is known to not yet exist
-    InsertOnly {
+    /// Inserts an element that the caller knows does not yet exist.
+    /// This is a performance optimization hint — no existence check is
+    /// performed. The caller asserts the key is new.
+    InsertOnlyKnownToNotExist {
+        /// Element
+        element: Element,
+    },
+    /// Inserts an element only if the key does not already exist.
+    /// An existence check is performed; if the key is found the operation
+    /// is rejected with an error.
+    InsertIfNotExists {
         /// Element
         element: Element,
     },
@@ -220,7 +230,7 @@ pub enum GroveOp {
     /// **Internal only — do not construct directly.**
     /// Insert tree with root hash for standard Merk trees.
     ///
-    /// Created during batch propagation from an `InsertOrReplace`/`InsertOnly`
+    /// Created during batch propagation from an `InsertOrReplace`/`InsertOnlyKnownToNotExist`/`InsertIfNotExists`
     /// occupied entry when a child subtree's root hash is propagated upward.
     /// For non-Merk trees, see `InsertNonMerkTree`.
     ///
@@ -330,13 +340,14 @@ impl GroveOp {
             GroveOp::Replace { .. } => 6,
             GroveOp::Patch { .. } => 7,
             GroveOp::InsertOrReplace { .. } => 8,
-            GroveOp::InsertOnly { .. } => 9,
-            GroveOp::CommitmentTreeInsert { .. } => 10,
-            GroveOp::MmrTreeAppend { .. } => 11,
-            GroveOp::BulkAppend { .. } => 12,
-            GroveOp::DenseTreeInsert { .. } => 13,
-            GroveOp::ReplaceNonMerkTreeRoot { .. } => 14,
-            GroveOp::InsertNonMerkTree { .. } => 15,
+            GroveOp::InsertOnlyKnownToNotExist { .. } => 9,
+            GroveOp::InsertIfNotExists { .. } => 10,
+            GroveOp::CommitmentTreeInsert { .. } => 11,
+            GroveOp::MmrTreeAppend { .. } => 12,
+            GroveOp::BulkAppend { .. } => 13,
+            GroveOp::DenseTreeInsert { .. } => 14,
+            GroveOp::ReplaceNonMerkTreeRoot { .. } => 15,
+            GroveOp::InsertNonMerkTree { .. } => 16,
         }
     }
 }
@@ -558,7 +569,12 @@ impl fmt::Debug for QualifiedGroveDbOp {
 
         let op_dbg = match &self.op {
             GroveOp::InsertOrReplace { element } => format!("Insert Or Replace {:?}", element),
-            GroveOp::InsertOnly { element } => format!("Insert {:?}", element),
+            GroveOp::InsertOnlyKnownToNotExist { element } => {
+                format!("Insert Only Known To Not Exist {:?}", element)
+            }
+            GroveOp::InsertIfNotExists { element } => {
+                format!("Insert If Not Exists {:?}", element)
+            }
             GroveOp::Replace { element } => format!("Replace {:?}", element),
             GroveOp::Patch { element, .. } => format!("Patch {:?}", element),
             GroveOp::RefreshReference {
@@ -603,13 +619,26 @@ impl fmt::Debug for QualifiedGroveDbOp {
 }
 
 impl QualifiedGroveDbOp {
-    /// An insert op using a known owned path and known key
+    /// An insert op using a known owned path and known key.
+    /// The caller asserts the key is new — no existence check is performed.
+    /// This is a performance optimization hint.
     pub fn insert_only_op(path: Vec<Vec<u8>>, key: Vec<u8>, element: Element) -> Self {
         let path = KeyInfoPath::from_known_owned_path(path);
         Self {
             path,
             key: Some(KnownKey(key)),
-            op: GroveOp::InsertOnly { element },
+            op: GroveOp::InsertOnlyKnownToNotExist { element },
+        }
+    }
+
+    /// An insert op that checks if the key already exists and rejects
+    /// the operation if it does, enforcing uniqueness.
+    pub fn insert_if_not_exists_op(path: Vec<Vec<u8>>, key: Vec<u8>, element: Element) -> Self {
+        let path = KeyInfoPath::from_known_owned_path(path);
+        Self {
+            path,
+            key: Some(KnownKey(key)),
+            op: GroveOp::InsertIfNotExists { element },
         }
     }
 
@@ -919,7 +948,8 @@ impl QualifiedGroveDbOp {
         let mut conflicts: HashMap<KeyInfoPath, Vec<usize>> = HashMap::new();
         for (idx, op) in ops.iter().enumerate() {
             match op.op {
-                GroveOp::InsertOnly { .. }
+                GroveOp::InsertOnlyKnownToNotExist { .. }
+                | GroveOp::InsertIfNotExists { .. }
                 | GroveOp::InsertOrReplace { .. }
                 | GroveOp::Replace { .. }
                 | GroveOp::Patch { .. } => {}
@@ -1510,7 +1540,8 @@ where
                         }
                     }
                 }
-                GroveOp::InsertOnly { element } => match element {
+                GroveOp::InsertOnlyKnownToNotExist { element }
+                | GroveOp::InsertIfNotExists { element } => match element {
                     Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
                         let serialized = cost_return_on_error_into_no_add!(
                             cost,
@@ -1675,10 +1706,22 @@ where
         let mut batch_operations: Vec<(Vec<u8>, Op)> = vec![];
         for (key_info, op) in ops_at_path_by_key.into_iter() {
             match op {
-                GroveOp::InsertOnly { element }
-                | GroveOp::InsertOrReplace { element }
-                | GroveOp::Replace { element }
-                | GroveOp::Patch { element, .. } => {
+                op_ref @ (GroveOp::InsertOnlyKnownToNotExist { .. }
+                | GroveOp::InsertIfNotExists { .. }
+                | GroveOp::InsertOrReplace { .. }
+                | GroveOp::Replace { .. }
+                | GroveOp::Patch { .. }) => {
+                    let is_insert_if_not_exists =
+                        matches!(op_ref, GroveOp::InsertIfNotExists { .. });
+                    let element = match op_ref {
+                        GroveOp::InsertOnlyKnownToNotExist { element }
+                        | GroveOp::InsertIfNotExists { element }
+                        | GroveOp::InsertOrReplace { element }
+                        | GroveOp::Replace { element }
+                        | GroveOp::Patch { element, .. } => element,
+                        _ => unreachable!(),
+                    };
+
                     // Check tree-override protection for all non-reference elements.
                     if batch_apply_options.validate_insertion_does_not_override_tree
                         && !matches!(&element, Element::Reference(..))
@@ -1819,7 +1862,9 @@ where
                                     .get_feature_type(in_tree_type)
                                     .wrap_with_cost(OperationCost::default())
                             );
-                            if batch_apply_options.validate_insertion_does_not_override {
+                            if is_insert_if_not_exists
+                                || batch_apply_options.validate_insertion_does_not_override
+                            {
                                 let merk = self.merks.get_mut(path).expect("the Merk is cached");
 
                                 let inserted = cost_return_on_error_into!(
@@ -1834,7 +1879,7 @@ where
                                 );
                                 if !inserted {
                                     return Err(Error::InvalidBatchOperation(
-                                        "attempting to overwrite an element",
+                                        "attempting to insert element that already exists",
                                     ))
                                     .wrap_with_cost(cost);
                                 }
@@ -2399,7 +2444,8 @@ impl GroveDb {
                                                     .wrap_with_cost(cost);
                                                 }
                                                 GroveOp::InsertOrReplace { element }
-                                                | GroveOp::InsertOnly { element }
+                                                | GroveOp::InsertOnlyKnownToNotExist { element }
+                                                | GroveOp::InsertIfNotExists { element }
                                                 | GroveOp::Replace { element }
                                                 | GroveOp::Patch { element, .. } => {
                                                     // Standard Merk trees
@@ -2776,13 +2822,34 @@ impl GroveDb {
                         )
                     );
                 }
-                GroveOp::InsertOnly { element } => {
+                GroveOp::InsertOnlyKnownToNotExist { element } => {
                     let path_slices: Vec<&[u8]> =
                         op.path.iterator().map(|p| p.as_slice()).collect();
                     let key = cost_return_on_error_no_add!(
                         cost,
                         op.key.as_ref().ok_or(Error::InvalidBatchOperation(
-                            "insert_only op is missing a key",
+                            "insert_only_known_to_not_exist op is missing a key",
+                        ))
+                    );
+                    cost_return_on_error!(
+                        &mut cost,
+                        self.insert(
+                            path_slices.as_slice(),
+                            key.as_slice(),
+                            element.to_owned(),
+                            options.clone().map(|o| o.as_insert_options()),
+                            transaction,
+                            grove_version,
+                        )
+                    );
+                }
+                GroveOp::InsertIfNotExists { element } => {
+                    let path_slices: Vec<&[u8]> =
+                        op.path.iterator().map(|p| p.as_slice()).collect();
+                    let key = cost_return_on_error_no_add!(
+                        cost,
+                        op.key.as_ref().ok_or(Error::InvalidBatchOperation(
+                            "insert_if_not_exists op is missing a key",
                         ))
                     );
                     let mut insert_options = options

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -2882,7 +2882,7 @@ impl GroveDb {
                     let key = cost_return_on_error_no_add!(
                         cost,
                         op.key.as_ref().ok_or(Error::InvalidBatchOperation(
-                            "insert_only_known_to_not_exist op is missing a key",
+                            "insert_only_known_to_not_already_exist op is missing a key",
                         ))
                     );
                     cost_return_on_error!(

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -204,11 +204,16 @@ pub enum GroveOp {
         element: Element,
     },
     /// Inserts an element only if the key does not already exist.
-    /// An existence check is performed; if the key is found the operation
-    /// is rejected with an error.
+    /// An existence check is performed; if the key is found the behaviour
+    /// depends on `error_if_exists`:
+    /// - `true`: the operation is rejected with an error (default).
+    /// - `false`: the insert is silently skipped.
     InsertIfNotExists {
         /// Element
         element: Element,
+        /// If true, return an error when the key already exists.
+        /// If false, silently skip the insert.
+        error_if_exists: bool,
     },
     /// Inserts or Replaces an element
     InsertOrReplace {
@@ -572,8 +577,15 @@ impl fmt::Debug for QualifiedGroveDbOp {
             GroveOp::InsertWithKnownToNotAlreadyExist { element } => {
                 format!("Insert With Known To Not Already Exist {:?}", element)
             }
-            GroveOp::InsertIfNotExists { element } => {
-                format!("Insert If Not Exists {:?}", element)
+            GroveOp::InsertIfNotExists {
+                element,
+                error_if_exists,
+            } => {
+                if *error_if_exists {
+                    format!("Insert If Not Exists (error on existing) {:?}", element)
+                } else {
+                    format!("Insert If Not Exists (skip on existing) {:?}", element)
+                }
             }
             GroveOp::Replace { element } => format!("Replace {:?}", element),
             GroveOp::Patch { element, .. } => format!("Patch {:?}", element),
@@ -650,7 +662,28 @@ impl QualifiedGroveDbOp {
         Self {
             path,
             key: Some(KnownKey(key)),
-            op: GroveOp::InsertIfNotExists { element },
+            op: GroveOp::InsertIfNotExists {
+                element,
+                error_if_exists: true,
+            },
+        }
+    }
+
+    /// An insert op that checks if the key already exists and silently
+    /// skips the insert when it does (no error).
+    pub fn insert_if_not_exists_or_skip_op(
+        path: Vec<Vec<u8>>,
+        key: Vec<u8>,
+        element: Element,
+    ) -> Self {
+        let path = KeyInfoPath::from_known_owned_path(path);
+        Self {
+            path,
+            key: Some(KnownKey(key)),
+            op: GroveOp::InsertIfNotExists {
+                element,
+                error_if_exists: false,
+            },
         }
     }
 
@@ -1553,7 +1586,7 @@ where
                     }
                 }
                 GroveOp::InsertWithKnownToNotAlreadyExist { element }
-                | GroveOp::InsertIfNotExists { element } => match element {
+                | GroveOp::InsertIfNotExists { element, .. } => match element {
                     Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
                         let serialized = cost_return_on_error_into_no_add!(
                             cost,
@@ -1723,11 +1756,15 @@ where
                 | GroveOp::InsertOrReplace { .. }
                 | GroveOp::Replace { .. }
                 | GroveOp::Patch { .. }) => {
-                    let is_insert_if_not_exists =
-                        matches!(op_ref, GroveOp::InsertIfNotExists { .. });
+                    let (is_insert_if_not_exists, error_if_exists) = match &op_ref {
+                        GroveOp::InsertIfNotExists {
+                            error_if_exists, ..
+                        } => (true, *error_if_exists),
+                        _ => (false, false),
+                    };
                     let element = match op_ref {
                         GroveOp::InsertWithKnownToNotAlreadyExist { element }
-                        | GroveOp::InsertIfNotExists { element }
+                        | GroveOp::InsertIfNotExists { element, .. }
                         | GroveOp::InsertOrReplace { element }
                         | GroveOp::Replace { element }
                         | GroveOp::Patch { element, .. } => element,
@@ -1889,7 +1926,10 @@ where
                                         grove_version,
                                     )
                                 );
-                                if !inserted {
+                                if !inserted
+                                    && (error_if_exists
+                                        || batch_apply_options.validate_insertion_does_not_override)
+                                {
                                     return Err(Error::InvalidBatchOperation(
                                         "attempting to insert element that already exists",
                                     ))
@@ -2459,7 +2499,7 @@ impl GroveDb {
                                                 | GroveOp::InsertWithKnownToNotAlreadyExist {
                                                     element,
                                                 }
-                                                | GroveOp::InsertIfNotExists { element }
+                                                | GroveOp::InsertIfNotExists { element, .. }
                                                 | GroveOp::Replace { element }
                                                 | GroveOp::Patch { element, .. } => {
                                                     // Standard Merk trees
@@ -2857,7 +2897,10 @@ impl GroveDb {
                         )
                     );
                 }
-                GroveOp::InsertIfNotExists { element } => {
+                GroveOp::InsertIfNotExists {
+                    element,
+                    error_if_exists,
+                } => {
                     let path_slices: Vec<&[u8]> =
                         op.path.iterator().map(|p| p.as_slice()).collect();
                     let key = cost_return_on_error_no_add!(
@@ -2866,22 +2909,35 @@ impl GroveDb {
                             "insert_if_not_exists op is missing a key",
                         ))
                     );
-                    let mut insert_options = options
-                        .clone()
-                        .map(|o| o.as_insert_options())
-                        .unwrap_or_default();
-                    insert_options.validate_insertion_does_not_override = true;
-                    cost_return_on_error!(
-                        &mut cost,
-                        self.insert(
-                            path_slices.as_slice(),
-                            key.as_slice(),
-                            element.to_owned(),
-                            Some(insert_options),
-                            transaction,
-                            grove_version,
-                        )
-                    );
+                    if error_if_exists {
+                        let mut insert_options = options
+                            .clone()
+                            .map(|o| o.as_insert_options())
+                            .unwrap_or_default();
+                        insert_options.validate_insertion_does_not_override = true;
+                        cost_return_on_error!(
+                            &mut cost,
+                            self.insert(
+                                path_slices.as_slice(),
+                                key.as_slice(),
+                                element.to_owned(),
+                                Some(insert_options),
+                                transaction,
+                                grove_version,
+                            )
+                        );
+                    } else {
+                        cost_return_on_error!(
+                            &mut cost,
+                            self.insert_if_not_exists(
+                                path_slices.as_slice(),
+                                key.as_slice(),
+                                element.to_owned(),
+                                transaction,
+                                grove_version,
+                            )
+                        );
+                    }
                 }
                 GroveOp::Delete | GroveOp::DeleteTree(_) => {
                     let path_slices: Vec<&[u8]> =

--- a/grovedb/src/tests/batch_coverage_tests.rs
+++ b/grovedb/src/tests/batch_coverage_tests.rs
@@ -365,11 +365,11 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_operations_without_batching_insert_only() {
+    fn test_apply_operations_without_batching_insert_only_known_to_not_exist() {
         let grove_version = GroveVersion::latest();
         let db = make_test_grovedb(grove_version);
 
-        // InsertOnly should succeed when key does not exist
+        // InsertOnlyKnownToNotExist should succeed when key does not exist
         let ops = vec![QualifiedGroveDbOp::insert_only_op(
             vec![TEST_LEAF.to_vec()],
             b"insert_only_key".to_vec(),
@@ -390,9 +390,37 @@ mod tests {
             .unwrap()
             .expect("element should exist");
         assert_eq!(result, Element::new_item(b"val".to_vec()));
+    }
 
-        // InsertOnly should fail when key already exists
-        let ops = vec![QualifiedGroveDbOp::insert_only_op(
+    #[test]
+    fn test_apply_operations_without_batching_insert_if_not_exists() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // InsertIfNotExists should succeed when key does not exist
+        let ops = vec![QualifiedGroveDbOp::insert_if_not_exists_op(
+            vec![TEST_LEAF.to_vec()],
+            b"insert_only_key".to_vec(),
+            Element::new_item(b"val".to_vec()),
+        )];
+
+        db.apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap()
+            .expect("insert_if_not_exists should succeed for new key");
+
+        let result = db
+            .get(
+                [TEST_LEAF].as_ref(),
+                b"insert_only_key",
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("element should exist");
+        assert_eq!(result, Element::new_item(b"val".to_vec()));
+
+        // InsertIfNotExists should fail when key already exists
+        let ops = vec![QualifiedGroveDbOp::insert_if_not_exists_op(
             vec![TEST_LEAF.to_vec()],
             b"insert_only_key".to_vec(),
             Element::new_item(b"val2".to_vec()),
@@ -403,7 +431,7 @@ mod tests {
             .unwrap();
         assert!(
             result.is_err(),
-            "insert_only should fail when key already exists"
+            "insert_if_not_exists should fail when key already exists"
         );
     }
 
@@ -867,13 +895,16 @@ mod tests {
 
     #[test]
     fn test_grove_op_ordering() {
-        // DeleteTree = 0, Delete = 2, InsertOrReplace = 8, InsertOnly = 9
+        // DeleteTree = 0, Delete = 2, InsertOrReplace = 8, InsertOnlyKnownToNotExist = 9, InsertIfNotExists = 10
         let delete_tree = GroveOp::DeleteTree(TreeType::NormalTree);
         let delete = GroveOp::Delete;
         let insert_or_replace = GroveOp::InsertOrReplace {
             element: Element::new_item(b"test".to_vec()),
         };
-        let insert_only = GroveOp::InsertOnly {
+        let insert_only = GroveOp::InsertOnlyKnownToNotExist {
+            element: Element::new_item(b"test".to_vec()),
+        };
+        let insert_if_not_exists = GroveOp::InsertIfNotExists {
             element: Element::new_item(b"test".to_vec()),
         };
 
@@ -887,7 +918,11 @@ mod tests {
         );
         assert!(
             insert_or_replace < insert_only,
-            "InsertOrReplace (8) should be less than InsertOnly (9)"
+            "InsertOrReplace (8) should be less than InsertOnlyKnownToNotExist (9)"
+        );
+        assert!(
+            insert_only < insert_if_not_exists,
+            "InsertOnlyKnownToNotExist (9) should be less than InsertIfNotExists (10)"
         );
     }
 
@@ -1480,11 +1515,11 @@ mod tests {
     }
 
     // ===================================================================
-    // 30. Batch: InsertOnly when element already exists (with validation)
+    // 30. Batch: InsertIfNotExists when element already exists
     // ===================================================================
 
     #[test]
-    fn test_batch_insert_only_existing_element_with_validation_fails() {
+    fn test_batch_insert_if_not_exists_existing_element_fails() {
         let grove_version = GroveVersion::latest();
         let db = make_test_grovedb(grove_version);
 
@@ -1500,22 +1535,17 @@ mod tests {
         .unwrap()
         .expect("insert existing item");
 
-        // Try InsertOnly on the same key with validate_insertion_does_not_override
-        let ops = vec![QualifiedGroveDbOp::insert_only_op(
+        // Try InsertIfNotExists on the same key — should fail without needing options
+        let ops = vec![QualifiedGroveDbOp::insert_if_not_exists_op(
             vec![TEST_LEAF.to_vec()],
             b"existing".to_vec(),
             Element::new_item(b"should_fail".to_vec()),
         )];
 
-        let options = Some(BatchApplyOptions {
-            validate_insertion_does_not_override: true,
-            ..Default::default()
-        });
-
-        let result = db.apply_batch(ops, options, None, grove_version).unwrap();
+        let result = db.apply_batch(ops, None, None, grove_version).unwrap();
         assert!(
             result.is_err(),
-            "InsertOnly on existing element with validation should fail"
+            "InsertIfNotExists on existing element should fail"
         );
     }
 
@@ -1677,7 +1707,7 @@ mod tests {
     }
 
     // ===================================================================
-    // 34. Batch: insert tree then items under it, using InsertOnly
+    // 34. Batch: insert tree then items under it, using InsertOnlyKnownToNotExist
     // ===================================================================
 
     #[test]
@@ -1685,8 +1715,8 @@ mod tests {
         let grove_version = GroveVersion::latest();
         let db = make_empty_grovedb();
 
-        // InsertOnly for tree and items. The tree insert triggers the
-        // occupied-entry propagation path for InsertOnly variant.
+        // InsertOnlyKnownToNotExist for tree and items. The tree insert triggers the
+        // occupied-entry propagation path for InsertOnlyKnownToNotExist variant.
         let ops = vec![
             QualifiedGroveDbOp::insert_only_op(vec![], b"new_tree".to_vec(), Element::empty_tree()),
             QualifiedGroveDbOp::insert_only_op(

--- a/grovedb/src/tests/batch_coverage_tests.rs
+++ b/grovedb/src/tests/batch_coverage_tests.rs
@@ -369,7 +369,7 @@ mod tests {
         let grove_version = GroveVersion::latest();
         let db = make_test_grovedb(grove_version);
 
-        // InsertOnlyKnownToNotExist should succeed when key does not exist
+        // InsertWithKnownToNotAlreadyExist should succeed when key does not exist
         let ops = vec![QualifiedGroveDbOp::insert_only_op(
             vec![TEST_LEAF.to_vec()],
             b"insert_only_key".to_vec(),
@@ -895,13 +895,13 @@ mod tests {
 
     #[test]
     fn test_grove_op_ordering() {
-        // DeleteTree = 0, Delete = 2, InsertOrReplace = 8, InsertOnlyKnownToNotExist = 9, InsertIfNotExists = 10
+        // DeleteTree = 0, Delete = 2, InsertOrReplace = 8, InsertWithKnownToNotAlreadyExist = 9, InsertIfNotExists = 10
         let delete_tree = GroveOp::DeleteTree(TreeType::NormalTree);
         let delete = GroveOp::Delete;
         let insert_or_replace = GroveOp::InsertOrReplace {
             element: Element::new_item(b"test".to_vec()),
         };
-        let insert_only = GroveOp::InsertOnlyKnownToNotExist {
+        let insert_only = GroveOp::InsertWithKnownToNotAlreadyExist {
             element: Element::new_item(b"test".to_vec()),
         };
         let insert_if_not_exists = GroveOp::InsertIfNotExists {
@@ -918,11 +918,11 @@ mod tests {
         );
         assert!(
             insert_or_replace < insert_only,
-            "InsertOrReplace (8) should be less than InsertOnlyKnownToNotExist (9)"
+            "InsertOrReplace (8) should be less than InsertWithKnownToNotAlreadyExist (9)"
         );
         assert!(
             insert_only < insert_if_not_exists,
-            "InsertOnlyKnownToNotExist (9) should be less than InsertIfNotExists (10)"
+            "InsertWithKnownToNotAlreadyExist (9) should be less than InsertIfNotExists (10)"
         );
     }
 
@@ -1798,7 +1798,7 @@ mod tests {
     }
 
     // ===================================================================
-    // 34. Batch: insert tree then items under it, using InsertOnlyKnownToNotExist
+    // 34. Batch: insert tree then items under it, using InsertWithKnownToNotAlreadyExist
     // ===================================================================
 
     #[test]
@@ -1806,8 +1806,8 @@ mod tests {
         let grove_version = GroveVersion::latest();
         let db = make_empty_grovedb();
 
-        // InsertOnlyKnownToNotExist for tree and items. The tree insert triggers the
-        // occupied-entry propagation path for InsertOnlyKnownToNotExist variant.
+        // InsertWithKnownToNotAlreadyExist for tree and items. The tree insert triggers the
+        // occupied-entry propagation path for InsertWithKnownToNotAlreadyExist variant.
         let ops = vec![
             QualifiedGroveDbOp::insert_only_op(vec![], b"new_tree".to_vec(), Element::empty_tree()),
             QualifiedGroveDbOp::insert_only_op(

--- a/grovedb/src/tests/batch_coverage_tests.rs
+++ b/grovedb/src/tests/batch_coverage_tests.rs
@@ -1550,6 +1550,97 @@ mod tests {
     }
 
     // ===================================================================
+    // 30b. InsertIfNotExists: tree + items in same batch (propagation path)
+    // ===================================================================
+
+    #[test]
+    fn test_batch_insert_if_not_exists_tree_then_items_same_batch() {
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        // InsertIfNotExists for tree and items. The tree insert triggers the
+        // occupied-entry propagation path for InsertIfNotExists variant.
+        let ops = vec![
+            QualifiedGroveDbOp::insert_if_not_exists_op(
+                vec![],
+                b"new_tree".to_vec(),
+                Element::empty_tree(),
+            ),
+            QualifiedGroveDbOp::insert_if_not_exists_op(
+                vec![b"new_tree".to_vec()],
+                b"item1".to_vec(),
+                Element::new_item(b"v1".to_vec()),
+            ),
+            QualifiedGroveDbOp::insert_if_not_exists_op(
+                vec![b"new_tree".to_vec()],
+                b"item2".to_vec(),
+                Element::new_item(b"v2".to_vec()),
+            ),
+        ];
+
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("insert_if_not_exists batch with tree + items should succeed");
+
+        let i1 = db
+            .get([b"new_tree"].as_ref(), b"item1", None, grove_version)
+            .unwrap()
+            .expect("item1 should exist");
+        assert_eq!(i1, Element::new_item(b"v1".to_vec()));
+    }
+
+    // ===================================================================
+    // 30c. InsertIfNotExists: Debug format
+    // ===================================================================
+
+    #[test]
+    fn test_insert_if_not_exists_debug_format() {
+        let op = QualifiedGroveDbOp::insert_if_not_exists_op(
+            vec![b"path".to_vec()],
+            b"key".to_vec(),
+            Element::new_item(b"val".to_vec()),
+        );
+        let debug_str = format!("{:?}", op);
+        assert!(
+            debug_str.contains("Insert If Not Exists"),
+            "Debug output should contain 'Insert If Not Exists', got: {debug_str}"
+        );
+    }
+
+    // ===================================================================
+    // 30d. InsertIfNotExists: reference to InsertIfNotExists item in same batch
+    // ===================================================================
+
+    #[test]
+    fn test_batch_ref_to_insert_if_not_exists_item() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        let ops = vec![
+            QualifiedGroveDbOp::insert_if_not_exists_op(
+                vec![TEST_LEAF.to_vec()],
+                b"if_ne_item".to_vec(),
+                Element::new_item(b"hello".to_vec()),
+            ),
+            QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec()],
+                b"ref_to_if_ne".to_vec(),
+                Element::new_reference(ReferencePathType::SiblingReference(b"if_ne_item".to_vec())),
+            ),
+        ];
+
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("batch ref to InsertIfNotExists item");
+
+        let fetched = db
+            .get([TEST_LEAF].as_ref(), b"ref_to_if_ne", None, grove_version)
+            .unwrap()
+            .expect("ref should resolve");
+        assert_eq!(fetched, Element::new_item(b"hello".to_vec()));
+    }
+
+    // ===================================================================
     // 31. Batch: RefreshReference with trust_refresh_reference = false
     // ===================================================================
 

--- a/grovedb/src/tests/batch_coverage_tests.rs
+++ b/grovedb/src/tests/batch_coverage_tests.rs
@@ -906,6 +906,7 @@ mod tests {
         };
         let insert_if_not_exists = GroveOp::InsertIfNotExists {
             element: Element::new_item(b"test".to_vec()),
+            error_if_exists: true,
         };
 
         assert!(
@@ -1595,6 +1596,7 @@ mod tests {
 
     #[test]
     fn test_insert_if_not_exists_debug_format() {
+        // error_if_exists = true (default)
         let op = QualifiedGroveDbOp::insert_if_not_exists_op(
             vec![b"path".to_vec()],
             b"key".to_vec(),
@@ -1602,8 +1604,20 @@ mod tests {
         );
         let debug_str = format!("{:?}", op);
         assert!(
-            debug_str.contains("Insert If Not Exists"),
-            "Debug output should contain 'Insert If Not Exists', got: {debug_str}"
+            debug_str.contains("Insert If Not Exists (error on existing)"),
+            "Debug output should contain 'Insert If Not Exists (error on existing)', got: {debug_str}"
+        );
+
+        // error_if_exists = false (skip)
+        let op_skip = QualifiedGroveDbOp::insert_if_not_exists_or_skip_op(
+            vec![b"path".to_vec()],
+            b"key".to_vec(),
+            Element::new_item(b"val".to_vec()),
+        );
+        let debug_str_skip = format!("{:?}", op_skip);
+        assert!(
+            debug_str_skip.contains("Insert If Not Exists (skip on existing)"),
+            "Debug output should contain 'Insert If Not Exists (skip on existing)', got: {debug_str_skip}"
         );
     }
 
@@ -1638,6 +1652,94 @@ mod tests {
             .unwrap()
             .expect("ref should resolve");
         assert_eq!(fetched, Element::new_item(b"hello".to_vec()));
+    }
+
+    // ===================================================================
+    // 30e. InsertIfNotExists: skip on existing (error_if_exists = false)
+    // ===================================================================
+
+    #[test]
+    fn test_batch_insert_if_not_exists_skip_on_existing() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert an item first
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"skip_key",
+            Element::new_item(b"original".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert original item");
+
+        // InsertIfNotExists with error_if_exists=false should silently skip
+        let ops = vec![QualifiedGroveDbOp::insert_if_not_exists_or_skip_op(
+            vec![TEST_LEAF.to_vec()],
+            b"skip_key".to_vec(),
+            Element::new_item(b"should_be_ignored".to_vec()),
+        )];
+
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("insert_if_not_exists with skip should succeed");
+
+        // The original element should still be there, not overwritten
+        let result = db
+            .get([TEST_LEAF].as_ref(), b"skip_key", None, grove_version)
+            .unwrap()
+            .expect("element should still exist");
+        assert_eq!(
+            result,
+            Element::new_item(b"original".to_vec()),
+            "original value should be preserved"
+        );
+    }
+
+    // ===================================================================
+    // 30f. InsertIfNotExists: skip on existing via sequential (without-batching) path
+    // ===================================================================
+
+    #[test]
+    fn test_apply_operations_without_batching_insert_if_not_exists_skip() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Insert an item first
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"skip_seq_key",
+            Element::new_item(b"original".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert original item");
+
+        // InsertIfNotExists with error_if_exists=false via sequential path
+        let ops = vec![QualifiedGroveDbOp::insert_if_not_exists_or_skip_op(
+            vec![TEST_LEAF.to_vec()],
+            b"skip_seq_key".to_vec(),
+            Element::new_item(b"should_be_ignored".to_vec()),
+        )];
+
+        db.apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap()
+            .expect("insert_if_not_exists with skip should succeed on sequential path");
+
+        // The original element should still be there
+        let result = db
+            .get([TEST_LEAF].as_ref(), b"skip_seq_key", None, grove_version)
+            .unwrap()
+            .expect("element should still exist");
+        assert_eq!(
+            result,
+            Element::new_item(b"original".to_vec()),
+            "original value should be preserved on sequential path"
+        );
     }
 
     // ===================================================================

--- a/grovedb/src/tests/batch_unit_tests.rs
+++ b/grovedb/src/tests/batch_unit_tests.rs
@@ -118,7 +118,7 @@ mod tests {
                 // 8
                 element: dummy_element.clone(),
             },
-            GroveOp::InsertOnlyKnownToNotExist {
+            GroveOp::InsertWithKnownToNotAlreadyExist {
                 // 9
                 element: dummy_element.clone(),
             },
@@ -531,7 +531,7 @@ mod tests {
         let results = QualifiedGroveDbOp::verify_consistency_of_operations(&ops);
         assert!(
             !results.is_empty(),
-            "InsertOnlyKnownToNotExist under a deleted path should be flagged"
+            "InsertWithKnownToNotAlreadyExist under a deleted path should be flagged"
         );
     }
 
@@ -829,8 +829,8 @@ mod tests {
     // code paths that are not reached by existing tests.
     // ===================================================================
 
-    /// Reference to an item being InsertOnlyKnownToNotExist'd in the same batch.
-    /// Exercises the InsertOnlyKnownToNotExist { Item } branch (L1469-1476).
+    /// Reference to an item being InsertWithKnownToNotAlreadyExist'd in the same batch.
+    /// Exercises the InsertWithKnownToNotAlreadyExist { Item } branch (L1469-1476).
     #[test]
     fn test_batch_ref_to_insert_only_item() {
         let grove_version = GroveVersion::latest();
@@ -854,7 +854,7 @@ mod tests {
 
         db.apply_batch(ops, None, None, grove_version)
             .unwrap()
-            .expect("batch ref to InsertOnlyKnownToNotExist item");
+            .expect("batch ref to InsertWithKnownToNotAlreadyExist item");
 
         // Verify the reference resolves
         let result = db
@@ -864,9 +864,9 @@ mod tests {
         assert_eq!(result, Element::new_item(b"hello".to_vec()));
     }
 
-    /// Reference chain through an InsertOnlyKnownToNotExist reference in the same batch.
-    /// ref_a → ref_b (InsertOnlyKnownToNotExist) → existing item on disk.
-    /// Exercises the InsertOnlyKnownToNotExist { Reference } branch (L1478-1490).
+    /// Reference chain through an InsertWithKnownToNotAlreadyExist reference in the same batch.
+    /// ref_a → ref_b (InsertWithKnownToNotAlreadyExist) → existing item on disk.
+    /// Exercises the InsertWithKnownToNotAlreadyExist { Reference } branch (L1478-1490).
     #[test]
     fn test_batch_ref_to_insert_only_reference_chain() {
         let grove_version = GroveVersion::latest();
@@ -884,7 +884,7 @@ mod tests {
         .unwrap()
         .expect("insert base item");
 
-        // Batch: InsertOnlyKnownToNotExist a reference to base_item, then another ref to that
+        // Batch: InsertWithKnownToNotAlreadyExist a reference to base_item, then another ref to that
         let ops = vec![
             QualifiedGroveDbOp::insert_only_op(
                 vec![TEST_LEAF.to_vec()],
@@ -906,7 +906,7 @@ mod tests {
 
         db.apply_batch(ops, None, None, grove_version)
             .unwrap()
-            .expect("batch ref chain through InsertOnlyKnownToNotExist reference");
+            .expect("batch ref chain through InsertWithKnownToNotAlreadyExist reference");
 
         let result = db
             .get([TEST_LEAF].as_ref(), b"ref_a", None, grove_version)
@@ -1449,7 +1449,7 @@ mod tests {
 
     // ===================================================================
     // Group 14: follow_reference_get_value_hash — ref pointing to a
-    //           tree in an InsertOnlyKnownToNotExist/Replace/Patch op (L1492-1506)
+    //           tree in an InsertWithKnownToNotAlreadyExist/Replace/Patch op (L1492-1506)
     // ===================================================================
 
     #[test]

--- a/grovedb/src/tests/batch_unit_tests.rs
+++ b/grovedb/src/tests/batch_unit_tests.rs
@@ -118,7 +118,7 @@ mod tests {
                 // 8
                 element: dummy_element.clone(),
             },
-            GroveOp::InsertOnly {
+            GroveOp::InsertOnlyKnownToNotExist {
                 // 9
                 element: dummy_element.clone(),
             },
@@ -531,7 +531,7 @@ mod tests {
         let results = QualifiedGroveDbOp::verify_consistency_of_operations(&ops);
         assert!(
             !results.is_empty(),
-            "InsertOnly under a deleted path should be flagged"
+            "InsertOnlyKnownToNotExist under a deleted path should be flagged"
         );
     }
 
@@ -829,8 +829,8 @@ mod tests {
     // code paths that are not reached by existing tests.
     // ===================================================================
 
-    /// Reference to an item being InsertOnly'd in the same batch.
-    /// Exercises the InsertOnly { Item } branch (L1469-1476).
+    /// Reference to an item being InsertOnlyKnownToNotExist'd in the same batch.
+    /// Exercises the InsertOnlyKnownToNotExist { Item } branch (L1469-1476).
     #[test]
     fn test_batch_ref_to_insert_only_item() {
         let grove_version = GroveVersion::latest();
@@ -854,7 +854,7 @@ mod tests {
 
         db.apply_batch(ops, None, None, grove_version)
             .unwrap()
-            .expect("batch ref to InsertOnly item");
+            .expect("batch ref to InsertOnlyKnownToNotExist item");
 
         // Verify the reference resolves
         let result = db
@@ -864,9 +864,9 @@ mod tests {
         assert_eq!(result, Element::new_item(b"hello".to_vec()));
     }
 
-    /// Reference chain through an InsertOnly reference in the same batch.
-    /// ref_a → ref_b (InsertOnly) → existing item on disk.
-    /// Exercises the InsertOnly { Reference } branch (L1478-1490).
+    /// Reference chain through an InsertOnlyKnownToNotExist reference in the same batch.
+    /// ref_a → ref_b (InsertOnlyKnownToNotExist) → existing item on disk.
+    /// Exercises the InsertOnlyKnownToNotExist { Reference } branch (L1478-1490).
     #[test]
     fn test_batch_ref_to_insert_only_reference_chain() {
         let grove_version = GroveVersion::latest();
@@ -884,7 +884,7 @@ mod tests {
         .unwrap()
         .expect("insert base item");
 
-        // Batch: InsertOnly a reference to base_item, then another ref to that
+        // Batch: InsertOnlyKnownToNotExist a reference to base_item, then another ref to that
         let ops = vec![
             QualifiedGroveDbOp::insert_only_op(
                 vec![TEST_LEAF.to_vec()],
@@ -906,7 +906,7 @@ mod tests {
 
         db.apply_batch(ops, None, None, grove_version)
             .unwrap()
-            .expect("batch ref chain through InsertOnly reference");
+            .expect("batch ref chain through InsertOnlyKnownToNotExist reference");
 
         let result = db
             .get([TEST_LEAF].as_ref(), b"ref_a", None, grove_version)
@@ -1449,7 +1449,7 @@ mod tests {
 
     // ===================================================================
     // Group 14: follow_reference_get_value_hash — ref pointing to a
-    //           tree in an InsertOnly/Replace/Patch op (L1492-1506)
+    //           tree in an InsertOnlyKnownToNotExist/Replace/Patch op (L1492-1506)
     // ===================================================================
 
     #[test]

--- a/grovedb/src/tests/batch_unit_tests.rs
+++ b/grovedb/src/tests/batch_unit_tests.rs
@@ -122,22 +122,26 @@ mod tests {
                 // 9
                 element: dummy_element.clone(),
             },
-            GroveOp::CommitmentTreeInsert {
+            GroveOp::InsertIfNotExists {
                 // 10
+                element: dummy_element.clone(),
+            },
+            GroveOp::CommitmentTreeInsert {
+                // 11
                 cmx: dummy_hash,
                 rho: dummy_hash,
                 payload: vec![],
             },
-            GroveOp::MmrTreeAppend { value: vec![] },   // 11
-            GroveOp::BulkAppend { value: vec![] },      // 12
-            GroveOp::DenseTreeInsert { value: vec![] }, // 13
+            GroveOp::MmrTreeAppend { value: vec![] },   // 12
+            GroveOp::BulkAppend { value: vec![] },      // 13
+            GroveOp::DenseTreeInsert { value: vec![] }, // 14
             GroveOp::ReplaceNonMerkTreeRoot {
-                // 14
+                // 15
                 hash: dummy_hash,
                 meta: meta_commitment.clone(),
             },
             GroveOp::InsertNonMerkTree {
-                // 15
+                // 16
                 hash: dummy_hash,
                 root_key: None,
                 flags: None,
@@ -335,7 +339,15 @@ mod tests {
                     b"k".to_vec(),
                     element.clone(),
                 ),
-                "Insert",
+                "Insert With Known To Not Already Exist",
+            ),
+            (
+                QualifiedGroveDbOp::insert_if_not_exists_op(
+                    vec![b"p".to_vec()],
+                    b"k".to_vec(),
+                    element.clone(),
+                ),
+                "Insert If Not Exists",
             ),
             (
                 QualifiedGroveDbOp::replace_op(vec![b"p".to_vec()], b"k".to_vec(), element.clone()),

--- a/grovedb/src/tests/batch_unit_tests.rs
+++ b/grovedb/src/tests/batch_unit_tests.rs
@@ -125,6 +125,7 @@ mod tests {
             GroveOp::InsertIfNotExists {
                 // 10
                 element: dummy_element.clone(),
+                error_if_exists: true,
             },
             GroveOp::CommitmentTreeInsert {
                 // 11

--- a/grovedb/src/tests/misc_coverage_tests.rs
+++ b/grovedb/src/tests/misc_coverage_tests.rs
@@ -2994,6 +2994,132 @@ fn batch_worst_case_insert_only_item_cost() {
     );
 }
 
+#[test]
+fn batch_average_case_insert_if_not_exists_item_cost() {
+    let grove_version = GroveVersion::latest();
+
+    let ops_insert_only = vec![QualifiedGroveDbOp::insert_only_op(
+        vec![],
+        b"key1".to_vec(),
+        Element::new_item(b"value1".to_vec()),
+    )];
+
+    let ops_if_not_exists = vec![QualifiedGroveDbOp::insert_if_not_exists_op(
+        vec![],
+        b"key1".to_vec(),
+        Element::new_item(b"value1".to_vec()),
+    )];
+
+    let make_paths = || {
+        let mut paths = HashMap::new();
+        paths.insert(
+            KeyInfoPath(vec![]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: EstimatedLayerCount::ApproximateElements(5),
+                estimated_layer_sizes: EstimatedLayerSizes::AllItems(15, 17, None),
+            },
+        );
+        paths
+    };
+
+    let cost_insert_only = GroveDb::estimated_case_operations_for_batch(
+        AverageCaseCostsType(make_paths()),
+        ops_insert_only,
+        None,
+        |_cost, _old_flags, _new_flags| Ok(false),
+        |_flags, _removed_key_bytes, _removed_value_bytes| Ok((NoStorageRemoval, NoStorageRemoval)),
+        grove_version,
+    )
+    .cost_as_result()
+    .expect("average case insert only cost should succeed");
+
+    let cost_if_not_exists = GroveDb::estimated_case_operations_for_batch(
+        AverageCaseCostsType(make_paths()),
+        ops_if_not_exists,
+        None,
+        |_cost, _old_flags, _new_flags| Ok(false),
+        |_flags, _removed_key_bytes, _removed_value_bytes| Ok((NoStorageRemoval, NoStorageRemoval)),
+        grove_version,
+    )
+    .cost_as_result()
+    .expect("average case insert_if_not_exists cost should succeed");
+
+    assert!(
+        cost_if_not_exists.seek_count > cost_insert_only.seek_count,
+        "insert_if_not_exists should have more seeks than insert_only ({} vs {})",
+        cost_if_not_exists.seek_count,
+        cost_insert_only.seek_count,
+    );
+    assert!(
+        cost_if_not_exists.storage_loaded_bytes > cost_insert_only.storage_loaded_bytes,
+        "insert_if_not_exists should load more bytes than insert_only ({} vs {})",
+        cost_if_not_exists.storage_loaded_bytes,
+        cost_insert_only.storage_loaded_bytes,
+    );
+}
+
+#[test]
+fn batch_worst_case_insert_if_not_exists_item_cost() {
+    let grove_version = GroveVersion::latest();
+
+    let ops_insert_only = vec![QualifiedGroveDbOp::insert_only_op(
+        vec![],
+        b"key1".to_vec(),
+        Element::new_item(b"value1".to_vec()),
+    )];
+
+    let ops_if_not_exists = vec![QualifiedGroveDbOp::insert_if_not_exists_op(
+        vec![],
+        b"key1".to_vec(),
+        Element::new_item(b"value1".to_vec()),
+    )];
+
+    let make_paths = || {
+        let mut paths = HashMap::new();
+        paths.insert(
+            KeyInfoPath(vec![]),
+            WorstCaseLayerInformation::MaxElementsNumber(5),
+        );
+        paths
+    };
+
+    let cost_insert_only = GroveDb::estimated_case_operations_for_batch(
+        WorstCaseCostsType(make_paths()),
+        ops_insert_only,
+        None,
+        |_cost, _old_flags, _new_flags| Ok(false),
+        |_flags, _removed_key_bytes, _removed_value_bytes| Ok((NoStorageRemoval, NoStorageRemoval)),
+        grove_version,
+    )
+    .cost_as_result()
+    .expect("worst case insert only cost should succeed");
+
+    let cost_if_not_exists = GroveDb::estimated_case_operations_for_batch(
+        WorstCaseCostsType(make_paths()),
+        ops_if_not_exists,
+        None,
+        |_cost, _old_flags, _new_flags| Ok(false),
+        |_flags, _removed_key_bytes, _removed_value_bytes| Ok((NoStorageRemoval, NoStorageRemoval)),
+        grove_version,
+    )
+    .cost_as_result()
+    .expect("worst case insert_if_not_exists cost should succeed");
+
+    assert!(
+        cost_if_not_exists.seek_count > cost_insert_only.seek_count,
+        "insert_if_not_exists should have more seeks than insert_only ({} vs {})",
+        cost_if_not_exists.seek_count,
+        cost_insert_only.seek_count,
+    );
+    assert!(
+        cost_if_not_exists.storage_loaded_bytes > cost_insert_only.storage_loaded_bytes,
+        "insert_if_not_exists should load more bytes than insert_only ({} vs {})",
+        cost_if_not_exists.storage_loaded_bytes,
+        cost_insert_only.storage_loaded_bytes,
+    );
+}
+
 // ===========================================================================
 // Additional batch estimated cost tests for edge cases
 // ===========================================================================


### PR DESCRIPTION
## Summary

- `InsertOnly` had ambiguous semantics — documented as an optimization hint ("we know this doesn't exist") but the non-batch path enforced uniqueness. Platform uses it purely as an optimization hint to skip replacement cost overhead.
- Split into two clear variants:
  - **`InsertOnlyKnownToNotExist`**: optimization hint, no existence check, same cost as `InsertOrReplace`. `insert_only_op()` constructs this (preserves platform compatibility).
  - **`InsertIfNotExists`**: enforces uniqueness by seeking to verify the key doesn't exist before inserting. Adds a seek cost. `insert_if_not_exists_op()` constructs this.

## Test plan

- [x] All existing tests pass (1283 passed, renamed to use new variant names)
- [x] `InsertIfNotExists` tests verify rejection when key exists
- [x] `InsertOnlyKnownToNotExist` tests verify plain insert behavior
- [x] Estimated costs include extra seek for `InsertIfNotExists`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added InsertIfNotExists operation for conditional inserts with configurable error-on-exist behavior
  * New public API: insert_if_not_exists_op(...) to create conditional insert operations

* **Updates**
  * Renamed InsertOnly to InsertWithKnownToNotAlreadyExist (deprecated alias preserved)
  * Cost estimates updated: InsertIfNotExists now accounts for an extra existence-check cost (more seeks/bytes)
  * Debug/diagnostic messages updated to reflect new variants

* **Tests**
  * Added tests comparing costs and behavior between insert-if-not-exists and known-not-exist inserts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->