### PR TITLE
fix: replace panic!() with error returns in TreeNode/Walker attach/detach_expect (M2)

### DIFF
--- a/merk/src/proofs/query/merk_integration_tests.rs
+++ b/merk/src/proofs/query/merk_integration_tests.rs
@@ -39,10 +39,12 @@ fn make_3_node_tree() -> TreeNode {
             true,
             Some(TreeNode::new(vec![3], vec![3], None, BasicMerkNode).unwrap()),
         )
+        .unwrap()
         .attach(
             false,
             Some(TreeNode::new(vec![7], vec![7], None, BasicMerkNode).unwrap()),
-        );
+        )
+        .unwrap();
     tree.commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
         .expect("commit failed");
@@ -55,7 +57,9 @@ fn make_6_node_tree() -> TreeNode {
     let mut three_tree = TreeNode::new(vec![3], vec![3], None, BasicMerkNode)
         .unwrap()
         .attach(true, Some(two_tree))
-        .attach(false, Some(four_tree));
+        .unwrap()
+        .attach(false, Some(four_tree))
+        .unwrap();
     three_tree
         .commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
@@ -64,7 +68,8 @@ fn make_6_node_tree() -> TreeNode {
     let seven_tree = TreeNode::new(vec![7], vec![7], None, BasicMerkNode).unwrap();
     let mut eight_tree = TreeNode::new(vec![8], vec![8], None, BasicMerkNode)
         .unwrap()
-        .attach(true, Some(seven_tree));
+        .attach(true, Some(seven_tree))
+        .unwrap();
     eight_tree
         .commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
@@ -73,7 +78,9 @@ fn make_6_node_tree() -> TreeNode {
     let mut root_tree = TreeNode::new(vec![5], vec![5], None, BasicMerkNode)
         .unwrap()
         .attach(true, Some(three_tree))
-        .attach(false, Some(eight_tree));
+        .unwrap()
+        .attach(false, Some(eight_tree))
+        .unwrap();
     root_tree
         .commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
@@ -707,6 +714,7 @@ fn doc_proof() {
                         true,
                         Some(TreeNode::new(vec![1], vec![1], None, BasicMerkNode).unwrap()),
                     )
+                    .unwrap()
                     .attach(
                         false,
                         Some(
@@ -718,11 +726,14 @@ fn doc_proof() {
                                         TreeNode::new(vec![3], vec![3], None, BasicMerkNode)
                                             .unwrap(),
                                     ),
-                                ),
+                                )
+                                .unwrap(),
                         ),
-                    ),
+                    )
+                    .unwrap(),
             ),
         )
+        .unwrap()
         .attach(
             false,
             Some(
@@ -740,15 +751,18 @@ fn doc_proof() {
                                             .unwrap(),
                                     ),
                                 )
+                                .unwrap()
                                 .attach(
                                     false,
                                     Some(
                                         TreeNode::new(vec![8], vec![8], None, BasicMerkNode)
                                             .unwrap(),
                                     ),
-                                ),
+                                )
+                                .unwrap(),
                         ),
                     )
+                    .unwrap()
                     .attach(
                         false,
                         Some(
@@ -760,11 +774,14 @@ fn doc_proof() {
                                         TreeNode::new(vec![10], vec![10], None, BasicMerkNode)
                                             .unwrap(),
                                     ),
-                                ),
+                                )
+                                .unwrap(),
                         ),
-                    ),
+                    )
+                    .unwrap(),
             ),
-        );
+        )
+        .unwrap();
     tree.commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
         .unwrap();
