### PR TITLE
docs: add security notes for ProveOptions, consistency check, and atomicity (L4, L6, L7)

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -2841,12 +2841,17 @@ impl GroveDb {
     /// # Warning -- not atomic
     ///
     /// Unlike [`apply_batch`](Self::apply_batch), this method processes each
-    /// operation individually and commits its side-effects immediately. If an
-    /// operation in the middle of the list fails, all preceding operations
-    /// will have already been persisted and **will not be rolled back**.
+    /// operation individually and applies its side-effects to the current
+    /// storage context immediately. If an operation in the middle of the list
+    /// fails, all preceding operations will have already been applied and
+    /// **will not be rolled back** within this method. (Note: when a
+    /// `transaction` is supplied, the caller can still roll back the entire
+    /// transaction; the non-atomicity refers to the inability to undo
+    /// *individual* operations within the list.)
     /// This means:
     ///
-    /// * The database may be left in a partially-updated state on failure.
+    /// * The storage context may be left in a partially-updated state on
+    ///   failure.
     /// * Root hashes may differ from the result of applying the same
     ///   operations via `apply_batch`, because batch application propagates
     ///   root hashes in a single pass whereas this method updates trees

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -2836,7 +2836,25 @@ impl GroveDb {
             .add_cost(cost)
     }
 
-    /// Applies operations on GroveDB without batching
+    /// Applies operations on GroveDB one at a time, without batching.
+    ///
+    /// # Warning -- not atomic
+    ///
+    /// Unlike [`apply_batch`](Self::apply_batch), this method processes each
+    /// operation individually and commits its side-effects immediately. If an
+    /// operation in the middle of the list fails, all preceding operations
+    /// will have already been persisted and **will not be rolled back**.
+    /// This means:
+    ///
+    /// * The database may be left in a partially-updated state on failure.
+    /// * Root hashes may differ from the result of applying the same
+    ///   operations via `apply_batch`, because batch application propagates
+    ///   root hashes in a single pass whereas this method updates trees
+    ///   one-by-one.
+    ///
+    /// Use this method **only** for testing, debugging, or situations where
+    /// partial application is explicitly acceptable. For production workloads
+    /// that require atomicity, use [`apply_batch`](Self::apply_batch) instead.
     pub fn apply_operations_without_batching(
         &self,
         ops: Vec<QualifiedGroveDbOp>,
@@ -5309,5 +5327,46 @@ mod tests {
         db.apply_batch(ops, None, Some(&tx), grove_version)
             .unwrap()
             .expect("batch with 255-byte key should succeed");
+    }
+
+    #[test]
+    fn test_apply_operations_without_batching_is_not_atomic() {
+        // Demonstrates that apply_operations_without_batching is NOT atomic:
+        // if the second operation fails, the first operation's side-effects
+        // are still committed to the database.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        let tx = db.start_transaction();
+
+        // Op 1: Insert a valid item under TEST_LEAF -- this should succeed.
+        // Op 2: Insert an item under a non-existent subtree -- this should fail.
+        let ops = vec![
+            QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec()],
+                b"key1".to_vec(),
+                Element::new_item(b"value1".to_vec()),
+            ),
+            QualifiedGroveDbOp::insert_or_replace_op(
+                vec![b"nonexistent_subtree".to_vec()],
+                b"key2".to_vec(),
+                Element::new_item(b"value2".to_vec()),
+            ),
+        ];
+
+        // The overall call should fail because the second op targets a
+        // subtree that does not exist.
+        let result = db.apply_operations_without_batching(ops, None, Some(&tx), grove_version);
+        assert!(
+            result.unwrap().is_err(),
+            "should fail because the second op targets a non-existent subtree"
+        );
+
+        // Despite the failure, the first operation was already committed
+        // (non-atomic behavior). We can observe this by reading key1.
+        let element = db
+            .get([TEST_LEAF].as_ref(), b"key1", Some(&tx), grove_version)
+            .unwrap()
+            .expect("first op should have been committed despite later failure");
+        assert_eq!(element, Element::new_item(b"value1".to_vec()));
     }
 }

