### PR TITLE
ci: add shared build step to avoid 3x compilation

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -31,9 +31,40 @@ jobs:
               - '**/Cargo.toml'
               - 'Cargo.lock'
 
+  build-test:
+    name: Build Tests (instrumented)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.any-code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: "false"
+          # cargo-llvm-cov uses target/llvm-cov-target/ instead of target/
+          workspaces: ". -> target/llvm-cov-target"
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@cargo-nextest
+      - name: Build test binaries with coverage instrumentation
+        run: >
+          cargo llvm-cov nextest
+          --no-run
+          --workspace
+          --all-features
+      - name: Save instrumented build artifacts
+        uses: actions/cache/save@v4
+        with:
+          path: target/llvm-cov-target
+          key: llvm-cov-build-${{ github.sha }}-${{ hashFiles('**/Cargo.lock') }}
+
   test:
     name: Test (${{ matrix.partition }}/3)
-    needs: detect-changes
+    needs: [detect-changes, build-test]
     if: needs.detect-changes.outputs.any-code == 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -47,16 +78,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: "false"
-      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@cargo-nextest
+      - name: Restore instrumented build artifacts
+        uses: actions/cache/restore@v4
+        with:
+          path: target/llvm-cov-target
+          key: llvm-cov-build-${{ github.sha }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Run tests (shard ${{ matrix.partition }}/3)
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: sccache
         run: >
           cargo llvm-cov nextest
           --workspace


### PR DESCRIPTION
## Summary
- Add a `build-test` job that compiles all test binaries once with `cargo llvm-cov nextest --no-run`
- Share the instrumented build artifacts with the 3 test partitions via `actions/cache`
- Test partitions restore pre-built artifacts and only run their shard of tests
- Remove sccache from test jobs (ineffective with `cargo-llvm-cov`)
- Configure `rust-cache` to cache `target/llvm-cov-target/` for cross-run caching

## Problem

Currently, all 3 test partitions independently compile the full workspace with llvm-cov instrumentation (~7 minutes each). This means 3x redundant compilations per CI run (~21 minutes of total compute time for compilation alone).

## Solution

```
Before:  partition 1 ─── [compile 7m] ─── [test]
         partition 2 ─── [compile 7m] ─── [test]    (all parallel)
         partition 3 ─── [compile 7m] ─── [test]

After:   build-test ─── [compile 7m] ─── [cache save]
         partition 1 ─── [cache restore] ─── [test]
         partition 2 ─── [cache restore] ─── [test]  (parallel after build)
         partition 3 ─── [cache restore] ─── [test]
```

**Trade-off**: Wall-clock time increases slightly (build step is sequential before test shards), but total compute time drops from ~21 to ~7 minutes of compilation. Subsequent pushes to the same PR benefit from `rust-cache` making the build step incremental.

## Test plan
- [ ] Verify `build-test` job completes successfully
- [ ] Verify all 3 test partitions restore cache and run without recompilation
- [ ] Verify coverage reports are still uploaded correctly to Codecov
- [ ] Compare total CI time vs baseline on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured continuous integration workflow to improve test execution efficiency through optimized partitioning and artifact caching.
  * Enhanced code coverage instrumentation and reporting for better visibility into code quality metrics during development cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->