@@ -3678,7 +3695,8 @@ fn test_5_item_tree_tampering_detected_with_elements() {
     // Create [2] with [1] as left child
     let mut two_tree = TreeNode::new(vec![2], val2.clone(), None, BasicMerkNode)
         .unwrap()
-        .attach(true, Some(one_tree));
+        .attach(true, Some(one_tree))
+        .unwrap();
     two_tree
         .commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
@@ -3687,7 +3705,8 @@ fn test_5_item_tree_tampering_detected_with_elements() {
     // Create [4] with [5] as right child
     let mut four_tree = TreeNode::new(vec![4], val4.clone(), None, BasicMerkNode)
         .unwrap()
-        .attach(false, Some(five_tree));
+        .attach(false, Some(five_tree))
+        .unwrap();
     four_tree
         .commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
@@ -3697,7 +3716,9 @@ fn test_5_item_tree_tampering_detected_with_elements() {
     let mut tree = TreeNode::new(vec![3], val3.clone(), None, BasicMerkNode)
         .unwrap()
         .attach(true, Some(two_tree))
-        .attach(false, Some(four_tree));
+        .unwrap()
+        .attach(false, Some(four_tree))
+        .unwrap();
     tree.commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
         .expect("commit failed");
@@ -3844,7 +3865,8 @@ fn test_5_item_tree_tampering_detected_raw_values() {
     // Create [2] with [1] as left child
     let mut two_tree = TreeNode::new(vec![2], b"bbb".to_vec(), None, BasicMerkNode)
         .unwrap()
-        .attach(true, Some(one_tree));
+        .attach(true, Some(one_tree))
+        .unwrap();
     two_tree
         .commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
@@ -3853,7 +3875,8 @@ fn test_5_item_tree_tampering_detected_raw_values() {
     // Create [4] with [5] as right child
     let mut four_tree = TreeNode::new(vec![4], b"ddd".to_vec(), None, BasicMerkNode)
         .unwrap()
-        .attach(false, Some(five_tree));
+        .attach(false, Some(five_tree))
+        .unwrap();
     four_tree
         .commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
@@ -3863,7 +3886,9 @@ fn test_5_item_tree_tampering_detected_raw_values() {
     let mut tree = TreeNode::new(vec![3], b"ccc".to_vec(), None, BasicMerkNode)
         .unwrap()
         .attach(true, Some(two_tree))
-        .attach(false, Some(four_tree));
+        .unwrap()
+        .attach(false, Some(four_tree))
+        .unwrap();
     tree.commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
         .expect("commit failed");
@@ -4003,7 +4028,9 @@ fn test_tampering_detected_invalid_discriminant() {
     let mut tree = TreeNode::new(vec![5], vec![99], None, BasicMerkNode)
         .unwrap()
         .attach(true, Some(left))
-        .attach(false, Some(right));
+        .unwrap()
+        .attach(false, Some(right))
+        .unwrap();
     tree.commit(&mut NoopCommit {}, &|_, _| Ok(0))
         .unwrap()
         .expect("commit failed");

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -746,34 +746,28 @@ impl TreeNode {
     /// Attaches the child (if any) to the root node on the given side. Creates
     /// a `Link` of variant `Link::Modified` which contains the child.
     ///
-    /// Panics if there is already a child on the given side.
+    /// Returns an error if there is already a child on the given side,
+    /// indicating a corrupted tree state.
     #[inline]
-    pub fn attach(mut self, left: bool, maybe_child: Option<Self>) -> Self {
+    pub fn attach(mut self, left: bool, maybe_child: Option<Self>) -> Result<Self, Error> {
         debug_assert_ne!(
             Some(self.key()),
             maybe_child.as_ref().map(|c| c.key()),
             "Tried to attach tree with same key"
         );
 
-        // let parent = std::str::from_utf8(self.key());
-        // if maybe_child.is_some(){
-        //     let child = std::str::from_utf8(maybe_child.as_ref().unwrap().key());
-        //     println!("attaching {} to {}", child.unwrap(), parent.unwrap());
-        // } else {
-        //     println!("attaching nothing to {}", parent.unwrap());
-        // }
-
         let slot = self.slot_mut(left);
 
         if slot.is_some() {
-            panic!(
-                "Tried to attach to {} tree slot, but it is already Some",
-                side_to_str(left)
-            );
+            return Err(Error::CorruptedState(if left {
+                "Tried to attach to left tree slot, but it is already Some"
+            } else {
+                "Tried to attach to right tree slot, but it is already Some"
+            }));
         }
         *slot = Link::maybe_from_modified_tree(maybe_child);
 
-        self
+        Ok(self)
     }
 
     /// Detaches the child on the given side (if any) from the root node, and
@@ -799,21 +793,23 @@ impl TreeNode {
     /// Detaches the child on the given side from the root node, and
     /// returns `(root_node, child)`.
     ///
-    /// Panics if there is no child on the given side.
+    /// Returns an error if there is no child on the given side, indicating
+    /// a corrupted tree state.
     ///
     /// One will usually want to reattach (see `attach`) a child on the same
     /// side after applying some operation to the detached child.
     #[inline]
-    pub fn detach_expect(self, left: bool) -> (Self, Self) {
+    pub fn detach_expect(self, left: bool) -> Result<(Self, Self), Error> {
         let (parent, maybe_child) = self.detach(left);
 
         if let Some(child) = maybe_child {
-            (parent, child)
+            Ok((parent, child))
         } else {
-            panic!(
-                "Expected tree to have {} child, but got None",
-                side_to_str(left)
-            );
+            Err(Error::CorruptedState(if left {
+                "Expected tree to have left child, but got None"
+            } else {
+                "Expected tree to have right child, but got None"
+            }))
         }
     }
 
@@ -826,7 +822,7 @@ impl TreeNode {
     /// less error prone that detaching with `detach` and reattaching with
     /// `attach`.
     #[inline]
-    pub fn walk<F>(self, left: bool, f: F) -> Self
+    pub fn walk<F>(self, left: bool, f: F) -> Result<Self, Error>
     where
         F: FnOnce(Option<Self>) -> Option<Self>,
     {
@@ -834,13 +830,14 @@ impl TreeNode {
         tree.attach(left, f(maybe_child))
     }
 
-    /// Like `walk`, but panics if there is no child on the given side.
+    /// Like `walk`, but returns an error if there is no child on the given
+    /// side, indicating a corrupted tree state.
     #[inline]
-    pub fn walk_expect<F>(self, left: bool, f: F) -> Self
+    pub fn walk_expect<F>(self, left: bool, f: F) -> Result<Self, Error>
     where
         F: FnOnce(Self) -> Option<Self>,
     {
-        let (tree, child) = self.detach_expect(left);
+        let (tree, child) = self.detach_expect(left)?;
         tree.attach(left, f(child))
     }
 
@@ -1273,39 +1270,43 @@ mod test {
         assert!(tree.child(true).is_none());
         assert!(tree.child(false).is_none());
 
-        let tree = tree.attach(true, None);
+        let tree = tree.attach(true, None).unwrap();
         assert!(tree.child(true).is_none());
         assert!(tree.child(false).is_none());
 
-        let tree = tree.attach(
-            true,
-            Some(TreeNode::new(vec![2], vec![102], None, BasicMerkNode).unwrap()),
-        );
+        let tree = tree
+            .attach(
+                true,
+                Some(TreeNode::new(vec![2], vec![102], None, BasicMerkNode).unwrap()),
+            )
+            .unwrap();
         assert_eq!(tree.key(), &[1]);
         assert_eq!(tree.child(true).unwrap().key(), &[2]);
         assert!(tree.child(false).is_none());
 
         let tree = TreeNode::new(vec![3], vec![103], None, BasicMerkNode)
             .unwrap()
-            .attach(false, Some(tree));
+            .attach(false, Some(tree))
+            .unwrap();
         assert_eq!(tree.key(), &[3]);
         assert_eq!(tree.child(false).unwrap().key(), &[1]);
         assert!(tree.child(true).is_none());
     }
 
-    #[should_panic]
     #[test]
     fn attach_existing() {
-        TreeNode::new(vec![0], vec![1], None, BasicMerkNode)
+        let result = TreeNode::new(vec![0], vec![1], None, BasicMerkNode)
             .unwrap()
             .attach(
                 true,
                 Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap()),
             )
+            .unwrap()
             .attach(
                 true,
                 Some(TreeNode::new(vec![4], vec![5], None, BasicMerkNode).unwrap()),
             );
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1316,28 +1317,36 @@ mod test {
                 true,
                 Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap()),
             )
+            .unwrap()
             .attach(
                 false,
                 Some(TreeNode::new(vec![4], vec![5], None, BasicMerkNode).unwrap()),
-            );
+            )
+            .unwrap();
 
-        let tree = tree.walk(true, |left_opt| {
-            assert_eq!(left_opt.as_ref().unwrap().key(), &[2]);
-            None
-        });
+        let tree = tree
+            .walk(true, |left_opt| {
+                assert_eq!(left_opt.as_ref().unwrap().key(), &[2]);
+                None
+            })
+            .unwrap();
         assert!(tree.child(true).is_none());
         assert!(tree.child(false).is_some());
 
-        let tree = tree.walk(true, |left_opt| {
-            assert!(left_opt.is_none());
-            Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap())
-        });
+        let tree = tree
+            .walk(true, |left_opt| {
+                assert!(left_opt.is_none());
+                Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap())
+            })
+            .unwrap();
         assert_eq!(tree.link(true).unwrap().key(), &[2]);
 
-        let tree = tree.walk_expect(false, |right| {
-            assert_eq!(right.key(), &[4]);
-            None
-        });
+        let tree = tree
+            .walk_expect(false, |right| {
+                assert_eq!(right.key(), &[4]);
+                None
+            })
+            .unwrap();
         assert!(tree.child(true).is_some());
         assert!(tree.child(false).is_none());
     }
@@ -1349,7 +1358,8 @@ mod test {
             .attach(
                 true,
                 Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap()),
-            );
+            )
+            .unwrap();
         assert!(tree.link(true).expect("expected link").is_modified());
         assert!(tree.child(true).is_some());
         assert!(tree.link(false).is_none());
@@ -1365,7 +1375,7 @@ mod test {
         // assert!(tree.link(true).expect("expected link").is_pruned());
         // assert!(tree.child(true).is_none());
 
-        let tree = tree.walk(true, |_| None);
+        let tree = tree.walk(true, |_| None).unwrap();
         assert!(tree.link(true).is_none());
         assert!(tree.child(true).is_none());
     }
@@ -1377,7 +1387,8 @@ mod test {
             .attach(
                 true,
                 Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap()),
-            );
+            )
+            .unwrap();
         tree.commit(&mut NoopCommit {}, &|_, _| Ok(0))
             .unwrap()
             .expect("commit failed");
@@ -1409,10 +1420,12 @@ mod test {
         assert_eq!(tree.child_pending_writes(true), 0);
         assert_eq!(tree.child_pending_writes(false), 0);
 
-        let tree = tree.attach(
-            true,
-            Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap()),
-        );
+        let tree = tree
+            .attach(
+                true,
+                Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap()),
+            )
+            .unwrap();
         assert_eq!(tree.child_pending_writes(true), 1);
         assert_eq!(tree.child_pending_writes(false), 0);
     }
@@ -1425,17 +1438,19 @@ mod test {
         assert_eq!(tree.child_height(false), 0);
         assert_eq!(tree.balance_factor(), 0);
 
-        let tree = tree.attach(
-            true,
-            Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap()),
-        );
+        let tree = tree
+            .attach(
+                true,
+                Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap()),
+            )
+            .unwrap();
         assert_eq!(tree.height(), 2);
         assert_eq!(tree.child_height(true), 1);
         assert_eq!(tree.child_height(false), 0);
         assert_eq!(tree.balance_factor(), -1);
 
         let (tree, maybe_child) = tree.detach(true);
-        let tree = tree.attach(false, maybe_child);
+        let tree = tree.attach(false, maybe_child).unwrap();
         assert_eq!(tree.height(), 2);
         assert_eq!(tree.child_height(true), 0);
         assert_eq!(tree.child_height(false), 1);
@@ -1449,7 +1464,8 @@ mod test {
             .attach(
                 false,
                 Some(TreeNode::new(vec![2], vec![3], None, BasicMerkNode).unwrap()),
-            );
+            )
+            .unwrap();
         tree.commit(&mut NoopCommit {}, &|_, _| Ok(0))
             .unwrap()
             .expect("commit failed");
@@ -1464,7 +1480,8 @@ mod test {
             .attach(
                 false,
                 Some(TreeNode::new(vec![2], vec![3], None, SummedMerkNode(5)).unwrap()),
-            );
+            )
+            .unwrap();
         tree.commit(&mut NoopCommit {}, &|_, _| Ok(0))
             .unwrap()
             .expect("commit failed");

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -929,14 +929,15 @@ where
         );
 
         // attach grandchild to self
-        tree.attach(left, maybe_grandchild)
+        let tree = cost_return_on_error_no_add!(cost, tree.attach(left, maybe_grandchild));
+        let tree = cost_return_on_error!(
+            &mut cost,
+            tree.maybe_balance(value_defined_cost_fn, grove_version)
+        );
+        // attach self to child, return child
+        let child = cost_return_on_error_no_add!(cost, child.attach(!left, Some(tree)));
+        child
             .maybe_balance(value_defined_cost_fn, grove_version)
-            .flat_map_ok(|tree| {
-                // attach self to child, return child
-                child
-                    .attach(!left, Some(tree))
-                    .maybe_balance(value_defined_cost_fn, grove_version)
-            })
             .add_cost(cost)
     }
 
@@ -1003,12 +1004,15 @@ where
     where
         V: Fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>,
     {
-        self.remove_edge(left, value_defined_cost_fn, grove_version)
-            .flat_map_ok(|(edge, maybe_child)| {
-                edge.attach(!left, maybe_child)
-                    .attach(left, Some(attach))
-                    .maybe_balance(value_defined_cost_fn, grove_version)
-            })
+        let mut cost = OperationCost::default();
+        let (edge, maybe_child) = cost_return_on_error!(
+            &mut cost,
+            self.remove_edge(left, value_defined_cost_fn, grove_version)
+        );
+        let edge = cost_return_on_error_no_add!(cost, edge.attach(!left, maybe_child));
+        let edge = cost_return_on_error_no_add!(cost, edge.attach(left, Some(attach)));
+        edge.maybe_balance(value_defined_cost_fn, grove_version)
+            .add_cost(cost)
     }
 
     /// Traverses to the tree's edge on the given side and detaches it
@@ -1035,8 +1039,8 @@ where
                 &mut cost,
                 child.remove_edge(left, value_defined_cost_fn, grove_version)
             );
