### PR TITLE
fix: enforce depth limit during proof deserialization

### DIFF
--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -123,6 +123,9 @@ impl MerkOnlyLayerProof {
         }
         let merk_proof = Vec::<u8>::decode(decoder)?;
         let len = u64::decode(decoder)? as usize;
+        if len > MAX_PROOF_DEPTH {
+            return Err(DecodeError::Other("proof layer has too many children"));
+        }
         let mut lower_layers = BTreeMap::new();
         for _ in 0..len {
             let key = Key::decode(decoder)?;
@@ -146,6 +149,9 @@ impl MerkOnlyLayerProof {
         }
         let merk_proof = Vec::<u8>::borrow_decode(decoder)?;
         let len = u64::borrow_decode(decoder)? as usize;
+        if len > MAX_PROOF_DEPTH {
+            return Err(DecodeError::Other("proof layer has too many children"));
+        }
         let mut lower_layers = BTreeMap::new();
         for _ in 0..len {
             let key = Key::borrow_decode(decoder)?;
@@ -213,6 +219,9 @@ impl LayerProof {
         }
         let merk_proof = ProofBytes::decode(decoder)?;
         let len = u64::decode(decoder)? as usize;
+        if len > MAX_PROOF_DEPTH {
+            return Err(DecodeError::Other("proof layer has too many children"));
+        }
         let mut lower_layers = BTreeMap::new();
         for _ in 0..len {
             let key = Key::decode(decoder)?;
@@ -236,6 +245,9 @@ impl LayerProof {
         }
         let merk_proof = ProofBytes::borrow_decode(decoder)?;
         let len = u64::borrow_decode(decoder)? as usize;
+        if len > MAX_PROOF_DEPTH {
+            return Err(DecodeError::Other("proof layer has too many children"));
+        }
         let mut lower_layers = BTreeMap::new();
         for _ in 0..len {
             let key = Key::borrow_decode(decoder)?;

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -16,13 +16,17 @@ use std::{collections::BTreeMap, fmt};
 /// fitting comfortably within typical stack sizes.
 pub const MAX_PROOF_DEPTH: usize = 128;
 
-use bincode::{Decode, Encode};
+use bincode::{
+    de::{BorrowDecoder, Decoder as BincodeDecoder},
+    error::DecodeError,
+    BorrowDecode, Decode, Encode,
+};
 use grovedb_bulk_append_tree::BulkAppendTreeProof;
 use grovedb_dense_fixed_sized_merkle_tree::DenseTreeProof;
 use grovedb_merk::{
     proofs::{
         query::{Key, VerifyOptions},
-        Decoder, Node, Op,
+        Decoder as MerkDecoder, Node, Op,
     },
     CryptoHash,
 };
@@ -96,12 +100,77 @@ impl Default for ProveOptions {
 }
 
 /// A single layer of a legacy (v0) GroveDB proof containing only merk proofs.
-#[derive(Encode, Decode)]
+///
+/// Uses a custom `Decode` implementation that enforces [`MAX_PROOF_DEPTH`]
+/// during deserialization to prevent stack overflow from deeply nested proofs.
+#[derive(Encode)]
 pub struct MerkOnlyLayerProof {
     /// Encoded merk proof bytes for this layer.
     pub merk_proof: Vec<u8>,
     /// Proofs for child subtrees keyed by their key in the parent tree.
     pub lower_layers: BTreeMap<Key, MerkOnlyLayerProof>,
+}
+
+impl MerkOnlyLayerProof {
+    fn decode_with_depth<D: BincodeDecoder>(
+        decoder: &mut D,
+        depth: usize,
+    ) -> Result<Self, DecodeError> {
+        if depth > MAX_PROOF_DEPTH {
+            return Err(DecodeError::Other(
+                "proof layer nesting depth exceeded maximum",
+            ));
+        }
+        let merk_proof = Vec::<u8>::decode(decoder)?;
+        let len = u64::decode(decoder)? as usize;
+        let mut lower_layers = BTreeMap::new();
+        for _ in 0..len {
+            let key = Key::decode(decoder)?;
+            let value = Self::decode_with_depth(decoder, depth + 1)?;
+            lower_layers.insert(key, value);
+        }
+        Ok(MerkOnlyLayerProof {
+            merk_proof,
+            lower_layers,
+        })
+    }
+
+    fn borrow_decode_with_depth<'de, D: BorrowDecoder<'de>>(
+        decoder: &mut D,
+        depth: usize,
+    ) -> Result<Self, DecodeError> {
+        if depth > MAX_PROOF_DEPTH {
+            return Err(DecodeError::Other(
+                "proof layer nesting depth exceeded maximum",
+            ));
+        }
+        let merk_proof = Vec::<u8>::borrow_decode(decoder)?;
+        let len = u64::borrow_decode(decoder)? as usize;
+        let mut lower_layers = BTreeMap::new();
+        for _ in 0..len {
+            let key = Key::borrow_decode(decoder)?;
+            let value = Self::borrow_decode_with_depth(decoder, depth + 1)?;
+            lower_layers.insert(key, value);
+        }
+        Ok(MerkOnlyLayerProof {
+            merk_proof,
+            lower_layers,
+        })
+    }
+}
+
+impl<Context> Decode<Context> for MerkOnlyLayerProof {
+    fn decode<D: BincodeDecoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        Self::decode_with_depth(decoder, 0)
+    }
+}
+
+impl<'de, Context> BorrowDecode<'de, Context> for MerkOnlyLayerProof {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
+        Self::borrow_decode_with_depth(decoder, 0)
+    }
 }
 
 /// Encoded proof bytes for different tree backing store types.
@@ -121,12 +190,77 @@ pub enum ProofBytes {
 }
 
 /// A single layer of a v1 GroveDB proof supporting multiple tree types.
-#[derive(Encode, Decode)]
+///
+/// Uses a custom `Decode` implementation that enforces [`MAX_PROOF_DEPTH`]
+/// during deserialization to prevent stack overflow from deeply nested proofs.
+#[derive(Encode)]
 pub struct LayerProof {
     /// Proof bytes for this layer (may be any supported tree type).
     pub merk_proof: ProofBytes,
     /// Proofs for child subtrees keyed by their key in the parent tree.
     pub lower_layers: BTreeMap<Key, LayerProof>,
+}
+
+impl LayerProof {
+    fn decode_with_depth<D: BincodeDecoder>(
+        decoder: &mut D,
+        depth: usize,
+    ) -> Result<Self, DecodeError> {
+        if depth > MAX_PROOF_DEPTH {
+            return Err(DecodeError::Other(
+                "proof layer nesting depth exceeded maximum",
+            ));
+        }
+        let merk_proof = ProofBytes::decode(decoder)?;
+        let len = u64::decode(decoder)? as usize;
+        let mut lower_layers = BTreeMap::new();
+        for _ in 0..len {
+            let key = Key::decode(decoder)?;
+            let value = Self::decode_with_depth(decoder, depth + 1)?;
+            lower_layers.insert(key, value);
+        }
+        Ok(LayerProof {
+            merk_proof,
+            lower_layers,
+        })
+    }
+
+    fn borrow_decode_with_depth<'de, D: BorrowDecoder<'de>>(
+        decoder: &mut D,
+        depth: usize,
+    ) -> Result<Self, DecodeError> {
+        if depth > MAX_PROOF_DEPTH {
+            return Err(DecodeError::Other(
+                "proof layer nesting depth exceeded maximum",
+            ));
+        }
+        let merk_proof = ProofBytes::borrow_decode(decoder)?;
+        let len = u64::borrow_decode(decoder)? as usize;
+        let mut lower_layers = BTreeMap::new();
+        for _ in 0..len {
+            let key = Key::borrow_decode(decoder)?;
+            let value = Self::borrow_decode_with_depth(decoder, depth + 1)?;
+            lower_layers.insert(key, value);
+        }
+        Ok(LayerProof {
+            merk_proof,
+            lower_layers,
+        })
+    }
+}
+
+impl<Context> Decode<Context> for LayerProof {
+    fn decode<D: BincodeDecoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        Self::decode_with_depth(decoder, 0)
+    }
+}
+
+impl<'de, Context> BorrowDecode<'de, Context> for LayerProof {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
+        Self::borrow_decode_with_depth(decoder, 0)
+    }
 }
 
 /// A versioned GroveDB proof that can be verified against a path query.
