### PR TITLE
docs: document find_subtrees stale state limitation during batch delete

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -3545,6 +3545,15 @@ impl GroveDb {
         // but the child subtree's storage (and any nested subtrees) remains.
         // We use find_subtrees to recursively discover all nested subtrees
         // and clear their storage, matching the non-batch delete behavior.
+        //
+        // NOTE: find_subtrees reads from the committed transaction state
+        // (without the pending storage_batch), so any subtrees *inserted*
+        // by this same batch are invisible to it.  This is safe because
+        // verify_consistency_of_operations (enabled by default) rejects
+        // batches that insert under a path being deleted.  If the caller
+        // disables the consistency check, inserts under deleted paths can
+        // cause orphaned storage prefixes.  See the doc comment on
+        // BatchApplyOptions::disable_operation_consistency_check.
         for child_path in &merk_delete_paths {
             let child_subtree_path: SubtreePath<Vec<u8>> = child_path.as_slice().into();
             let subtrees_paths = cost_return_on_error!(
@@ -3924,6 +3933,15 @@ impl GroveDb {
 
         // Clean up storage for deleted standard Merk subtrees (same as
         // apply_batch_with_element_flags_update).
+        //
+        // NOTE: find_subtrees reads from the committed transaction state
+        // (without the pending storage_batch), so any subtrees *inserted*
+        // by this same batch are invisible to it.  This is safe because
+        // verify_consistency_of_operations (enabled by default) rejects
+        // batches that insert under a path being deleted.  If the caller
+        // disables the consistency check, inserts under deleted paths can
+        // cause orphaned storage prefixes.  See the doc comment on
+        // BatchApplyOptions::disable_operation_consistency_check.
         for child_path in &merk_delete_paths {
             let child_subtree_path: SubtreePath<Vec<u8>> = child_path.as_slice().into();
             let subtrees_paths = cost_return_on_error!(

--- a/grovedb/src/batch/options.rs
+++ b/grovedb/src/batch/options.rs
@@ -44,6 +44,23 @@ pub struct BatchApplyOptions {
     /// intentionally relies on last-op-wins semantics (e.g., an idempotent
     /// replay scenario). In all other cases, leave this set to `false` to
     /// catch accidental conflicts early.
+    ///
+    /// # Warning -- potential storage leak on insert-under-delete
+    ///
+    /// When set to `true`, the consistency check that rejects inserts below
+    /// deleted paths is also skipped. If a batch both inserts a subtree and
+    /// deletes an ancestor of that subtree, the post-`apply_body` cleanup
+    /// uses [`GroveDb::find_subtrees`](crate::GroveDb::find_subtrees) to
+    /// discover nested subtrees for storage removal. However,
+    /// `find_subtrees` reads from the committed transaction state (without
+    /// the pending `StorageBatch`), so subtrees created by the same batch
+    /// are invisible to it. This means the newly-inserted subtree's storage
+    /// prefix will not be cleaned up, resulting in orphaned data in the
+    /// underlying store.
+    ///
+    /// With the consistency check enabled (the default), such batches are
+    /// rejected before `apply_body` runs, so this stale-state window is
+    /// never reachable.
     pub disable_operation_consistency_check: bool,
     /// Base root storage is free
     pub base_root_storage_is_free: bool,

--- a/grovedb/src/operations/auxiliary.rs
+++ b/grovedb/src/operations/auxiliary.rs
@@ -133,6 +133,21 @@ impl GroveDb {
     /// Finds keys which are trees for a given subtree recursively.
     /// One element means a key of a `merk`, n > 1 elements mean relative path
     /// for a deeply nested subtree.
+    ///
+    /// # Storage batch visibility
+    ///
+    /// This method reads directly from the transaction (passing `None` for
+    /// the storage batch parameter), so it only sees data that has been
+    /// **committed** to the transaction. Any writes staged in a pending
+    /// `StorageBatch` (e.g., from `apply_body` during batch processing)
+    /// are invisible.
+    ///
+    /// In practice this is safe because the batch consistency check
+    /// ([`crate::batch::QualifiedGroveDbOp::verify_consistency_of_operations`])
+    /// rejects batches that insert subtrees under paths being deleted.
+    /// The stale-state window only matters if the consistency check is
+    /// bypassed via
+    /// [`BatchApplyOptions::disable_operation_consistency_check`](crate::batch::BatchApplyOptions::disable_operation_consistency_check).
     pub fn find_subtrees<B: AsRef<[u8]>>(
         &self,
         path: &SubtreePath<B>,


### PR DESCRIPTION
## Summary

- `find_subtrees` reads from committed transaction state only (passes `None` for the storage batch), so subtrees inserted by the same batch are invisible to it during `DeleteTree` cleanup
- This is safe in practice because `verify_consistency_of_operations` (enabled by default) rejects batches that insert under paths being deleted
- The stale-state window is only reachable when `disable_operation_consistency_check = true`
- Added documentation at:
  - `disable_operation_consistency_check` field: warning about potential storage leak
  - `find_subtrees` method: storage batch visibility section
  - Both `find_subtrees` call sites in batch processing: NOTE comments

## Test plan

- [x] Documentation-only change — no behavioral changes
- [x] All existing batch validation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)