### PR TITLE
docs: document add_parent_tree_on_subquery limit bypass (M6)

### DIFF
--- a/grovedb-query/src/query.rs
+++ b/grovedb-query/src/query.rs
@@ -22,7 +22,16 @@ pub struct Query {
     pub conditional_subquery_branches: Option<IndexMap<QueryItem, SubqueryBranch>>,
     /// Left to right?
     pub left_to_right: bool,
-    /// Add self to results if we subquery
+    /// When `true`, the parent tree element (e.g. a `CountTree` or `SumTree`)
+    /// is included in query results alongside its subquery children.
+    ///
+    /// # Known limitation (audit M6)
+    ///
+    /// Parent tree results added by this flag do **not** currently count
+    /// against `SizedQuery::limit`. A query with `limit = 10` may return
+    /// more than 10 results when this flag is active, because the limit
+    /// only governs child-level results. This will be resolved in a future
+    /// redesign that introduces per-level limits.
     pub add_parent_tree_on_subquery: bool,
 }
 

--- a/grovedb-query/src/query.rs
+++ b/grovedb-query/src/query.rs
@@ -32,6 +32,14 @@ pub struct Query {
     /// more than 10 results when this flag is active, because the limit
     /// only governs child-level results. This will be resolved in a future
     /// redesign that introduces per-level limits.
+    ///
+    /// # Absence-proof verification
+    ///
+    /// When verifying with `verify_query_with_absence_proof` or
+    /// `verify_subset_query_with_absence_proof`, results are reconstructed
+    /// from `terminal_keys()` which does not emit parent-tree entries.
+    /// Parent tree elements will therefore not appear in the verified
+    /// result set in those modes.
     pub add_parent_tree_on_subquery: bool,
 }
 

--- a/grovedb-query/src/query.rs
+++ b/grovedb-query/src/query.rs
@@ -25,7 +25,7 @@ pub struct Query {
     /// When `true`, the parent tree element (e.g. a `CountTree` or `SumTree`)
     /// is included in query results alongside its subquery children.
     ///
-    /// # Known limitation (audit M6)
+    /// # Known limitation
     ///
     /// Parent tree results added by this flag do **not** currently count
     /// against `SizedQuery::limit`. A query with `limit = 10` may return

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -508,10 +508,10 @@ impl GroveDb {
                                         break;
                                     }
                                 } else {
-                                    // Known limitation (audit M6): this parent
-                                    // tree result is pushed without decrementing
-                                    // limit_left. Will be addressed by per-level
-                                    // limits redesign.
+                                    // Known limitation: this parent tree result
+                                    // is pushed without decrementing limit_left.
+                                    // Will be addressed by per-level limits
+                                    // redesign.
                                     if query.should_add_parent_tree_at_path(
                                         current_path,
                                         grove_version,
@@ -1430,10 +1430,10 @@ impl GroveDb {
                                         break;
                                     }
                                 } else {
-                                    // Known limitation (audit M6): this parent
-                                    // tree result is pushed without decrementing
-                                    // limit_left. Will be addressed by per-level
-                                    // limits redesign.
+                                    // Known limitation: this parent tree result
+                                    // is pushed without decrementing limit_left.
+                                    // Will be addressed by per-level limits
+                                    // redesign.
                                     if query.should_add_parent_tree_at_path(
                                         current_path,
                                         grove_version,

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -508,6 +508,10 @@ impl GroveDb {
                                         break;
                                     }
                                 } else {
+                                    // Known limitation (audit M6): this parent
+                                    // tree result is pushed without decrementing
+                                    // limit_left. Will be addressed by per-level
+                                    // limits redesign.
                                     if query.should_add_parent_tree_at_path(
                                         current_path,
                                         grove_version,
@@ -1426,6 +1430,10 @@ impl GroveDb {
                                         break;
                                     }
                                 } else {
+                                    // Known limitation (audit M6): this parent
+                                    // tree result is pushed without decrementing
+                                    // limit_left. Will be addressed by per-level
+                                    // limits redesign.
                                     if query.should_add_parent_tree_at_path(
                                         current_path,
                                         grove_version,


### PR DESCRIPTION
## Summary

This is Claude. Documents a known limitation where `add_parent_tree_on_subquery` parent tree results do not count against `SizedQuery::limit` (audit finding M6).

- Added doc comment on `Query::add_parent_tree_on_subquery` field explaining the behavior
- Added inline comments at both verification sites (v0 and v1 paths) in `verify.rs`

This is intentionally left unfixed for now — it will be naturally resolved by a future redesign that introduces per-level limits instead of a single global limit.

Supersedes #603 (which was closed).

## Test plan
- [x] `cargo build -p grovedb` passes
- [x] Documentation-only change, no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated query documentation to clarify parent-tree result inclusion behavior and its interaction with result limits.

* **Changes**
  * Modified how parent-tree results are handled in proof verification. A known limitation has been documented with redesign planned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->