@@ -372,7 +506,7 @@ impl fmt::Display for GroveDBProofV1 {
 
 fn decode_merk_proof(proof: &[u8]) -> Result<String, fmt::Error> {
     let mut result = String::new();
-    let ops = Decoder::new(proof);
+    let ops = MerkDecoder::new(proof);
 
     for (i, op) in ops.enumerate() {
         match op {

--- a/grovedb/src/tests/proof_depth_limit_tests.rs
+++ b/grovedb/src/tests/proof_depth_limit_tests.rs
@@ -343,6 +343,141 @@ mod tests {
     }
 
     // =========================================================================
+    // Deserialization depth limit tests
+    //
+    // These tests verify that deeply nested proof payloads are rejected
+    // during bincode deserialization itself (before verification runs),
+    // preventing stack overflow from maliciously crafted proofs.
+    // =========================================================================
+
+    /// Helper: build a bincode-encoded V0 proof with `depth` levels of nesting.
+    fn build_nested_v0_proof_bytes(depth: usize) -> Vec<u8> {
+        use bincode::Encode;
+
+        // Build innermost layer first, then wrap it
+        let mut layer = MerkOnlyLayerProof {
+            merk_proof: vec![],
+            lower_layers: BTreeMap::new(),
+        };
+        for _ in 0..depth {
+            let mut lower_layers = BTreeMap::new();
+            lower_layers.insert(vec![0u8], layer);
+            layer = MerkOnlyLayerProof {
+                merk_proof: vec![],
+                lower_layers,
+            };
+        }
+        let proof = crate::operations::proof::GroveDBProofV0 {
+            root_layer: layer,
+            prove_options: ProveOptions::default(),
+        };
+        let full_proof = crate::operations::proof::GroveDBProof::V0(proof);
+        let config = bincode::config::standard().with_big_endian();
+        bincode::encode_to_vec(&full_proof, config).expect("encoding should succeed")
+    }
+
+    /// Helper: build a bincode-encoded V1 proof with `depth` levels of nesting.
+    fn build_nested_v1_proof_bytes(depth: usize) -> Vec<u8> {
+        use bincode::Encode;
+
+        let mut layer = LayerProof {
+            merk_proof: ProofBytes::Merk(vec![]),
+            lower_layers: BTreeMap::new(),
+        };
+        for _ in 0..depth {
+            let mut lower_layers = BTreeMap::new();
+            lower_layers.insert(vec![0u8], layer);
+            layer = LayerProof {
+                merk_proof: ProofBytes::Merk(vec![]),
+                lower_layers,
+            };
+        }
+        let proof = crate::operations::proof::GroveDBProofV1 {
+            root_layer: layer,
+            prove_options: ProveOptions::default(),
+        };
+        let full_proof = crate::operations::proof::GroveDBProof::V1(proof);
+        let config = bincode::config::standard().with_big_endian();
+        bincode::encode_to_vec(&full_proof, config).expect("encoding should succeed")
+    }
+
+    #[test]
+    fn deserialization_rejects_v0_proof_exceeding_depth_limit() {
+        let grove_version = GroveVersion::latest();
+        let path_query = make_simple_path_query();
+
+        // Build a proof nested deeper than MAX_PROOF_DEPTH
+        let proof_bytes = build_nested_v0_proof_bytes(MAX_PROOF_DEPTH + 10);
+
+        let result = GroveDb::verify_query(&proof_bytes, &path_query, grove_version);
+        let err =
+            result.expect_err("deserialization should reject proof nested beyond MAX_PROOF_DEPTH");
+        let err_string = format!("{}", err);
+        assert!(
+            err_string.contains("nesting depth exceeded"),
+            "error should mention nesting depth, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn deserialization_rejects_v1_proof_exceeding_depth_limit() {
+        let grove_version = GroveVersion::latest();
+        let path_query = make_simple_path_query();
+
+        let proof_bytes = build_nested_v1_proof_bytes(MAX_PROOF_DEPTH + 10);
+
+        let result = GroveDb::verify_query(&proof_bytes, &path_query, grove_version);
+        let err =
+            result.expect_err("deserialization should reject proof nested beyond MAX_PROOF_DEPTH");
+        let err_string = format!("{}", err);
+        assert!(
+            err_string.contains("nesting depth exceeded"),
+            "error should mention nesting depth, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn deserialization_accepts_v0_proof_at_valid_depth() {
+        // A proof nested at exactly MAX_PROOF_DEPTH should deserialize OK
+        // (verification will fail for other reasons, but not depth).
+        let grove_version = GroveVersion::latest();
+        let path_query = make_simple_path_query();
+
+        let proof_bytes = build_nested_v0_proof_bytes(MAX_PROOF_DEPTH);
+
+        let result = GroveDb::verify_query(&proof_bytes, &path_query, grove_version);
+        // Should fail, but NOT due to nesting depth
+        if let Err(err) = result {
+            let err_string = format!("{}", err);
+            assert!(
+                !err_string.contains("nesting depth exceeded"),
+                "proof at MAX_PROOF_DEPTH should not fail depth check, got: {}",
+                err_string
+            );
+        }
+    }
+
+    #[test]
+    fn deserialization_accepts_v1_proof_at_valid_depth() {
+        let grove_version = GroveVersion::latest();
+        let path_query = make_simple_path_query();
+
+        let proof_bytes = build_nested_v1_proof_bytes(MAX_PROOF_DEPTH);
+
+        let result = GroveDb::verify_query(&proof_bytes, &path_query, grove_version);
+        if let Err(err) = result {
+            let err_string = format!("{}", err);
+            assert!(
+                !err_string.contains("nesting depth exceeded"),
+                "proof at MAX_PROOF_DEPTH should not fail depth check, got: {}",
+                err_string
+            );
+        }
+    }
+
+    // =========================================================================
     // Boundary tests: verify that depth exactly at the limit is accepted
     // and depth one past the limit is rejected.
     // =========================================================================

--- a/grovedb/src/tests/proof_depth_limit_tests.rs
+++ b/grovedb/src/tests/proof_depth_limit_tests.rs
@@ -478,6 +478,183 @@ mod tests {
     }
 
     // =========================================================================
+    // "Too many children" tests: verify that a single layer with more
+    // children than MAX_PROOF_DEPTH is rejected during deserialization.
+    // =========================================================================
+
+    /// Helper: build a V0 proof where the root layer has `num_children`
+    /// direct children (flat, not nested).
+    fn build_wide_v0_proof_bytes(num_children: usize) -> Vec<u8> {
+        use bincode::Encode;
+
+        let mut lower_layers = BTreeMap::new();
+        for i in 0..num_children {
+            lower_layers.insert(
+                (i as u32).to_be_bytes().to_vec(),
+                MerkOnlyLayerProof {
+                    merk_proof: vec![],
+                    lower_layers: BTreeMap::new(),
+                },
+            );
+        }
+        let root_layer = MerkOnlyLayerProof {
+            merk_proof: vec![],
+            lower_layers,
+        };
+        let proof = crate::operations::proof::GroveDBProofV0 {
+            root_layer,
+            prove_options: ProveOptions::default(),
+        };
+        let full_proof = crate::operations::proof::GroveDBProof::V0(proof);
+        let config = bincode::config::standard().with_big_endian();
+        bincode::encode_to_vec(&full_proof, config).expect("encoding should succeed")
+    }
+
+    /// Helper: build a V1 proof where the root layer has `num_children`
+    /// direct children (flat, not nested).
+    fn build_wide_v1_proof_bytes(num_children: usize) -> Vec<u8> {
+        use bincode::Encode;
+
+        let mut lower_layers = BTreeMap::new();
+        for i in 0..num_children {
+            lower_layers.insert(
+                (i as u32).to_be_bytes().to_vec(),
+                LayerProof {
+                    merk_proof: ProofBytes::Merk(vec![]),
+                    lower_layers: BTreeMap::new(),
+                },
+            );
+        }
+        let root_layer = LayerProof {
+            merk_proof: ProofBytes::Merk(vec![]),
+            lower_layers,
+        };
+        let proof = crate::operations::proof::GroveDBProofV1 {
+            root_layer,
+            prove_options: ProveOptions::default(),
+        };
+        let full_proof = crate::operations::proof::GroveDBProof::V1(proof);
+        let config = bincode::config::standard().with_big_endian();
+        bincode::encode_to_vec(&full_proof, config).expect("encoding should succeed")
+    }
+
+    #[test]
+    fn deserialization_rejects_v0_proof_with_too_many_children() {
+        let grove_version = GroveVersion::latest();
+        let path_query = make_simple_path_query();
+
+        let proof_bytes = build_wide_v0_proof_bytes(MAX_PROOF_DEPTH + 1);
+
+        let result = GroveDb::verify_query(&proof_bytes, &path_query, grove_version);
+        let err = result.expect_err("should reject proof with too many children per layer");
+        let err_string = format!("{}", err);
+        assert!(
+            err_string.contains("too many children"),
+            "error should mention too many children, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn deserialization_rejects_v1_proof_with_too_many_children() {
+        let grove_version = GroveVersion::latest();
+        let path_query = make_simple_path_query();
+
+        let proof_bytes = build_wide_v1_proof_bytes(MAX_PROOF_DEPTH + 1);
+
+        let result = GroveDb::verify_query(&proof_bytes, &path_query, grove_version);
+        let err = result.expect_err("should reject proof with too many children per layer");
+        let err_string = format!("{}", err);
+        assert!(
+            err_string.contains("too many children"),
+            "error should mention too many children, got: {}",
+            err_string
+        );
+    }
+
+    // =========================================================================
+    // BorrowDecode path tests: exercise the borrow_decode_with_depth methods.
+    // =========================================================================
+
+    /// Helper: assert that borrow_decode_from_slice fails with an error
+    /// containing the given substring. Uses match instead of expect_err
+    /// because GroveDBProof does not implement Debug.
+    fn assert_borrow_decode_err(proof_bytes: &[u8], expected_substr: &str) {
+        let config = bincode::config::standard().with_big_endian();
+        let result = bincode::borrow_decode_from_slice::<crate::operations::proof::GroveDBProof, _>(
+            proof_bytes,
+            config,
+        );
+        match result {
+            Ok(_) => panic!(
+                "borrow_decode should have failed with error containing '{}'",
+                expected_substr
+            ),
+            Err(err) => {
+                let err_string = format!("{}", err);
+                assert!(
+                    err_string.contains(expected_substr),
+                    "error should contain '{}', got: {}",
+                    expected_substr,
+                    err_string
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn borrow_decode_rejects_v0_proof_exceeding_depth_limit() {
+        let proof_bytes = build_nested_v0_proof_bytes(MAX_PROOF_DEPTH + 10);
+        assert_borrow_decode_err(&proof_bytes, "nesting depth exceeded");
+    }
+
+    #[test]
+    fn borrow_decode_rejects_v1_proof_exceeding_depth_limit() {
+        let proof_bytes = build_nested_v1_proof_bytes(MAX_PROOF_DEPTH + 10);
+        assert_borrow_decode_err(&proof_bytes, "nesting depth exceeded");
+    }
+
+    #[test]
+    fn borrow_decode_accepts_v0_proof_at_valid_depth() {
+        let proof_bytes = build_nested_v0_proof_bytes(5);
+        let config = bincode::config::standard().with_big_endian();
+        let result = bincode::borrow_decode_from_slice::<crate::operations::proof::GroveDBProof, _>(
+            &proof_bytes,
+            config,
+        );
+        assert!(
+            result.is_ok(),
+            "borrow_decode should accept proof at small depth"
+        );
+    }
+
+    #[test]
+    fn borrow_decode_accepts_v1_proof_at_valid_depth() {
+        let proof_bytes = build_nested_v1_proof_bytes(5);
+        let config = bincode::config::standard().with_big_endian();
+        let result = bincode::borrow_decode_from_slice::<crate::operations::proof::GroveDBProof, _>(
+            &proof_bytes,
+            config,
+        );
+        assert!(
+            result.is_ok(),
+            "borrow_decode should accept proof at small depth"
+        );
+    }
+
+    #[test]
+    fn borrow_decode_rejects_v0_proof_with_too_many_children() {
+        let proof_bytes = build_wide_v0_proof_bytes(MAX_PROOF_DEPTH + 1);
+        assert_borrow_decode_err(&proof_bytes, "too many children");
+    }
+
+    #[test]
+    fn borrow_decode_rejects_v1_proof_with_too_many_children() {
+        let proof_bytes = build_wide_v1_proof_bytes(MAX_PROOF_DEPTH + 1);
+        assert_borrow_decode_err(&proof_bytes, "too many children");
+    }
+
+    // =========================================================================
     // Boundary tests: verify that depth exactly at the limit is accepted
     // and depth one past the limit is rejected.
     // =========================================================================


### PR DESCRIPTION
## Summary

- `LayerProof` and `MerkOnlyLayerProof` used `#[derive(Decode)]` with recursive `BTreeMap<Key, Self>` fields, creating unbounded recursion during bincode deserialization
- The existing `MAX_PROOF_DEPTH` check only fires during proof **verification**, which runs **after** deserialization completes
- A crafted proof payload with ~50K nesting levels could crash the verifying process via stack overflow before the depth check ever executes
- Any network peer that can submit a proof for verification could exploit this for denial-of-service

### Fix

Replace derived `Decode` with custom implementations for both `LayerProof` and `MerkOnlyLayerProof` that track recursion depth during deserialization and reject payloads exceeding `MAX_PROOF_DEPTH` (128).

## Test plan

- [x] `deserialization_rejects_v0_proof_exceeding_depth_limit` — verifies V0 proof nested beyond limit is rejected during deserialization
- [x] `deserialization_rejects_v1_proof_exceeding_depth_limit` — same for V1
- [x] `deserialization_accepts_v0_proof_at_valid_depth` — verifies proof at exactly MAX_PROOF_DEPTH deserializes OK
- [x] `deserialization_accepts_v1_proof_at_valid_depth` — same for V1
- [x] All 14 existing proof depth limit tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened proof deserialization to enforce a maximum nesting depth and reject overly deep or too-wide proofs; decoding now consistently respects depth limits and returns clear error messages.

* **Tests**
  * Added extensive tests covering depth-limit enforcement and boundary cases across both proof versions and multiple deserialization paths to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->