### PR TITLE
docs: document non-atomic delete cost computation (TOCTOU)

### DIFF
--- a/merk/src/merk/clear.rs
+++ b/merk/src/merk/clear.rs
@@ -7,7 +7,12 @@ impl<'db, S> Merk<S>
 where
     S: StorageContext<'db>,
 {
-    /// Deletes tree data
+    /// Deletes all tree data (nodes) from storage.
+    ///
+    /// Deletes are issued with `cost_info: None`, so freed-bytes cost is
+    /// estimated from committed DB state. This is acceptable for a
+    /// bulk-clear operation. See `RocksDbStorage::continue_write_batch`
+    /// for the full rationale.
     pub fn clear(&mut self) -> CostResult<(), Error> {
         let mut cost = OperationCost::default();
 
@@ -17,7 +22,6 @@ where
         let mut to_delete = self.storage.new_batch();
         while iter.valid().unwrap_add_cost(&mut cost) {
             if let Some(key) = iter.key().unwrap_add_cost(&mut cost) {
-                // todo: deal with cost reimbursement
                 to_delete.delete(key, None);
             }
             iter.next().unwrap_add_cost(&mut cost);

--- a/merk/src/merk/meta.rs
+++ b/merk/src/merk/meta.rs
@@ -32,6 +32,11 @@ impl<'db, S: StorageContext<'db>> Merk<S> {
     }
 
     /// Delete metadata under `key`.
+    ///
+    /// Uses `cost_info: None`, so freed-bytes cost is estimated from
+    /// committed DB state. Metadata is not part of the authenticated
+    /// tree structure and has no associated storage fees, so cost
+    /// precision is not required here.
     pub fn delete_meta(&mut self, key: &[u8]) -> CostResult<(), Error> {
         self.storage
             .delete_meta(key, None)

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -554,20 +554,25 @@ where
         res
     }
 
-    /// Sets the tree's top node (base) key
+    /// Sets the tree's top node (base) key.
+    ///
     /// The base root key should only be used if the Merk tree is independent
-    /// Meaning that it doesn't have a parent Merk
+    /// (i.e., it does not have a parent Merk).
+    ///
+    /// When clearing the root key (\`key\` is \`None\`), the delete is issued
+    /// with \`cost_info: None\` so freed-bytes cost is estimated from
+    /// committed DB state. This is acceptable because root-key storage is
+    /// treated as free in the default configuration
+    /// (\`base_root_storage_is_free: true\`).
     pub fn set_base_root_key(&mut self, key: Option<Vec<u8>>) -> CostResult<(), Error> {
         if let Some(key) = key {
             self.storage
                 .put_root(ROOT_KEY_KEY, key.as_slice(), None)
-                .map_err(Error::StorageError) // todo: maybe
-                                              // change None?
+                .map_err(Error::StorageError)
         } else {
             self.storage
                 .delete_root(ROOT_KEY_KEY, None)
-                .map_err(Error::StorageError) // todo: maybe
-                                              // change None?
+                .map_err(Error::StorageError)
         }
     }
 

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -214,9 +214,41 @@ impl RocksDbStorage {
             .map_ok(|operation_cost| (db_batch, operation_cost))
     }
 
-    /// Continues the write batch, returning pending costs
+    /// Continues the write batch, returning pending costs.
+    ///
     /// Pending costs are costs that should only be applied after successful
     /// write of the write batch.
+    ///
+    /// # Delete cost computation when `cost_info` is `None`
+    ///
+    /// When a delete operation lacks pre-computed `cost_info`, the freed-bytes
+    /// cost is estimated by reading the current value from **committed**
+    /// database state (`self.db.get()`), not from the in-flight batch or
+    /// transaction. This is a known TOCTOU-style limitation in cost
+    /// accounting only -- it does **not** affect data integrity.
+    ///
+    /// In practice this is acceptable because:
+    ///
+    /// 1. The main tree-node delete path (Merk commit) **always** provides
+    ///    `Some(cost_info)` via `KeyUpdates::deleted_keys`, so the fallback
+    ///    never runs for the performance-critical and cost-sensitive path.
+    ///
+    /// 2. The `None` fallback is only reached by cleanup/utility operations:
+    ///    - `Merk::clear()` and `PrefixedRocksDbTransactionContext::clear()`
+    ///      (subtree deletion)
+    ///    - `Merk::delete_meta()` (metadata cleanup)
+    ///    - `Merk::set_base_root_key(None)` (root key removal)
+    ///    - `GroveDb::delete_aux()` when the caller omits cost info
+    ///    These operations intentionally trade cost precision for simplicity.
+    ///
+    /// 3. The `StorageBatch` put-wins semantics (see [`StorageBatch::delete`])
+    ///    prevents the worst-case scenario where a same-batch put+delete for
+    ///    the same key would make the committed-state read completely stale.
+    ///
+    /// 4. If the key was inserted within the current (uncommitted) transaction
+    ///    but is not yet committed, `self.db.get()` returns `None` / the old
+    ///    committed value, causing freed bytes to be **underestimated** -- a
+    ///    safe direction for cost accounting.
     pub fn continue_write_batch(
         &self,
         db_batch: &mut WriteBatchWithTransaction<true>,
@@ -312,7 +344,8 @@ impl RocksDbStorage {
                 AbstractBatchOperation::Delete { key, cost_info } => {
                     db_batch.delete(&key);
 
-                    // TODO: fix not atomic freed size computation
+                    // Non-atomic freed-size fallback: reads committed state.
+                    // See method-level doc comment for rationale.
 
                     if let Some(key_value_removed_bytes) = cost_info {
                         cost.seek_count += 1;
@@ -329,7 +362,6 @@ impl RocksDbStorage {
                         .unwrap_or(0);
                         cost.storage_loaded_bytes += value_len as u64;
                         let key_len = key.len() as u32;
-                        // todo: improve deletion
                         pending_costs.storage_cost.removed_bytes += BasicStorageRemoval(
                             key_len
                                 + value_len
@@ -341,7 +373,8 @@ impl RocksDbStorage {
                 AbstractBatchOperation::DeleteAux { key, cost_info } => {
                     db_batch.delete_cf(cf_aux(&self.db), &key);
 
-                    // TODO: fix not atomic freed size computation
+                    // Non-atomic freed-size fallback: reads committed state.
+                    // See method-level doc comment for rationale.
                     if let Some(key_value_removed_bytes) = cost_info {
                         cost.seek_count += 1;
                         pending_costs.storage_cost.removed_bytes +=
@@ -357,7 +390,6 @@ impl RocksDbStorage {
                         cost.storage_loaded_bytes += value_len as u64;
 
                         let key_len = key.len() as u32;
-                        // todo: improve deletion
                         pending_costs.storage_cost.removed_bytes += BasicStorageRemoval(
                             key_len
                                 + value_len
@@ -369,7 +401,8 @@ impl RocksDbStorage {
                 AbstractBatchOperation::DeleteRoot { key, cost_info } => {
                     db_batch.delete_cf(cf_roots(&self.db), &key);
 
-                    // TODO: fix not atomic freed size computation
+                    // Non-atomic freed-size fallback: reads committed state.
+                    // See method-level doc comment for rationale.
                     if let Some(key_value_removed_bytes) = cost_info {
                         cost.seek_count += 1;
                         pending_costs.storage_cost.removed_bytes +=
@@ -387,7 +420,6 @@ impl RocksDbStorage {
                         cost.storage_loaded_bytes += value_len as u64;
 
                         let key_len = key.len() as u32;
-                        // todo: improve deletion
                         pending_costs.storage_cost.removed_bytes += BasicStorageRemoval(
                             key_len
                                 + value_len
@@ -399,7 +431,8 @@ impl RocksDbStorage {
                 AbstractBatchOperation::DeleteMeta { key, cost_info } => {
                     db_batch.delete_cf(cf_meta(&self.db), &key);
 
-                    // TODO: fix not atomic freed size computation
+                    // Non-atomic freed-size fallback: reads committed state.
+                    // See method-level doc comment for rationale.
                     if let Some(key_value_removed_bytes) = cost_info {
                         cost.seek_count += 1;
                         pending_costs.storage_cost.removed_bytes +=
@@ -417,7 +450,6 @@ impl RocksDbStorage {
                         cost.storage_loaded_bytes += value_len as u64;
 
                         let key_len = key.len() as u32;
-                        // todo: improve deletion
                         pending_costs.storage_cost.removed_bytes += BasicStorageRemoval(
                             key_len
                                 + value_len

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -239,7 +239,7 @@ impl RocksDbStorage {
     ///    - `Merk::delete_meta()` (metadata cleanup)
     ///    - `Merk::set_base_root_key(None)` (root key removal)
     ///    - `GroveDb::delete_aux()` when the caller omits cost info
-    ///    These operations intentionally trade cost precision for simplicity.
+    ///      These operations intentionally trade cost precision for simplicity.
     ///
     /// 3. The `StorageBatch` put-wins semantics (see [`StorageBatch::delete`])
     ///    prevents the worst-case scenario where a same-batch put+delete for

--- a/storage/src/rocksdb_storage/storage_context/context_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_tx.rs
@@ -70,6 +70,13 @@ impl<'db> PrefixedRocksDbTransactionContext<'db> {
 
     /// Clears all data in the default (data) column family for this prefix.
     /// Auxiliary, roots, and meta column families are **not** affected.
+    ///
+    /// Note: deletes are issued with `cost_info: None`, so freed-bytes cost
+    /// is estimated from committed DB state rather than pre-computed. This is
+    /// acceptable for a bulk-clear operation where precise per-key cost
+    /// tracking is not required. See
+    /// [`RocksDbStorage::continue_write_batch`](super::super::storage::RocksDbStorage::continue_write_batch)
+    /// for the full rationale.
     pub fn clear(&mut self) -> CostResult<(), Error> {
         let mut cost = OperationCost::default();
 
@@ -78,11 +85,7 @@ impl<'db> PrefixedRocksDbTransactionContext<'db> {
 
         while iter.valid().unwrap_add_cost(&mut cost) {
             if let Some(key) = iter.key().unwrap_add_cost(&mut cost) {
-                cost_return_on_error!(
-                    &mut cost,
-                    // todo: calculate cost
-                    self.delete(key, None)
-                );
+                cost_return_on_error!(&mut cost, self.delete(key, None));
             }
             iter.next().unwrap_add_cost(&mut cost);
         }


### PR DESCRIPTION
## Summary

- Documents the non-atomic freed-size cost computation in `RocksDbStorage::continue_write_batch` as a known design limitation rather than a bug
- Adds comprehensive doc comment to `continue_write_batch` explaining the 4 reasons the TOCTOU-style limitation is acceptable
- Replaces all `TODO: fix not atomic freed size computation` and `todo: improve deletion` comments with references to the rationale
- Documents `cost_info: None` usage at each call site (`Merk::clear`, `Merk::delete_meta`, `Merk::set_base_root_key`, `PrefixedRocksDbTransactionContext::clear`)

## Investigation findings

The `continue_write_batch` method reads committed DB state (`self.db.get()`) to estimate freed bytes when a delete operation has no pre-computed `cost_info`. Investigation confirmed this is **not exploitable** because:

1. **Main path always provides cost**: `Merk::commit()` always passes `Some(storage_cost)` via `KeyUpdates::deleted_keys`
2. **None fallback is cleanup-only**: Only reached by `clear()`, `delete_meta()`, `set_base_root_key(None)`, and `delete_aux()` without cost info
3. **Put-wins semantics**: `StorageBatch::delete()` drops deletes when a put for the same key already exists in the batch
4. **Safe direction**: Underestimation of freed bytes (when key exists only in uncommitted transaction) is the safe direction for cost accounting

## Test plan

- [x] `cargo check -p grovedb-storage -p grovedb-merk` passes
- [x] `cargo test -p grovedb-storage --features rocksdb_storage` passes (27 tests)
- [x] Pre-commit hooks pass (cargo fmt, typos, etc.)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)