### PR TITLE
ci: fix rust-cache to cache llvm-cov target directory

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -50,13 +50,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "false"
-      - uses: mozilla-actions/sccache-action@v0.0.9
+          # cargo-llvm-cov uses target/llvm-cov-target/ instead of target/
+          workspaces: ". -> target/llvm-cov-target"
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@cargo-nextest
       - name: Run tests (shard ${{ matrix.partition }}/3)
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: sccache
         run: >
           cargo llvm-cov nextest
           --workspace


### PR DESCRIPTION
## Summary
- Configure `Swatinem/rust-cache` with `workspaces: ". -> target/llvm-cov-target"` so it caches the correct directory used by `cargo-llvm-cov`
- Remove sccache from the test job since `cargo-llvm-cov` overrides `RUSTC_WRAPPER` for instrumentation, making sccache ineffective for coverage builds
- sccache remains on the linting job where it works correctly

## Problem

`cargo-llvm-cov` uses `target/llvm-cov-target/` as its target directory to avoid mixing instrumented and non-instrumented builds. However, `Swatinem/rust-cache` defaults to caching `target/`, meaning the test builds were never benefiting from cross-run caching. Every CI run compiled the full workspace from scratch.

Additionally, sccache was configured on the test job but was ineffective because `cargo-llvm-cov` needs to control `RUSTC_WRAPPER` itself for instrumentation.

## Expected Impact

After this change, the second and subsequent pushes to a PR should see significantly faster compilation in the test job, as `rust-cache` will now restore the correct build artifacts from the previous run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)