-            tree.attach(left, maybe_child)
-                .maybe_balance(value_defined_cost_fn, grove_version)
+            let tree = cost_return_on_error_no_add!(cost, tree.attach(left, maybe_child));
+            tree.maybe_balance(value_defined_cost_fn, grove_version)
                 .map_ok(|tree| (edge, Some(tree)))
                 .add_cost(cost)
         } else {

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -91,6 +91,9 @@ where
     /// Similar to `Tree#detach_expect`, but yields a `Walker` which fetches
     /// from the same source as `self`. Returned tuple is `(updated_self,
     /// child_walker)`.
+    ///
+    /// Returns an error if there is no child on the given side, indicating
+    /// a corrupted tree state.
     pub fn detach_expect<V>(
         self,
         left: bool,
@@ -101,14 +104,16 @@ where
         V: Fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>,
     {
         self.detach(left, value_defined_cost_fn, grove_version)
-            .map_ok(|(walker, maybe_child)| {
+            .flat_map_ok(|(walker, maybe_child)| {
                 if let Some(child) = maybe_child {
-                    (walker, child)
+                    Ok((walker, child)).wrap_with_cost(Default::default())
                 } else {
-                    panic!(
-                        "Expected {} child, got None",
-                        if left { "left" } else { "right" }
-                    );
+                    Err(Error::CorruptedState(if left {
+                        "Expected left child, got None"
+                    } else {
+                        "Expected right child, got None"
+                    }))
+                    .wrap_with_cost(Default::default())
                 }
             })
     }
@@ -137,7 +142,7 @@ where
             Ok(x) => x.map(|t| t.into()),
             Err(e) => return Err(e).wrap_with_cost(cost),
         };
-        walker.tree.own(|t| t.attach(left, new_child));
+        cost_return_on_error_no_add!(cost, walker.tree.own_result(|t| t.attach(left, new_child)));
         Ok(walker).wrap_with_cost(cost)
     }
 
@@ -165,7 +170,7 @@ where
             Ok(x) => x.map(|t| t.into()),
             Err(e) => return Err(e).wrap_with_cost(cost),
         };
-        walker.tree.own(|t| t.attach(left, new_child));
+        cost_return_on_error_no_add!(cost, walker.tree.own_result(|t| t.attach(left, new_child)));
         Ok(walker).wrap_with_cost(cost)
     }
 
