### PR TITLE
ci: revert shared build step

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -31,11 +31,15 @@ jobs:
               - '**/Cargo.toml'
               - 'Cargo.lock'
 
-  build-test:
-    name: Build Tests (instrumented)
+  test:
+    name: Test (${{ matrix.partition }}/3)
     needs: detect-changes
     if: needs.detect-changes.outputs.any-code == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,41 +54,6 @@ jobs:
           workspaces: ". -> target/llvm-cov-target"
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@cargo-nextest
-      - name: Build test binaries with coverage instrumentation
-        run: >
-          cargo llvm-cov nextest
-          --no-run
-          --workspace
-          --all-features
-      - name: Save instrumented build artifacts
-        uses: actions/cache/save@v4
-        with:
-          path: target/llvm-cov-target
-          key: llvm-cov-build-${{ github.sha }}-${{ hashFiles('**/Cargo.lock') }}
-
-  test:
-    name: Test (${{ matrix.partition }}/3)
-    needs: [detect-changes, build-test]
-    if: needs.detect-changes.outputs.any-code == 'true'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        partition: [1, 2, 3]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@cargo-nextest
-      - name: Restore instrumented build artifacts
-        uses: actions/cache/restore@v4
-        with:
-          path: target/llvm-cov-target
-          key: llvm-cov-build-${{ github.sha }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Run tests (shard ${{ matrix.partition }}/3)
         run: >
           cargo llvm-cov nextest


### PR DESCRIPTION
## Summary
- Revert #625 (shared build step)

## Why

The `cargo llvm-cov nextest --no-run` command used in the build step is deprecated and fails. The alternative `cargo llvm-cov build --tests` may use different compilation flags than `cargo llvm-cov nextest`, causing the test partitions to recompile everything anyway — making the build step pure overhead.

The rust-cache fix from #624 (caching `target/llvm-cov-target`) is retained and provides cross-run caching. The first push to a PR compiles 3x in parallel, but subsequent pushes benefit from incremental compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)