### PR TITLE
docs: document why Owner::own_result poisoning is safe

### DIFF
--- a/merk/src/owner.rs
+++ b/merk/src/owner.rs
@@ -67,12 +67,28 @@ impl<T> Owner<T> {
     /// The function must return a result of the same type (the same value, or a
     /// new value to take its place).
     ///
-    /// # Warning
+    /// # Poisoning behavior
     ///
     /// If `f` returns `Err`, the contained value has been consumed and the
     /// `Owner` is left in a poisoned state (`inner = None`). Any subsequent
     /// access (deref, `own`, `own_return`, etc.) will panic. Callers **must**
     /// not use the `Owner` after `own_result` returns an error.
+    ///
+    /// # Why this is safe in practice (audit note)
+    ///
+    /// All call sites are in [`Walker`](crate::tree::walk::Walker) methods
+    /// (`walk`, `walk_expect`, `attach`, `put_value`, etc.) where `own_result`
+    /// is called on `self.tree` (an `Owner<TreeNode>`). On every error path
+    /// the `Walker` is dropped immediately — it is never accessed after
+    /// `own_result` returns `Err`. This means the poisoned `Owner` is always
+    /// dropped without further use, so the panic is unreachable in practice.
+    ///
+    /// Changing the signature to `FnOnce(T) -> Result<T, (T, E)>` to force
+    /// value recovery was evaluated and rejected: it adds complexity to every
+    /// closure for no practical benefit, since the ownership pattern already
+    /// guarantees safe drop-on-error. If new call sites are added in the
+    /// future, they must follow the same pattern of not accessing the `Owner`
+    /// after an error.
     pub fn own_result<F, E>(&mut self, f: F) -> Result<(), E>
     where
         F: FnOnce(T) -> Result<T, E>,


### PR DESCRIPTION
## Summary
- Document in `Owner::own_result` why the poisoning behavior is not exploitable and does not need to be fixed
- Replaces the closed PR #621 which attempted to change the signature to force value recovery

## Context

A security audit flagged that `Owner::own_result` leaves the `Owner` in a poisoned state when the closure returns `Err`. Investigation confirmed this is **not exploitable**:

- All call sites are in `Walker` methods (`walk`, `walk_expect`, `attach`, `put_value`, etc.)
- On every error path, the `Walker` (which owns the `Owner<TreeNode>`) is dropped immediately
- The poisoned `Owner` is never accessed after `own_result` returns `Err`
- The panic is unreachable in practice

Changing the signature to `FnOnce(T) -> Result<T, (T, E)>` was evaluated and rejected — it adds complexity to every closure for no practical benefit.

This PR adds an "audit note" section to the doc comment so future audits don't re-investigate or attempt to fix this non-issue.

## Test plan
- [x] Existing tests pass (no code changes, only doc comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)