@@ -192,13 +197,16 @@ where
 
     /// Similar to `Tree#attach`, but can also take a `Walker` since it
     /// implements `Into<Tree>`.
-    pub fn attach<T>(mut self, left: bool, maybe_child: Option<T>) -> Self
+    ///
+    /// Returns an error if the slot is already occupied, indicating a
+    /// corrupted tree state.
+    pub fn attach<T>(mut self, left: bool, maybe_child: Option<T>) -> Result<Self, Error>
     where
         T: Into<TreeNode>,
     {
         self.tree
-            .own(|t| t.attach(left, maybe_child.map(|t| t.into())));
-        self
+            .own_result(|t| t.attach(left, maybe_child.map(|t| t.into())))?;
+        Ok(self)
     }
 
     /// Similar to `Tree#put_value`.
@@ -429,7 +437,8 @@ mod test {
             .attach(
                 true,
                 Some(TreeNode::new(b"foo".to_vec(), b"bar".to_vec(), None, BasicMerkNode).unwrap()),
-            );
+            )
+            .unwrap();
 
         let source = MockSource {};
         let walker = Walker::new(tree, source);
@@ -457,7 +466,8 @@ mod test {
             .attach(
                 true,
                 Some(TreeNode::new(b"foo".to_vec(), b"bar".to_vec(), None, BasicMerkNode).unwrap()),
-            );
+            )
+            .unwrap();
         tree.commit(&mut NoopCommit {}, &|_, _| Ok(0))
             .unwrap()
             .expect("commit failed");


### PR DESCRIPTION
## Summary

- `TreeNode::attach()`: returns `Result<Self, Error>` instead of panicking when child slot is occupied
- `TreeNode::detach_expect()`: returns `Result<(Self, Self), Error>` instead of panicking when expected child is `None`
- `Walker::detach_expect()`: returns error via `flat_map_ok` instead of panicking
- `Walker::attach()`: returns `Result<Self, Error>` to propagate attach errors
- Updated `walk()`, `walk_expect()` to propagate errors
- Updated `rotate()`, `promote_edge()`, `remove_edge()` in ops.rs to handle Result returns with `cost_return_on_error_no_add!`

**Audit finding M2**: These methods are called during core AVL tree operations (rotations, removes) on every insert/delete. If tree state is corrupted (e.g., storage returns bad data), the node would crash instead of returning a recoverable error.

## Test plan

- [x] `attach_existing` test changed from `#[should_panic]` to asserting `result.is_err()`
- [x] All 230 merk tests pass
- [x] Full workspace builds
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)