--- a/grovedb/src/batch/options.rs
+++ b/grovedb/src/batch/options.rs
@@ -18,13 +18,17 @@ pub struct BatchApplyOptions {
     pub allow_deleting_non_empty_trees: bool,
     /// Deleting non empty trees returns error
     pub deleting_non_empty_trees_returns_error: bool,
-    /// Disable the operation consistency check that detects duplicate or
-    /// conflicting operations targeting the same `(path, key)` pair within a
-    /// batch.
+    /// Disable the full operation consistency check performed by
+    /// [`QualifiedGroveDbOp::verify_consistency_of_operations`].
+    ///
+    /// This check detects several conflict types including:
+    /// - Duplicate operations targeting the same `(path, key)` pair
+    /// - Inserts below paths that are being deleted in the same batch
+    /// - Append/delete conflicts on the same tree
     ///
     /// When this is `false` (the default), the batch system calls
     /// [`QualifiedGroveDbOp::verify_consistency_of_operations`] before
-    /// applying and rejects the batch if any duplicates are found.
+    /// applying and rejects the batch if any conflicts are found.
     ///
     /// # Warning -- silent last-op-wins behavior
     ///
@@ -36,10 +40,10 @@ pub struct BatchApplyOptions {
     /// error or warning.
     ///
     /// This is safe **only** when the caller has already guaranteed that the
-    /// operation list contains no conflicting entries for the same key, or
-    /// when the caller intentionally relies on last-op-wins semantics (e.g.,
-    /// an idempotent replay scenario). In all other cases, leave this set to
-    /// `false` to catch accidental duplicates early.
+    /// operation list contains no conflicting entries, or when the caller
+    /// intentionally relies on last-op-wins semantics (e.g., an idempotent
+    /// replay scenario). In all other cases, leave this set to `false` to
+    /// catch accidental conflicts early.
     pub disable_operation_consistency_check: bool,
     /// Base root storage is free
     pub base_root_storage_is_free: bool,

--- a/grovedb/src/batch/options.rs
+++ b/grovedb/src/batch/options.rs
@@ -19,7 +19,7 @@ pub struct BatchApplyOptions {
     /// Deleting non empty trees returns error
     pub deleting_non_empty_trees_returns_error: bool,
     /// Disable the full operation consistency check performed by
-    /// [`QualifiedGroveDbOp::verify_consistency_of_operations`].
+    /// [`super::QualifiedGroveDbOp::verify_consistency_of_operations`].
     ///
     /// This check detects several conflict types including:
     /// - Duplicate operations targeting the same `(path, key)` pair
@@ -27,7 +27,7 @@ pub struct BatchApplyOptions {
     /// - Append/delete conflicts on the same tree
     ///
     /// When this is `false` (the default), the batch system calls
-    /// [`QualifiedGroveDbOp::verify_consistency_of_operations`] before
+    /// [`super::QualifiedGroveDbOp::verify_consistency_of_operations`] before
     /// applying and rejects the batch if any conflicts are found.
     ///
     /// # Warning -- silent last-op-wins behavior

--- a/grovedb/src/batch/options.rs
+++ b/grovedb/src/batch/options.rs
@@ -18,7 +18,28 @@ pub struct BatchApplyOptions {
     pub allow_deleting_non_empty_trees: bool,
     /// Deleting non empty trees returns error
     pub deleting_non_empty_trees_returns_error: bool,
-    /// Disable operation consistency check
+    /// Disable the operation consistency check that detects duplicate or
+    /// conflicting operations targeting the same `(path, key)` pair within a
+    /// batch.
+    ///
+    /// When this is `false` (the default), the batch system calls
+    /// [`QualifiedGroveDbOp::verify_consistency_of_operations`] before
+    /// applying and rejects the batch if any duplicates are found.
+    ///
+    /// # Warning -- silent last-op-wins behavior
+    ///
+    /// When set to `true`, duplicate operations on the same `(path, key)` are
+    /// **not** detected. Because the internal batch structure is a `BTreeMap`
+    /// keyed by `(path, key)`, inserting a second operation for an already-seen
+    /// key silently overwrites the first. The **last** operation encountered in
+    /// the input `Vec` wins, and the earlier operation is lost without any
+    /// error or warning.
+    ///
+    /// This is safe **only** when the caller has already guaranteed that the
+    /// operation list contains no conflicting entries for the same key, or
+    /// when the caller intentionally relies on last-op-wins semantics (e.g.,
+    /// an idempotent replay scenario). In all other cases, leave this set to
+    /// `false` to catch accidental duplicates early.
     pub disable_operation_consistency_check: bool,
     /// Base root storage is free
     pub base_root_storage_is_free: bool,

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -28,6 +28,19 @@ use crate::{
 };
 
 /// Options controlling proof generation behavior.
+///
+/// # Security note
+///
+/// `ProveOptions` is serialized as part of the proof via `bincode::Encode` /
+/// `bincode::Decode`. During verification the verifier deserializes these
+/// options from the proof bytes, which means **the values come from the
+/// (potentially untrusted) prover**. A malicious prover could craft a proof
+/// with `decrease_limit_on_empty_sub_query_result` set to `true` even when
+/// the original query used `false`, causing the verifier to consume its
+/// result limit faster and therefore return fewer results than actually
+/// exist. Verifiers that need to guard against this should compare the
+/// deserialized options against the expected values for the query being
+/// verified.
 #[derive(Debug, Clone, Copy, Encode, Decode)]
 pub struct ProveOptions {
     /// This tells the proof system to decrease the available limit of the query
@@ -36,11 +49,23 @@ pub struct ProveOptions {
     /// known structure where we know that there are only a few empty
     /// subtrees.
     ///
-    /// !!! Warning !!! Be very careful:
-    /// If this is set to `false` then you must be sure that the sub queries do
-    /// not match many trees, Otherwise you could crash the system as the
-    /// proof system goes through millions of subtrees and eventually runs
-    /// out of memory
+    /// # Warning
+    ///
+    /// Be very careful: if this is set to `false` then you must be sure that
+    /// the sub queries do not match many trees. Otherwise you could crash the
+    /// system as the proof system goes through millions of subtrees and
+    /// eventually runs out of memory.
+    ///
+    /// # Security note
+    ///
+    /// This field is embedded in the serialized proof and deserialized by the
+    /// verifier. Because it originates from the prover, it must be treated as
+    /// **untrusted input**. A malicious prover can set this to `true`
+    /// regardless of the original query intent, which causes the verifier to
+    /// count empty subtrees against the query limit and thereby return fewer
+    /// results than it should. Applications that need to defend against
+    /// result-truncation attacks should validate this value after
+    /// deserialization.
     pub decrease_limit_on_empty_sub_query_result: bool,
 }
 


### PR DESCRIPTION
## Summary

Three documentation/safety improvements:

**L4 — ProveOptions security note**: Added doc comments warning that `ProveOptions` is serialized in the proof and deserialized from untrusted prover data. A malicious prover can manipulate `decrease_limit_on_empty_sub_query_result` to cause fewer results to be returned.

**L6 — disable_operation_consistency_check**: Expanded doc comment to explain the silent last-op-wins behavior when enabled, and when it's safe to use.

**L7 — apply_operations_without_batching atomicity**: Added comprehensive warning that the method is not atomic — preceding operations persist even when later operations fail. Added test demonstrating this behavior.

## Test plan

- [x] `test_apply_operations_without_batching_is_not_atomic` — demonstrates first op persists when second op fails
- [x] All 1291 grovedb tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified non-atomic apply behavior: partial persistence on failure, guidance for choosing non-batched vs batched apply, and expanded notes on operation-consistency checks and last-op-wins semantics.
  * Enhanced proof-related docs with security guidance for handling deserialized/untrusted inputs and recommended validation.

* **Tests**
  * Added a test demonstrating non-atomic semantics when applying operations without batching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->