### PR TITLE
docs: document emptiness check limitation for same-batch inserts

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -3390,6 +3390,25 @@ impl GroveDb {
                         // Standard Merk trees: use is_empty_tree_except to
                         // account for other delete ops in the same batch that
                         // target this subtree.
+                        //
+                        // Limitation: this only considers Delete/DeleteTree ops
+                        // when building the exception set. It does NOT account
+                        // for Insert ops in the same batch that would add new
+                        // keys to this subtree. In theory, a batch could
+                        // contain deletes for every existing key (making the
+                        // tree appear empty) while also containing inserts that
+                        // add new keys, and this check would still report the
+                        // tree as empty.
+                        //
+                        // This is safe in practice because the consistency
+                        // check (`verify_consistency_of_operations`), which
+                        // runs before this code, detects "inserts under a
+                        // deleted path" and rejects such batches. The only way
+                        // to reach this code with conflicting insert + delete-
+                        // tree ops is by setting
+                        // `disable_operation_consistency_check = true`, in
+                        // which case the caller has accepted responsibility for
+                        // ensuring no such conflicts exist.
                         let batch_deleted_keys = ops
                             .iter()
                             .filter_map(|other_op| match &other_op.op {
@@ -3726,6 +3745,17 @@ impl GroveDb {
                         );
                         element.non_merk_entry_count().unwrap_or(0) == 0
                     } else {
+                        // Standard Merk trees: use is_empty_tree_except to
+                        // account for other delete ops in the same batch that
+                        // target this subtree.
+                        //
+                        // Limitation: this only considers Delete/DeleteTree ops
+                        // when building the exception set. It does NOT account
+                        // for Insert ops in the same batch that would add new
+                        // keys to this subtree. See the matching comment in
+                        // `apply_batch_with_element_flags_update` for details
+                        // on why this is safe in practice (the consistency
+                        // check guards against this scenario).
                         let batch_deleted_keys = ops
                             .iter()
                             .filter_map(|other_op| match &other_op.op {

--- a/grovedb/src/batch/options.rs
+++ b/grovedb/src/batch/options.rs
@@ -44,6 +44,16 @@ pub struct BatchApplyOptions {
     /// intentionally relies on last-op-wins semantics (e.g., an idempotent
     /// replay scenario). In all other cases, leave this set to `false` to
     /// catch accidental conflicts early.
+    ///
+    /// # Emptiness check limitation
+    ///
+    /// The pre-deletion emptiness check for `DeleteTree` ops uses
+    /// `is_empty_tree_except` which only accounts for Delete/DeleteTree ops
+    /// in the same batch -- it does not consider Insert ops that would add
+    /// new keys to the subtree. With the consistency check enabled (default),
+    /// such conflicting batches are rejected before the emptiness check runs.
+    /// When this flag is `true`, the caller must ensure no batch contains
+    /// both inserts into a subtree and a `DeleteTree` of that subtree.
     pub disable_operation_consistency_check: bool,
     /// Base root storage is free
     pub base_root_storage_is_free: bool,


### PR DESCRIPTION
## Summary

- Documents that the pre-deletion emptiness check for `DeleteTree` ops only considers Delete/DeleteTree ops when building the exception set — it does not account for Insert ops that would add new keys to the subtree
- This is safe in practice because the consistency check (`verify_consistency_of_operations`) rejects batches with conflicting insert + delete-tree ops before the emptiness check runs
- The limitation only applies when `disable_operation_consistency_check = true`, in which case the caller has accepted responsibility for ensuring no such conflicts exist
- Added documentation comments at both emptiness check sites in `batch/mod.rs` and on the `disable_operation_consistency_check` option in `batch/options.rs`

## Test plan

- [x] Documentation-only change — no behavioral changes
- [x] `cargo build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)