### PR TITLE
ci: fix build step

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -34,9 +34,7 @@ jobs:
   build-test:
     name: Build Tests (instrumented)
     needs: detect-changes
-    if: >-
-      needs.detect-changes.outputs.any-code == 'true'
-      && !contains(github.event.pull_request.labels.*.name, 'skip-tests')
+    if: needs.detect-changes.outputs.any-code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -67,9 +65,7 @@ jobs:
   test:
     name: Test (${{ matrix.partition }}/3)
     needs: [detect-changes, build-test]
-    if: >-
-      needs.detect-changes.outputs.any-code == 'true'
-      && !contains(github.event.pull_request.labels.*.name, 'skip-tests')
+    if: needs.detect-changes.outputs.any-code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -34,7 +34,9 @@ jobs:
   build-test:
     name: Build Tests (instrumented)
     needs: detect-changes
-    if: needs.detect-changes.outputs.any-code == 'true'
+    if: >-
+      needs.detect-changes.outputs.any-code == 'true'
+      && !contains(github.event.pull_request.labels.*.name, 'skip-tests')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,10 +54,10 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
       - name: Build test binaries with coverage instrumentation
         run: >
-          cargo llvm-cov nextest
-          --no-run
+          cargo llvm-cov build
           --workspace
           --all-features
+          --tests
       - name: Save instrumented build artifacts
         uses: actions/cache/save@v4
         with:
@@ -65,7 +67,9 @@ jobs:
   test:
     name: Test (${{ matrix.partition }}/3)
     needs: [detect-changes, build-test]
-    if: needs.detect-changes.outputs.any-code == 'true'
+    if: >-
+      needs.detect-changes.outputs.any-code == 'true'
+      && !contains(github.event.pull_request.labels.*.name, 'skip-tests')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Fix `cargo llvm-cov nextest --no-run` which is deprecated and fails with "not found *.profraw files"

## Bug fix

The build step introduced in #625 used `cargo llvm-cov nextest --no-run`, which is deprecated. It fails because it tries to merge profraw files that don't exist (no tests were run):

```
warning: --no-run is deprecated, use `cargo llvm-cov report` subcommand instead
error: failed to merge profile data: not found *.profraw files
```

Replaced with `cargo llvm-cov build --workspace --all-features --tests`, which correctly builds instrumented test binaries without running them.

## Test plan
- [ ] Verify build-test job completes successfully
- [ ] Verify test partitions restore cache and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)