### PR TITLE
fix: per-op DeleteTree emptiness check via IsSubtreeNonEmpty enum

### DIFF
--- a/docs/book/src/batch-operations.md
+++ b/docs/book/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parameterized by tree type
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/src/batch-operations.md
+++ b/docs/book/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },
@@ -37,6 +37,17 @@ pub enum NonMerkTreeMeta {
     MmrTree { mmr_size: u64 },
     BulkAppendTree { total_count: u64, chunk_power: u8 },
     DenseTree { count: u16, height: u8 },
+}
+```
+
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
 }
 ```
 

--- a/docs/book/translations/ar/src/batch-operations.md
+++ b/docs/book/translations/ar/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 كل عملية تُغلَّف في `QualifiedGroveDbOp` يتضمن المسار:
 
 ```rust

--- a/docs/book/translations/ar/src/batch-operations.md
+++ b/docs/book/translations/ar/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parameterized by tree type
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/ar/src/batch-operations.md
+++ b/docs/book/translations/ar/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/cs/src/batch-operations.md
+++ b/docs/book/translations/cs/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Kazda operace je obalena v `QualifiedGroveDbOp`, ktery zahrnuje cestu:
 
 ```rust

--- a/docs/book/translations/cs/src/batch-operations.md
+++ b/docs/book/translations/cs/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parametrizovano typem stromu
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parametrizovano typem stromu
 
     // Operace pridavani ne-Merk stromu (orientovane na uzivatele):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/cs/src/batch-operations.md
+++ b/docs/book/translations/cs/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parametrizovano typem stromu
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Operace pridavani ne-Merk stromu (orientovane na uzivatele):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/de/src/batch-operations.md
+++ b/docs/book/translations/de/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Jede Operation wird in ein `QualifiedGroveDbOp` verpackt, das den Pfad enthält:
 
 ```rust

--- a/docs/book/translations/de/src/batch-operations.md
+++ b/docs/book/translations/de/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parametrisiert nach Baumtyp
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Nicht-Merk-Baum-Anhängeoperationen (benutzerseitig):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/de/src/batch-operations.md
+++ b/docs/book/translations/de/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parametrisiert nach Baumtyp
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parametrisiert nach Baumtyp
 
     // Nicht-Merk-Baum-Anhängeoperationen (benutzerseitig):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/es/src/batch-operations.md
+++ b/docs/book/translations/es/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parameterized by tree type
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/es/src/batch-operations.md
+++ b/docs/book/translations/es/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/es/src/batch-operations.md
+++ b/docs/book/translations/es/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Cada operación se envuelve en un `QualifiedGroveDbOp` que incluye la ruta:
 
 ```rust

--- a/docs/book/translations/fr/src/batch-operations.md
+++ b/docs/book/translations/fr/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Chaque opération est enveloppée dans un `QualifiedGroveDbOp` qui inclut le chemin :
 
 ```rust

--- a/docs/book/translations/fr/src/batch-operations.md
+++ b/docs/book/translations/fr/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parameterized by tree type
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/fr/src/batch-operations.md
+++ b/docs/book/translations/fr/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/id/src/batch-operations.md
+++ b/docs/book/translations/id/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Setiap operasi dibungkus dalam `QualifiedGroveDbOp` yang mencakup path:
 
 ```rust

--- a/docs/book/translations/id/src/batch-operations.md
+++ b/docs/book/translations/id/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Diparameterisasi berdasarkan tipe pohon
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Operasi append pohon non-Merk (menghadap pengguna):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/id/src/batch-operations.md
+++ b/docs/book/translations/id/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Diparameterisasi berdasarkan tipe pohon
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Diparameterisasi berdasarkan tipe pohon
 
     // Operasi append pohon non-Merk (menghadap pengguna):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/it/src/batch-operations.md
+++ b/docs/book/translations/it/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parametrizzato per tipo di albero
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parametrizzato per tipo di albero
 
     // Operazioni di append per alberi non-Merk (rivolte all'utente):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/it/src/batch-operations.md
+++ b/docs/book/translations/it/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Ogni operazione e avvolta in un `QualifiedGroveDbOp` che include il percorso:
 
 ```rust

--- a/docs/book/translations/it/src/batch-operations.md
+++ b/docs/book/translations/it/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parametrizzato per tipo di albero
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Operazioni di append per alberi non-Merk (rivolte all'utente):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/ja/src/batch-operations.md
+++ b/docs/book/translations/ja/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parameterized by tree type
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/ja/src/batch-operations.md
+++ b/docs/book/translations/ja/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/ja/src/batch-operations.md
+++ b/docs/book/translations/ja/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 各操作はパスを含む `QualifiedGroveDbOp` でラップされます：
 
 ```rust

--- a/docs/book/translations/ko/src/batch-operations.md
+++ b/docs/book/translations/ko/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // 트리 타입으로 매개변수화
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // 트리 타입으로 매개변수화
 
     // 비-Merk 트리 추가 연산 (사용자 대면):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/ko/src/batch-operations.md
+++ b/docs/book/translations/ko/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // 트리 타입으로 매개변수화
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // 비-Merk 트리 추가 연산 (사용자 대면):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/ko/src/batch-operations.md
+++ b/docs/book/translations/ko/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 각 연산은 경로를 포함하는 `QualifiedGroveDbOp`으로 래핑됩니다:
 
 ```rust

--- a/docs/book/translations/pl/src/batch-operations.md
+++ b/docs/book/translations/pl/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Kazda operacja jest opakowana w `QualifiedGroveDbOp` zawierajacy sciezke:
 
 ```rust

--- a/docs/book/translations/pl/src/batch-operations.md
+++ b/docs/book/translations/pl/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parametryzowane typem drzewa
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parametryzowane typem drzewa
 
     // Operacje dopisywania drzew nie-Merk (uzytkownika):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/pl/src/batch-operations.md
+++ b/docs/book/translations/pl/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parametryzowane typem drzewa
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Operacje dopisywania drzew nie-Merk (uzytkownika):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/pt/src/batch-operations.md
+++ b/docs/book/translations/pt/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parametrizado pelo tipo de arvore
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parametrizado pelo tipo de arvore
 
     // Operacoes de append para arvores nao-Merk (voltadas ao usuario):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/pt/src/batch-operations.md
+++ b/docs/book/translations/pt/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Cada operacao e envolvida em um `QualifiedGroveDbOp` que inclui o caminho:
 
 ```rust

--- a/docs/book/translations/pt/src/batch-operations.md
+++ b/docs/book/translations/pt/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parametrizado pelo tipo de arvore
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Operacoes de append para arvores nao-Merk (voltadas ao usuario):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/ru/src/batch-operations.md
+++ b/docs/book/translations/ru/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Каждая операция обёрнута в `QualifiedGroveDbOp`, включающий путь:
 
 ```rust

--- a/docs/book/translations/ru/src/batch-operations.md
+++ b/docs/book/translations/ru/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parameterized by tree type
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/ru/src/batch-operations.md
+++ b/docs/book/translations/ru/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/th/src/batch-operations.md
+++ b/docs/book/translations/th/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // กำหนดพารามิเตอร์ตามประเภทต้นไม้
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // กำหนดพารามิเตอร์ตามประเภทต้นไม้
 
     // การดำเนินการ append สำหรับต้นไม้ non-Merk (ผู้ใช้เรียกใช้):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/th/src/batch-operations.md
+++ b/docs/book/translations/th/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // กำหนดพารามิเตอร์ตามประเภทต้นไม้
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // การดำเนินการ append สำหรับต้นไม้ non-Merk (ผู้ใช้เรียกใช้):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/th/src/batch-operations.md
+++ b/docs/book/translations/th/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 แต่ละการดำเนินการถูกครอบด้วย `QualifiedGroveDbOp` ที่รวม path:
 
 ```rust

--- a/docs/book/translations/tr/src/batch-operations.md
+++ b/docs/book/translations/tr/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Her islem, yolu iceren bir `QualifiedGroveDbOp` icine sarilir:
 
 ```rust

--- a/docs/book/translations/tr/src/batch-operations.md
+++ b/docs/book/translations/tr/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Agac tipine gore parametrelenmis
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Merk olmayan agac ekleme islemleri (kullaniciya yonelik):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/tr/src/batch-operations.md
+++ b/docs/book/translations/tr/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Agac tipine gore parametrelenmis
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Agac tipine gore parametrelenmis
 
     // Merk olmayan agac ekleme islemleri (kullaniciya yonelik):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/vi/src/batch-operations.md
+++ b/docs/book/translations/vi/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 Mỗi thao tác được bọc trong `QualifiedGroveDbOp` bao gồm đường dẫn:
 
 ```rust

--- a/docs/book/translations/vi/src/batch-operations.md
+++ b/docs/book/translations/vi/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Tham số hóa theo kiểu cây
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Thao tác thêm cho cây không phải Merk (dành cho người dùng):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/vi/src/batch-operations.md
+++ b/docs/book/translations/vi/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Tham số hóa theo kiểu cây
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Tham số hóa theo kiểu cây
 
     // Thao tác thêm cho cây không phải Merk (dành cho người dùng):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/zh/src/batch-operations.md
+++ b/docs/book/translations/zh/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType),                          // Parameterized by tree type
+    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/zh/src/batch-operations.md
+++ b/docs/book/translations/zh/src/batch-operations.md
@@ -13,7 +13,7 @@ pub enum GroveOp {
     Patch { element: Element, change_in_bytes: i32 },
     RefreshReference { reference_path_type, max_reference_hop, flags, trust_refresh_reference },
     Delete,
-    DeleteTree(TreeType, IsSubtreeNonEmpty),                          // Parameterized by tree type
+    DeleteTree(TreeType, SubelementsDeletionBehavior),  // Per-op deletion policy
 
     // Non-Merk tree append operations (user-facing):
     CommitmentTreeInsert { cmx: [u8; 32], payload: Vec<u8> },

--- a/docs/book/translations/zh/src/batch-operations.md
+++ b/docs/book/translations/zh/src/batch-operations.md
@@ -40,6 +40,17 @@ pub enum NonMerkTreeMeta {
 }
 ```
 
+**SubelementsDeletionBehavior** controls how a `DeleteTree` handles non-empty subtrees:
+
+```rust
+pub enum SubelementsDeletionBehavior {
+    DontCheck,       // Skip emptiness check; caller guarantees tree is empty
+    Error,           // Return Error::DeletingNonEmptyTree if non-empty
+    DeleteChildren,  // Check, and recursively delete children if non-empty
+    Skip,            // Check, and silently skip deletion if non-empty
+}
+```
+
 每个操作被包装在一个 `QualifiedGroveDbOp` 中，其中包含路径：
 
 ```rust

--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -161,7 +161,7 @@ where
                     }
                     Ok(())
                 }
-                GroveOp::RefreshReference { .. } | GroveOp::Delete | GroveOp::DeleteTree(_) => {
+                GroveOp::RefreshReference { .. } | GroveOp::Delete | GroveOp::DeleteTree(..) => {
                     Ok(())
                 }
                 GroveOp::CommitmentTreeInsert { .. }

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -151,7 +151,7 @@ impl GroveOp {
                 propagate,
                 grove_version,
             ),
-            GroveOp::DeleteTree(tree_type) => GroveDb::average_case_merk_delete_tree(
+            GroveOp::DeleteTree(tree_type, _) => GroveDb::average_case_merk_delete_tree(
                 key,
                 *tree_type,
                 layer_element_estimates,
@@ -497,7 +497,7 @@ mod tests {
     use crate::{
         batch::{
             estimated_costs::EstimatedCostsType::AverageCaseCostsType, key_info::KeyInfo, GroveOp,
-            KeyInfoPath, NonMerkTreeMeta, QualifiedGroveDbOp,
+            KeyInfoPath, NonMerkTreeMeta, QualifiedGroveDbOp, SubelementsDeletionBehavior,
         },
         reference_path::ReferencePathType,
         tests::{common::EMPTY_PATH, make_empty_grovedb},
@@ -1226,6 +1226,7 @@ mod tests {
             vec![vec![7]],
             b"tree_key".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
         let mut paths = HashMap::new();
         paths.insert(

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -143,7 +143,7 @@ impl GroveOp {
                 propagate,
                 grove_version,
             ),
-            GroveOp::DeleteTree(tree_type) => GroveDb::worst_case_merk_delete_tree(
+            GroveOp::DeleteTree(tree_type, _) => GroveDb::worst_case_merk_delete_tree(
                 key,
                 *tree_type,
                 worst_case_layer_element_estimates,
@@ -464,7 +464,7 @@ mod tests {
     use crate::{
         batch::{
             estimated_costs::EstimatedCostsType::WorstCaseCostsType, key_info::KeyInfo, GroveOp,
-            KeyInfoPath, NonMerkTreeMeta, QualifiedGroveDbOp,
+            KeyInfoPath, NonMerkTreeMeta, QualifiedGroveDbOp, SubelementsDeletionBehavior,
         },
         reference_path::ReferencePathType,
         tests::{common::EMPTY_PATH, make_empty_grovedb},
@@ -919,6 +919,7 @@ mod tests {
             vec![vec![7]],
             b"tree_key".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
         let mut paths = HashMap::new();
         paths.insert(KeyInfoPath(vec![]), MaxElementsNumber(1));

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -95,7 +95,11 @@ use crate::{
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum SubelementsDeletionBehavior {
     /// Do not check whether the subtree is empty before deleting.
-    /// The tree and all its children will be removed unconditionally.
+    /// The tree element is removed from the parent Merk unconditionally.
+    /// Any children that still exist will be left as orphaned data on disk
+    /// — callers typically use this when they have already ensured the
+    /// subtree is empty (e.g. the parent cleaned up children first) and
+    /// want to avoid the cost of a redundant emptiness check.
     DontCheck,
     /// Check emptiness. If the subtree is non-empty, return
     /// `Error::DeletingNonEmptyTree`.
@@ -3516,10 +3520,24 @@ impl GroveDb {
                         } else {
                             // Standard Merk trees: use is_empty_tree_except to
                             // account for other delete ops in the same batch.
+                            //
+                            // Exclude DeleteTree ops with Skip policy — those
+                            // might not execute if their target is non-empty,
+                            // so we cannot assume they will delete their key.
                             let batch_deleted_keys = ops
                                 .iter()
                                 .filter_map(|other_op| match &other_op.op {
-                                    GroveOp::Delete | GroveOp::DeleteTree(..) => {
+                                    GroveOp::Delete => {
+                                        if other_op.path.to_path() == child_path {
+                                            Some(other_op.key.as_ref()?.as_slice().to_vec())
+                                        } else {
+                                            None
+                                        }
+                                    }
+                                    GroveOp::DeleteTree(_, SubelementsDeletionBehavior::Skip) => {
+                                        None
+                                    }
+                                    GroveOp::DeleteTree(..) => {
                                         if other_op.path.to_path() == child_path {
                                             Some(other_op.key.as_ref()?.as_slice().to_vec())
                                         } else {
@@ -3868,10 +3886,22 @@ impl GroveDb {
                             );
                             element.non_merk_entry_count().unwrap_or(0) == 0
                         } else {
+                            // Exclude DeleteTree ops with Skip policy — those
+                            // might not execute if their target is non-empty.
                             let batch_deleted_keys = ops
                                 .iter()
                                 .filter_map(|other_op| match &other_op.op {
-                                    GroveOp::Delete | GroveOp::DeleteTree(..) => {
+                                    GroveOp::Delete => {
+                                        if other_op.path.to_path() == child_path {
+                                            Some(other_op.key.as_ref()?.as_slice().to_vec())
+                                        } else {
+                                            None
+                                        }
+                                    }
+                                    GroveOp::DeleteTree(_, SubelementsDeletionBehavior::Skip) => {
+                                        None
+                                    }
+                                    GroveOp::DeleteTree(..) => {
                                         if other_op.path.to_path() == child_path {
                                             Some(other_op.key.as_ref()?.as_slice().to_vec())
                                         } else {

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -79,13 +79,34 @@ use crate::batch::estimated_costs::EstimatedCostsType;
 use crate::{
     batch::{batch_structure::BatchStructure, mode::BatchRunMode},
     element::MaxReferenceHop,
-    operations::{get::MAX_REFERENCE_HOPS, proof::util::hex_to_ascii},
+    operations::{delete::DeleteOptions, get::MAX_REFERENCE_HOPS, proof::util::hex_to_ascii},
     reference_path::{
         path_from_reference_path_type, path_from_reference_qualified_path_type, ReferencePathType,
     },
     util::TxRef,
     Element, ElementFlags, Error, GroveDb, Transaction, TransactionArg,
 };
+
+/// Controls how a `DeleteTree` operation handles non-empty subtrees.
+///
+/// This enum is attached to each `DeleteTree` operation individually,
+/// replacing the old batch-level `allow_deleting_non_empty_trees` /
+/// `deleting_non_empty_trees_returns_error` flags on `BatchApplyOptions`.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum SubelementsDeletionBehavior {
+    /// Do not check whether the subtree is empty before deleting.
+    /// The tree and all its children will be removed unconditionally.
+    DontCheck,
+    /// Check emptiness. If the subtree is non-empty, return
+    /// `Error::DeletingNonEmptyTree`.
+    Error,
+    /// Check emptiness. If the subtree is non-empty, recursively delete
+    /// all children before deleting the tree itself.
+    DeleteChildren,
+    /// Check emptiness. If the subtree is non-empty, silently skip this
+    /// `DeleteTree` operation (no error, no deletion).
+    Skip,
+}
 
 /// Metadata for non-Merk tree types, carrying tree-type-specific state
 /// through the batch system.
@@ -306,7 +327,7 @@ pub enum GroveOp {
     /// Delete
     Delete,
     /// Delete tree
-    DeleteTree(TreeType),
+    DeleteTree(TreeType, SubelementsDeletionBehavior),
     /// Insert a note commitment + payload into a CommitmentTree
     CommitmentTreeInsert {
         /// 32-byte note commitment (must be a valid Pallas field element)
@@ -336,7 +357,7 @@ pub enum GroveOp {
 impl GroveOp {
     fn to_u8(&self) -> u8 {
         match self {
-            GroveOp::DeleteTree(_) => 0,
+            GroveOp::DeleteTree(..) => 0,
             // 1 used to be used for the DeleteSumTree
             GroveOp::Delete => 2,
             GroveOp::InsertTreeWithRootHash { .. } => 3,
@@ -601,7 +622,9 @@ impl fmt::Debug for QualifiedGroveDbOp {
                 )
             }
             GroveOp::Delete => "Delete".to_string(),
-            GroveOp::DeleteTree(tree_type) => format!("Delete Tree {}", tree_type),
+            GroveOp::DeleteTree(tree_type, check) => {
+                format!("Delete Tree {} ({:?})", tree_type, check)
+            }
             GroveOp::ReplaceTreeRootKey { .. } => "Replace Tree Hash and Root Key".to_string(),
             GroveOp::InsertTreeWithRootHash { .. } => "Insert Tree Hash and Root Key".to_string(),
             GroveOp::ReplaceNonMerkTreeRoot { meta, .. } => {
@@ -793,12 +816,17 @@ impl QualifiedGroveDbOp {
     }
 
     /// A delete tree op using a known owned path and known key
-    pub fn delete_tree_op(path: Vec<Vec<u8>>, key: Vec<u8>, tree_type: TreeType) -> Self {
+    pub fn delete_tree_op(
+        path: Vec<Vec<u8>>,
+        key: Vec<u8>,
+        tree_type: TreeType,
+        subelements_deletion_behavior: SubelementsDeletionBehavior,
+    ) -> Self {
         let path = KeyInfoPath::from_known_owned_path(path);
         Self {
             path,
             key: Some(KnownKey(key)),
-            op: GroveOp::DeleteTree(tree_type),
+            op: GroveOp::DeleteTree(tree_type, subelements_deletion_behavior),
         }
     }
 
@@ -812,11 +840,16 @@ impl QualifiedGroveDbOp {
     }
 
     /// A delete tree op
-    pub fn delete_estimated_tree_op(path: KeyInfoPath, key: KeyInfo, tree_type: TreeType) -> Self {
+    pub fn delete_estimated_tree_op(
+        path: KeyInfoPath,
+        key: KeyInfo,
+        tree_type: TreeType,
+        subelements_deletion_behavior: SubelementsDeletionBehavior,
+    ) -> Self {
         Self {
             path,
             key: Some(key),
-            op: GroveOp::DeleteTree(tree_type),
+            op: GroveOp::DeleteTree(tree_type, subelements_deletion_behavior),
         }
     }
 
@@ -1652,7 +1685,7 @@ where
                         grove_version,
                     )
                 }
-                GroveOp::Delete | GroveOp::DeleteTree(_) => Err(Error::InvalidBatchOperation(
+                GroveOp::Delete | GroveOp::DeleteTree(..) => Err(Error::InvalidBatchOperation(
                     "references can not point to something currently being deleted",
                 ))
                 .wrap_with_cost(cost),
@@ -2103,7 +2136,7 @@ where
                         )
                     );
                 }
-                GroveOp::DeleteTree(_tree_type) => {
+                GroveOp::DeleteTree(_tree_type, _) => {
                     cost_return_on_error_into!(
                         &mut cost,
                         Element::delete_into_batch_operations(
@@ -2716,7 +2749,7 @@ impl GroveDb {
                                                     ))
                                                     .wrap_with_cost(cost);
                                                 }
-                                                GroveOp::Delete | GroveOp::DeleteTree(_) => {
+                                                GroveOp::Delete | GroveOp::DeleteTree(..) => {
                                                     if calculated_root_key.is_some() {
                                                         return Err(Error::InvalidBatchOperation(
                                                             "modification of tree when it will be \
@@ -3017,7 +3050,7 @@ impl GroveDb {
                         );
                     }
                 }
-                GroveOp::Delete | GroveOp::DeleteTree(_) => {
+                GroveOp::Delete => {
                     let path_slices: Vec<&[u8]> =
                         op.path.iterator().map(|p| p.as_slice()).collect();
                     let key = cost_return_on_error_no_add!(
@@ -3032,6 +3065,41 @@ impl GroveDb {
                             path_slices.as_slice(),
                             key.as_slice(),
                             options.clone().map(|o| o.as_delete_options()),
+                            transaction,
+                            grove_version
+                        )
+                    );
+                }
+                GroveOp::DeleteTree(_, subelements_deletion_behavior) => {
+                    let path_slices: Vec<&[u8]> =
+                        op.path.iterator().map(|p| p.as_slice()).collect();
+                    let key = cost_return_on_error_no_add!(
+                        cost,
+                        op.key
+                            .as_ref()
+                            .ok_or(Error::InvalidBatchOperation("delete op is missing a key"))
+                    );
+                    let delete_options = DeleteOptions {
+                        allow_deleting_non_empty_trees: matches!(
+                            subelements_deletion_behavior,
+                            SubelementsDeletionBehavior::DontCheck
+                                | SubelementsDeletionBehavior::DeleteChildren
+                        ),
+                        deleting_non_empty_trees_returns_error: matches!(
+                            subelements_deletion_behavior,
+                            SubelementsDeletionBehavior::Error
+                        ),
+                        base_root_storage_is_free: options
+                            .as_ref()
+                            .is_none_or(|o| o.base_root_storage_is_free),
+                        validate_tree_at_path_exists: false,
+                    };
+                    cost_return_on_error!(
+                        &mut cost,
+                        self.delete(
+                            path_slices.as_slice(),
+                            key.as_slice(),
+                            Some(delete_options),
                             transaction,
                             grove_version
                         )
@@ -3398,128 +3466,123 @@ impl GroveDb {
         // nested subtrees.
         let mut non_merk_delete_paths: Vec<Vec<Vec<u8>>> = Vec::new();
         let mut merk_delete_paths: Vec<Vec<Vec<u8>>> = Vec::new();
-
-        let batch_apply_options_ref = batch_apply_options.as_ref().cloned().unwrap_or_default();
+        // Track paths skipped due to SubelementsDeletionBehavior::Skip so we can
+        // filter the corresponding ops out of the batch before apply_body.
+        let mut skipped_delete_paths: HashSet<Vec<Vec<u8>>> = HashSet::new();
 
         for op in ops.iter() {
-            if let GroveOp::DeleteTree(tree_type) = &op.op
+            if let GroveOp::DeleteTree(tree_type, subelements_deletion_behavior) = &op.op
                 && let Some(key) = op.key.as_ref()
             {
                 let mut child_path = op.path.to_path();
                 child_path.push(key.as_slice().to_vec());
 
-                // H2 fix: check emptiness of the subtree before allowing
-                // deletion, respecting batch_apply_options just like the
-                // non-batch path does.
-                if !batch_apply_options_ref.allow_deleting_non_empty_trees {
-                    let is_empty = if tree_type.uses_non_merk_data_storage() {
-                        // Non-Merk trees: check element-level entry count.
-                        let parent_path_vec = op.path.to_path();
-                        let parent_path: SubtreePath<Vec<u8>> = parent_path_vec.as_slice().into();
-                        let parent_storage = self
-                            .db
-                            .get_transactional_storage_context(
-                                parent_path,
-                                Some(&storage_batch),
-                                tx.as_ref(),
-                            )
-                            .unwrap_add_cost(&mut cost);
-                        let element = cost_return_on_error!(
-                            &mut cost,
-                            Element::get_from_storage(
-                                &parent_storage,
-                                key.as_slice(),
-                                grove_version,
-                            )
-                            .map_err(|e| {
-                                Error::CorruptedData(format!(
-                                    "unable to get element for delete tree emptiness check: {e}"
-                                ))
-                            })
-                        );
-                        element.non_merk_entry_count().unwrap_or(0) == 0
-                    } else {
-                        // Standard Merk trees: use is_empty_tree_except to
-                        // account for other delete ops in the same batch that
-                        // target this subtree.
-                        //
-                        // Limitation: this only considers Delete/DeleteTree ops
-                        // when building the exception set. It does NOT account
-                        // for Insert ops in the same batch that would add new
-                        // keys to this subtree. In theory, a batch could
-                        // contain deletes for every existing key (making the
-                        // tree appear empty) while also containing inserts that
-                        // add new keys, and this check would still report the
-                        // tree as empty.
-                        //
-                        // This is safe in practice because the consistency
-                        // check (`verify_consistency_of_operations`), which
-                        // runs before this code, detects "inserts under a
-                        // deleted path" and rejects such batches. The only way
-                        // to reach this code with conflicting insert + delete-
-                        // tree ops is by setting
-                        // `disable_operation_consistency_check = true`, in
-                        // which case the caller has accepted responsibility for
-                        // ensuring no such conflicts exist.
-                        let batch_deleted_keys = ops
-                            .iter()
-                            .filter_map(|other_op| match &other_op.op {
-                                GroveOp::Delete | GroveOp::DeleteTree(_) => {
-                                    if other_op.path.to_path() == child_path {
-                                        Some(other_op.key.as_ref()?.as_slice().to_vec())
-                                    } else {
-                                        None
-                                    }
-                                }
-                                _ => None,
-                            })
-                            .collect::<Vec<Vec<u8>>>();
-                        let batch_deleted_keys_refs: std::collections::BTreeSet<&[u8]> =
-                            batch_deleted_keys.iter().map(|k| k.as_slice()).collect();
-
-                        let child_subtree_path: SubtreePath<Vec<u8>> = child_path.as_slice().into();
-                        let child_storage = self
-                            .db
-                            .get_transactional_storage_context(
-                                child_subtree_path,
-                                Some(&storage_batch),
-                                tx.as_ref(),
-                            )
-                            .unwrap_add_cost(&mut cost);
-
-                        let child_merk = cost_return_on_error!(
-                            &mut cost,
-                            Merk::open_layered_with_root_key(
-                                child_storage,
-                                None,
-                                *tree_type,
-                                Some(&Element::value_defined_cost_for_serialized_value),
-                                grove_version,
-                            )
-                            .map_err(|e| {
-                                Error::CorruptedData(format!(
-                                    "unable to open subtree for emptiness check: {e}"
-                                ))
-                            })
-                        );
-
-                        child_merk
-                            .is_empty_tree_except(batch_deleted_keys_refs)
-                            .unwrap_add_cost(&mut cost)
-                    };
-
-                    if !is_empty {
-                        if batch_apply_options_ref.deleting_non_empty_trees_returns_error {
-                            return Err(Error::DeletingNonEmptyTree(
-                                "trying to do a batch delete operation for a non empty tree, \
-                                 but options not allowing this",
-                            ))
-                            .wrap_with_cost(cost);
+                // Per-op emptiness check based on the SubelementsDeletionBehavior policy.
+                match subelements_deletion_behavior {
+                    SubelementsDeletionBehavior::DontCheck => {
+                        // No check — unconditionally allow the delete.
+                    }
+                    SubelementsDeletionBehavior::Error
+                    | SubelementsDeletionBehavior::DeleteChildren
+                    | SubelementsDeletionBehavior::Skip => {
+                        let is_empty = if tree_type.uses_non_merk_data_storage() {
+                            // Non-Merk trees: check element-level entry count.
+                            let parent_path_vec = op.path.to_path();
+                            let parent_path: SubtreePath<Vec<u8>> =
+                                parent_path_vec.as_slice().into();
+                            let parent_storage = self
+                                .db
+                                .get_transactional_storage_context(
+                                    parent_path,
+                                    Some(&storage_batch),
+                                    tx.as_ref(),
+                                )
+                                .unwrap_add_cost(&mut cost);
+                            let element = cost_return_on_error!(
+                                &mut cost,
+                                Element::get_from_storage(
+                                    &parent_storage,
+                                    key.as_slice(),
+                                    grove_version,
+                                )
+                                .map_err(|e| {
+                                    Error::CorruptedData(format!(
+                                        "unable to get element for delete tree emptiness \
+                                         check: {e}"
+                                    ))
+                                })
+                            );
+                            element.non_merk_entry_count().unwrap_or(0) == 0
                         } else {
-                            // Skip this DeleteTree op — don't add to cleanup
-                            // paths and the op will still be in the batch but
-                            // we filter it out below.
-                            continue;
+                            // Standard Merk trees: use is_empty_tree_except to
+                            // account for other delete ops in the same batch.
+                            let batch_deleted_keys = ops
+                                .iter()
+                                .filter_map(|other_op| match &other_op.op {
+                                    GroveOp::Delete | GroveOp::DeleteTree(..) => {
+                                        if other_op.path.to_path() == child_path {
+                                            Some(other_op.key.as_ref()?.as_slice().to_vec())
+                                        } else {
+                                            None
+                                        }
+                                    }
+                                    _ => None,
+                                })
+                                .collect::<Vec<Vec<u8>>>();
+                            let batch_deleted_keys_refs: std::collections::BTreeSet<&[u8]> =
+                                batch_deleted_keys.iter().map(|k| k.as_slice()).collect();
+
+                            let child_subtree_path: SubtreePath<Vec<u8>> =
+                                child_path.as_slice().into();
+                            let child_storage = self
+                                .db
+                                .get_transactional_storage_context(
+                                    child_subtree_path,
+                                    Some(&storage_batch),
+                                    tx.as_ref(),
+                                )
+                                .unwrap_add_cost(&mut cost);
+
+                            let child_merk = cost_return_on_error!(
+                                &mut cost,
+                                Merk::open_layered_with_root_key(
+                                    child_storage,
+                                    None,
+                                    *tree_type,
+                                    Some(&Element::value_defined_cost_for_serialized_value),
+                                    grove_version,
+                                )
+                                .map_err(|e| {
+                                    Error::CorruptedData(format!(
+                                        "unable to open subtree for emptiness check: {e}"
+                                    ))
+                                })
+                            );
+
+                            child_merk
+                                .is_empty_tree_except(batch_deleted_keys_refs)
+                                .unwrap_add_cost(&mut cost)
+                        };
+
+                        if !is_empty {
+                            match subelements_deletion_behavior {
+                                SubelementsDeletionBehavior::Error => {
+                                    return Err(Error::DeletingNonEmptyTree(
+                                        "trying to do a batch delete operation for a non \
+                                         empty tree, but options not allowing this",
+                                    ))
+                                    .wrap_with_cost(cost);
+                                }
+                                SubelementsDeletionBehavior::DeleteChildren => {
+                                    // Proceed — children will be cleaned up
+                                    // in the storage cleanup phase below.
+                                }
+                                SubelementsDeletionBehavior::Skip => {
+                                    skipped_delete_paths.insert(child_path);
+                                    continue;
+                                }
+                                SubelementsDeletionBehavior::DontCheck => unreachable!(),
+                            }
                         }
                     }
                 }
@@ -3532,25 +3595,17 @@ impl GroveDb {
             }
         }
 
-        // When allow_deleting_non_empty_trees is false and
-        // deleting_non_empty_trees_returns_error is false, we need to filter
-        // out DeleteTree ops for non-empty trees (they were skipped above).
-        let ops = if !batch_apply_options_ref.allow_deleting_non_empty_trees
-            && !batch_apply_options_ref.deleting_non_empty_trees_returns_error
-        {
-            let all_delete_paths: std::collections::HashSet<Vec<Vec<u8>>> = non_merk_delete_paths
-                .iter()
-                .chain(merk_delete_paths.iter())
-                .cloned()
-                .collect();
+        // Filter out DeleteTree ops that were skipped due to
+        // SubelementsDeletionBehavior::Skip on non-empty trees.
+        let ops = if !skipped_delete_paths.is_empty() {
             ops.into_iter()
                 .filter(|op| {
-                    if let GroveOp::DeleteTree(_) = &op.op
+                    if let GroveOp::DeleteTree(..) = &op.op
                         && let Some(key) = op.key.as_ref()
                     {
                         let mut child_path = op.path.to_path();
                         child_path.push(key.as_slice().to_vec());
-                        return all_delete_paths.contains(&child_path);
+                        return !skipped_delete_paths.contains(&child_path);
                     }
                     true
                 })
@@ -3769,110 +3824,116 @@ impl GroveDb {
         let mut merk_delete_paths: Vec<Vec<Vec<u8>>> = Vec::new();
 
         let mut batch_apply_options = batch_apply_options.unwrap_or_default();
+        let mut skipped_delete_paths: HashSet<Vec<Vec<u8>>> = HashSet::new();
 
         for op in ops.iter() {
-            if let GroveOp::DeleteTree(tree_type) = &op.op
+            if let GroveOp::DeleteTree(tree_type, subelements_deletion_behavior) = &op.op
                 && let Some(key) = op.key.as_ref()
             {
                 let mut child_path = op.path.to_path();
                 child_path.push(key.as_slice().to_vec());
 
-                // H2 fix: check emptiness of the subtree before allowing
-                // deletion (same logic as apply_batch_with_element_flags_update).
-                if !batch_apply_options.allow_deleting_non_empty_trees {
-                    let is_empty = if tree_type.uses_non_merk_data_storage() {
-                        let parent_path_vec = op.path.to_path();
-                        let parent_path: SubtreePath<Vec<u8>> = parent_path_vec.as_slice().into();
-                        let parent_storage = self
-                            .db
-                            .get_transactional_storage_context(
-                                parent_path,
-                                Some(&storage_batch),
-                                tx.as_ref(),
-                            )
-                            .unwrap_add_cost(&mut cost);
-                        let element = cost_return_on_error!(
-                            &mut cost,
-                            Element::get_from_storage(
-                                &parent_storage,
-                                key.as_slice(),
-                                grove_version,
-                            )
-                            .map_err(|e| {
-                                Error::CorruptedData(format!(
-                                    "unable to get element for delete tree emptiness check: {e}"
-                                ))
-                            })
-                        );
-                        element.non_merk_entry_count().unwrap_or(0) == 0
-                    } else {
-                        // Standard Merk trees: use is_empty_tree_except to
-                        // account for other delete ops in the same batch that
-                        // target this subtree.
-                        //
-                        // Limitation: this only considers Delete/DeleteTree ops
-                        // when building the exception set. It does NOT account
-                        // for Insert ops in the same batch that would add new
-                        // keys to this subtree. See the matching comment in
-                        // `apply_batch_with_element_flags_update` for details
-                        // on why this is safe in practice (the consistency
-                        // check guards against this scenario).
-                        let batch_deleted_keys = ops
-                            .iter()
-                            .filter_map(|other_op| match &other_op.op {
-                                GroveOp::Delete | GroveOp::DeleteTree(_) => {
-                                    if other_op.path.to_path() == child_path {
-                                        Some(other_op.key.as_ref()?.as_slice().to_vec())
-                                    } else {
-                                        None
-                                    }
-                                }
-                                _ => None,
-                            })
-                            .collect::<Vec<Vec<u8>>>();
-                        let batch_deleted_keys_refs: std::collections::BTreeSet<&[u8]> =
-                            batch_deleted_keys.iter().map(|k| k.as_slice()).collect();
-
-                        let child_subtree_path: SubtreePath<Vec<u8>> = child_path.as_slice().into();
-                        let child_storage = self
-                            .db
-                            .get_transactional_storage_context(
-                                child_subtree_path,
-                                Some(&storage_batch),
-                                tx.as_ref(),
-                            )
-                            .unwrap_add_cost(&mut cost);
-
-                        let child_merk = cost_return_on_error!(
-                            &mut cost,
-                            Merk::open_layered_with_root_key(
-                                child_storage,
-                                None,
-                                *tree_type,
-                                Some(&Element::value_defined_cost_for_serialized_value),
-                                grove_version,
-                            )
-                            .map_err(|e| {
-                                Error::CorruptedData(format!(
-                                    "unable to open subtree for emptiness check: {e}"
-                                ))
-                            })
-                        );
-
-                        child_merk
-                            .is_empty_tree_except(batch_deleted_keys_refs)
-                            .unwrap_add_cost(&mut cost)
-                    };
-
-                    if !is_empty {
-                        if batch_apply_options.deleting_non_empty_trees_returns_error {
-                            return Err(Error::DeletingNonEmptyTree(
-                                "trying to do a batch delete operation for a non empty tree, \
-                                 but options not allowing this",
-                            ))
-                            .wrap_with_cost(cost);
+                match subelements_deletion_behavior {
+                    SubelementsDeletionBehavior::DontCheck => {
+                        // No check — unconditionally allow the delete.
+                    }
+                    SubelementsDeletionBehavior::Error
+                    | SubelementsDeletionBehavior::DeleteChildren
+                    | SubelementsDeletionBehavior::Skip => {
+                        let is_empty = if tree_type.uses_non_merk_data_storage() {
+                            let parent_path_vec = op.path.to_path();
+                            let parent_path: SubtreePath<Vec<u8>> =
+                                parent_path_vec.as_slice().into();
+                            let parent_storage = self
+                                .db
+                                .get_transactional_storage_context(
+                                    parent_path,
+                                    Some(&storage_batch),
+                                    tx.as_ref(),
+                                )
+                                .unwrap_add_cost(&mut cost);
+                            let element = cost_return_on_error!(
+                                &mut cost,
+                                Element::get_from_storage(
+                                    &parent_storage,
+                                    key.as_slice(),
+                                    grove_version,
+                                )
+                                .map_err(|e| {
+                                    Error::CorruptedData(format!(
+                                        "unable to get element for delete tree emptiness \
+                                         check: {e}"
+                                    ))
+                                })
+                            );
+                            element.non_merk_entry_count().unwrap_or(0) == 0
                         } else {
-                            continue;
+                            let batch_deleted_keys = ops
+                                .iter()
+                                .filter_map(|other_op| match &other_op.op {
+                                    GroveOp::Delete | GroveOp::DeleteTree(..) => {
+                                        if other_op.path.to_path() == child_path {
+                                            Some(other_op.key.as_ref()?.as_slice().to_vec())
+                                        } else {
+                                            None
+                                        }
+                                    }
+                                    _ => None,
+                                })
+                                .collect::<Vec<Vec<u8>>>();
+                            let batch_deleted_keys_refs: std::collections::BTreeSet<&[u8]> =
+                                batch_deleted_keys.iter().map(|k| k.as_slice()).collect();
+
+                            let child_subtree_path: SubtreePath<Vec<u8>> =
+                                child_path.as_slice().into();
+                            let child_storage = self
+                                .db
+                                .get_transactional_storage_context(
+                                    child_subtree_path,
+                                    Some(&storage_batch),
+                                    tx.as_ref(),
+                                )
+                                .unwrap_add_cost(&mut cost);
+
+                            let child_merk = cost_return_on_error!(
+                                &mut cost,
+                                Merk::open_layered_with_root_key(
+                                    child_storage,
+                                    None,
+                                    *tree_type,
+                                    Some(&Element::value_defined_cost_for_serialized_value),
+                                    grove_version,
+                                )
+                                .map_err(|e| {
+                                    Error::CorruptedData(format!(
+                                        "unable to open subtree for emptiness check: {e}"
+                                    ))
+                                })
+                            );
+
+                            child_merk
+                                .is_empty_tree_except(batch_deleted_keys_refs)
+                                .unwrap_add_cost(&mut cost)
+                        };
+
+                        if !is_empty {
+                            match subelements_deletion_behavior {
+                                SubelementsDeletionBehavior::Error => {
+                                    return Err(Error::DeletingNonEmptyTree(
+                                        "trying to do a batch delete operation for a non \
+                                         empty tree, but options not allowing this",
+                                    ))
+                                    .wrap_with_cost(cost);
+                                }
+                                SubelementsDeletionBehavior::DeleteChildren => {
+                                    // Proceed — children will be cleaned up.
+                                }
+                                SubelementsDeletionBehavior::Skip => {
+                                    skipped_delete_paths.insert(child_path);
+                                    continue;
+                                }
+                                SubelementsDeletionBehavior::DontCheck => unreachable!(),
+                            }
                         }
                     }
                 }
@@ -3885,23 +3946,17 @@ impl GroveDb {
             }
         }
 
-        // Filter out skipped DeleteTree ops when non-error mode is active.
-        let ops = if !batch_apply_options.allow_deleting_non_empty_trees
-            && !batch_apply_options.deleting_non_empty_trees_returns_error
-        {
-            let all_delete_paths: std::collections::HashSet<Vec<Vec<u8>>> = non_merk_delete_paths
-                .iter()
-                .chain(merk_delete_paths.iter())
-                .cloned()
-                .collect();
+        // Filter out DeleteTree ops that were skipped due to
+        // SubelementsDeletionBehavior::Skip on non-empty trees.
+        let ops = if !skipped_delete_paths.is_empty() {
             ops.into_iter()
                 .filter(|op| {
-                    if let GroveOp::DeleteTree(_) = &op.op
+                    if let GroveOp::DeleteTree(..) = &op.op
                         && let Some(key) = op.key.as_ref()
                     {
                         let mut child_path = op.path.to_path();
                         child_path.push(key.as_slice().to_vec());
-                        return all_delete_paths.contains(&child_path);
+                        return !skipped_delete_paths.contains(&child_path);
                     }
                     true
                 })
@@ -4351,8 +4406,6 @@ mod tests {
                 Some(BatchApplyOptions {
                     validate_insertion_does_not_override: false,
                     validate_insertion_does_not_override_tree: true,
-                    allow_deleting_non_empty_trees: false,
-                    deleting_non_empty_trees_returns_error: true,
                     disable_operation_consistency_check: true,
                     base_root_storage_is_free: true,
                     batch_pause_height: None,
@@ -4958,8 +5011,6 @@ mod tests {
                 Some(BatchApplyOptions {
                     validate_insertion_does_not_override: true,
                     validate_insertion_does_not_override_tree: true,
-                    allow_deleting_non_empty_trees: false,
-                    deleting_non_empty_trees_returns_error: true,
                     disable_operation_consistency_check: false,
                     base_root_storage_is_free: true,
                     batch_pause_height: None,
@@ -5001,9 +5052,7 @@ mod tests {
                 Some(BatchApplyOptions {
                     disable_operation_consistency_check: false,
                     validate_insertion_does_not_override_tree: true,
-                    allow_deleting_non_empty_trees: false,
                     validate_insertion_does_not_override: true,
-                    deleting_non_empty_trees_returns_error: true,
                     base_root_storage_is_free: true,
                     batch_pause_height: None,
                 }),
@@ -5036,8 +5085,6 @@ mod tests {
                 Some(BatchApplyOptions {
                     validate_insertion_does_not_override: true,
                     validate_insertion_does_not_override_tree: true,
-                    allow_deleting_non_empty_trees: false,
-                    deleting_non_empty_trees_returns_error: true,
                     disable_operation_consistency_check: false,
                     base_root_storage_is_free: true,
                     batch_pause_height: None,
@@ -5513,17 +5560,15 @@ mod tests {
         .expect("insert commitment tree data");
 
         // Delete it via batch.  The tree is non-empty (has one entry),
-        // so we must set allow_deleting_non_empty_trees.
+        // so we pass SubelementsDeletionBehavior::DontCheck to skip the emptiness check.
         let ops = vec![QualifiedGroveDbOp::delete_tree_op(
             vec![],
             b"ct".to_vec(),
             grovedb_merk::tree_type::TreeType::CommitmentTree(4),
+            SubelementsDeletionBehavior::DontCheck,
         )];
 
-        let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: true,
-            ..Default::default()
-        });
+        let batch_options = Some(BatchApplyOptions::default());
 
         db.apply_batch(ops, batch_options, Some(&tx), grove_version)
             .unwrap()
@@ -5600,18 +5645,16 @@ mod tests {
                 .expect("append mmr value");
         }
 
-        // The tree is non-empty (has 3 entries), so we must set
-        // allow_deleting_non_empty_trees.
+        // The tree is non-empty (has 3 entries), so we pass
+        // SubelementsDeletionBehavior::DontCheck to skip the emptiness check.
         let ops = vec![QualifiedGroveDbOp::delete_tree_op(
             vec![],
             b"mmr".to_vec(),
             grovedb_merk::tree_type::TreeType::MmrTree,
+            SubelementsDeletionBehavior::DontCheck,
         )];
 
-        let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: true,
-            ..Default::default()
-        });
+        let batch_options = Some(BatchApplyOptions::default());
 
         db.apply_batch(ops, batch_options, Some(&tx), grove_version)
             .unwrap()
@@ -5679,18 +5722,16 @@ mod tests {
                 .expect("insert dense tree value");
         }
 
-        // The tree is non-empty (has 3 entries), so we must set
-        // allow_deleting_non_empty_trees.
+        // The tree is non-empty (has 3 entries), so we pass
+        // SubelementsDeletionBehavior::DontCheck to skip the emptiness check.
         let ops = vec![QualifiedGroveDbOp::delete_tree_op(
             vec![],
             b"dense".to_vec(),
             grovedb_merk::tree_type::TreeType::DenseAppendOnlyFixedSizeTree(3),
+            SubelementsDeletionBehavior::DontCheck,
         )];
 
-        let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: true,
-            ..Default::default()
-        });
+        let batch_options = Some(BatchApplyOptions::default());
 
         db.apply_partial_batch(
             ops,

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -3083,6 +3083,14 @@ impl GroveDb {
                             .as_ref()
                             .ok_or(Error::InvalidBatchOperation("delete op is missing a key"))
                     );
+                    // Map the per-op enum to the lower-level DeleteOptions.
+                    // DontCheck and DeleteChildren both set
+                    // allow_deleting_non_empty_trees = true because the
+                    // single-op `delete()` already performs recursive child
+                    // subtree cleanup when that flag is true — the two
+                    // behaviors converge at this layer.  Skip maps to
+                    // allow=false + error=false, which makes `delete()`
+                    // silently return Ok(false) for non-empty trees.
                     let delete_options = DeleteOptions {
                         allow_deleting_non_empty_trees: matches!(
                             subelements_deletion_behavior,
@@ -3550,31 +3558,15 @@ impl GroveDb {
                             let batch_deleted_keys_refs: std::collections::BTreeSet<&[u8]> =
                                 batch_deleted_keys.iter().map(|k| k.as_slice()).collect();
 
-                            let child_subtree_path: SubtreePath<Vec<u8>> =
-                                child_path.as_slice().into();
-                            let child_storage = self
-                                .db
-                                .get_transactional_storage_context(
-                                    child_subtree_path,
-                                    Some(&storage_batch),
-                                    tx.as_ref(),
-                                )
-                                .unwrap_add_cost(&mut cost);
-
                             let child_merk = cost_return_on_error!(
                                 &mut cost,
-                                Merk::open_layered_with_root_key(
-                                    child_storage,
-                                    None,
-                                    *tree_type,
-                                    Some(&Element::value_defined_cost_for_serialized_value),
+                                self.open_batch_transactional_merk_at_path(
+                                    &storage_batch,
+                                    child_path.as_slice().into(),
+                                    tx.as_ref(),
+                                    false,
                                     grove_version,
                                 )
-                                .map_err(|e| {
-                                    Error::CorruptedData(format!(
-                                        "unable to open subtree for emptiness check: {e}"
-                                    ))
-                                })
                             );
 
                             child_merk
@@ -3914,31 +3906,15 @@ impl GroveDb {
                             let batch_deleted_keys_refs: std::collections::BTreeSet<&[u8]> =
                                 batch_deleted_keys.iter().map(|k| k.as_slice()).collect();
 
-                            let child_subtree_path: SubtreePath<Vec<u8>> =
-                                child_path.as_slice().into();
-                            let child_storage = self
-                                .db
-                                .get_transactional_storage_context(
-                                    child_subtree_path,
-                                    Some(&storage_batch),
-                                    tx.as_ref(),
-                                )
-                                .unwrap_add_cost(&mut cost);
-
                             let child_merk = cost_return_on_error!(
                                 &mut cost,
-                                Merk::open_layered_with_root_key(
-                                    child_storage,
-                                    None,
-                                    *tree_type,
-                                    Some(&Element::value_defined_cost_for_serialized_value),
+                                self.open_batch_transactional_merk_at_path(
+                                    &storage_batch,
+                                    child_path.as_slice().into(),
+                                    tx.as_ref(),
+                                    false,
                                     grove_version,
                                 )
-                                .map_err(|e| {
-                                    Error::CorruptedData(format!(
-                                        "unable to open subtree for emptiness check: {e}"
-                                    ))
-                                })
                             );
 
                             child_merk
@@ -4055,6 +4031,17 @@ impl GroveDb {
         // caller-provided, so the returned operations could contain duplicates,
         // internal-only ops, or inserts under paths being deleted. Apply the
         // same consistency gate used for the initial batch.
+        //
+        // Limitation: add-on DeleteTree ops bypass the
+        // SubelementsDeletionBehavior preflight (emptiness check, Skip
+        // filtering, cleanup path collection) that runs on the initial
+        // batch.  They go straight into continue_partial_apply_body →
+        // apply_body, where DeleteTree is a simple layered Merk delete
+        // with no emptiness enforcement.  In practice this is safe because
+        // partial-batch callers (Platform) control the callback and only
+        // return root-level propagation ops, not new DeleteTree ops.  If
+        // add-on DeleteTree support is needed in the future, the preflight
+        // must be extended to cover new_operations as well.
         if check_batch_operation_consistency && !new_operations.is_empty() {
             let consistency_result =
                 QualifiedGroveDbOp::verify_consistency_of_operations(&new_operations);

--- a/grovedb/src/batch/options.rs
+++ b/grovedb/src/batch/options.rs
@@ -14,10 +14,6 @@ pub struct BatchApplyOptions {
     pub validate_insertion_does_not_override: bool,
     /// Validate insertion does not override tree
     pub validate_insertion_does_not_override_tree: bool,
-    /// Allow deleting non-empty trees
-    pub allow_deleting_non_empty_trees: bool,
-    /// Deleting non empty trees returns error
-    pub deleting_non_empty_trees_returns_error: bool,
     /// Disable the full operation consistency check performed by
     /// [`super::QualifiedGroveDbOp::verify_consistency_of_operations`].
     ///
@@ -85,8 +81,6 @@ impl Default for BatchApplyOptions {
         BatchApplyOptions {
             validate_insertion_does_not_override: false,
             validate_insertion_does_not_override_tree: false,
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: true,
             disable_operation_consistency_check: false,
             base_root_storage_is_free: true,
             batch_pause_height: None,
@@ -107,10 +101,10 @@ impl BatchApplyOptions {
     }
 
     /// As delete options
-    pub(crate) fn as_delete_options(&self) -> DeleteOptions where {
+    pub(crate) fn as_delete_options(&self) -> DeleteOptions {
         DeleteOptions {
-            allow_deleting_non_empty_trees: self.allow_deleting_non_empty_trees,
-            deleting_non_empty_trees_returns_error: self.deleting_non_empty_trees_returns_error,
+            allow_deleting_non_empty_trees: false,
+            deleting_non_empty_trees_returns_error: true,
             base_root_storage_is_free: self.base_root_storage_is_free,
             validate_tree_at_path_exists: false,
         }

--- a/grovedb/src/batch/single_deletion_cost_tests.rs
+++ b/grovedb/src/batch/single_deletion_cost_tests.rs
@@ -12,7 +12,7 @@ mod tests {
     use intmap::IntMap;
 
     use crate::{
-        batch::QualifiedGroveDbOp,
+        batch::{QualifiedGroveDbOp, SubelementsDeletionBehavior},
         tests::{common::EMPTY_PATH, make_empty_grovedb},
         Element,
     };
@@ -77,6 +77,7 @@ mod tests {
             vec![],
             b"key1".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
         let batch_cost = db
             .apply_batch(ops, None, Some(&tx), grove_version)
@@ -221,6 +222,7 @@ mod tests {
             vec![],
             b"key1".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
         let batch_cost = db
             .apply_batch(ops, None, None, grove_version)
@@ -370,6 +372,7 @@ mod tests {
             vec![],
             b"key1".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
         let batch_cost = db
             .apply_batch(ops, None, Some(&tx), grove_version)
@@ -469,6 +472,7 @@ mod tests {
             vec![],
             b"key1".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
         let batch_cost = db
             .apply_batch_with_element_flags_update(
@@ -644,6 +648,7 @@ mod tests {
             vec![],
             b"key1".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
         let batch_cost = db
             .apply_batch(ops, None, None, grove_version)

--- a/grovedb/src/batch/single_sum_item_deletion_cost_tests.rs
+++ b/grovedb/src/batch/single_sum_item_deletion_cost_tests.rs
@@ -6,7 +6,7 @@ mod tests {
     use grovedb_version::version::GroveVersion;
 
     use crate::{
-        batch::QualifiedGroveDbOp,
+        batch::{QualifiedGroveDbOp, SubelementsDeletionBehavior},
         tests::{common::EMPTY_PATH, make_empty_grovedb},
         Element,
     };
@@ -48,6 +48,7 @@ mod tests {
             vec![],
             b"key1".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
         let batch_cost = db
             .apply_batch(ops, None, Some(&tx), grove_version)
@@ -155,6 +156,7 @@ mod tests {
             vec![],
             b"key1".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
         let batch_cost = db
             .apply_batch(ops, None, Some(&tx), grove_version)

--- a/grovedb/src/operations/delete/mod.rs
+++ b/grovedb/src/operations/delete/mod.rs
@@ -680,11 +680,14 @@ impl GroveDb {
                         Ok(None)
                     }
                 } else if is_empty {
+                    // Emptiness was already verified above — use DontCheck
+                    // to avoid a redundant re-check when the batch processes
+                    // this op.
                     Ok(Some(QualifiedGroveDbOp::delete_tree_op(
                         path.to_vec(),
                         key.to_vec(),
                         tree_type,
-                        SubelementsDeletionBehavior::Error,
+                        SubelementsDeletionBehavior::DontCheck,
                     )))
                 } else {
                     Err(Error::NotSupported(

--- a/grovedb/src/operations/delete/mod.rs
+++ b/grovedb/src/operations/delete/mod.rs
@@ -49,7 +49,7 @@ use grovedb_version::{check_grovedb_v0_with_cost, version::GroveVersion};
 use crate::util::{compat, TxRef};
 #[cfg(feature = "minimal")]
 use crate::{
-    batch::{GroveOp, QualifiedGroveDbOp},
+    batch::{GroveOp, QualifiedGroveDbOp, SubelementsDeletionBehavior},
     Element, ElementFlags, Error, GroveDb, Transaction, TransactionArg,
 };
 
@@ -637,7 +637,7 @@ impl GroveDb {
                     let batch_deleted_keys = current_batch_operations
                         .iter()
                         .filter_map(|op| match op.op {
-                            GroveOp::Delete | GroveOp::DeleteTree(_) => {
+                            GroveOp::Delete | GroveOp::DeleteTree(..) => {
                                 if op.path.eq_path_vec(&subtree_merk_path_vec) {
                                     Some(op.key.as_ref()?.as_slice())
                                 } else {
@@ -666,7 +666,7 @@ impl GroveDb {
                 // If there is any current batch operation that is inserting something in this
                 // tree then it is not empty either
                 is_empty &= !current_batch_operations.iter().any(|op| match op.op {
-                    GroveOp::Delete | GroveOp::DeleteTree(_) => false,
+                    GroveOp::Delete | GroveOp::DeleteTree(..) => false,
                     _ => op.path.eq_path_vec(&subtree_merk_path_vec),
                 });
 
@@ -684,6 +684,7 @@ impl GroveDb {
                         path.to_vec(),
                         key.to_vec(),
                         tree_type,
+                        SubelementsDeletionBehavior::Error,
                     )))
                 } else {
                     Err(Error::NotSupported(

--- a/grovedb/src/tests/batch_coverage_tests.rs
+++ b/grovedb/src/tests/batch_coverage_tests.rs
@@ -12,7 +12,7 @@ mod tests {
     use crate::{
         batch::{
             key_info::KeyInfo::KnownKey, BatchApplyOptions, GroveOp, KeyInfoPath, NonMerkTreeMeta,
-            QualifiedGroveDbOp,
+            QualifiedGroveDbOp, SubelementsDeletionBehavior,
         },
         reference_path::ReferencePathType,
         tests::{common::EMPTY_PATH, make_empty_grovedb, make_test_grovedb, TEST_LEAF},
@@ -154,6 +154,7 @@ mod tests {
             vec![],
             b"tree_to_del".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
 
         db.apply_batch(ops, None, None, grove_version)
@@ -194,15 +195,15 @@ mod tests {
         .unwrap()
         .expect("insert child item");
 
-        // Delete non-empty tree with allow_deleting_non_empty_trees = true
+        // Delete non-empty tree with SubelementsDeletionBehavior::DontCheck
         let ops = vec![QualifiedGroveDbOp::delete_tree_op(
             vec![],
             b"tree_with_items".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::DontCheck,
         )];
 
         let options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: true,
             ..Default::default()
         });
 
@@ -457,6 +458,7 @@ mod tests {
             vec![TEST_LEAF.to_vec()],
             b"subtree_to_delete".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
 
         db.apply_operations_without_batching(ops, None, None, grove_version)
@@ -896,7 +898,8 @@ mod tests {
     #[test]
     fn test_grove_op_ordering() {
         // DeleteTree = 0, Delete = 2, InsertOrReplace = 8, InsertWithKnownToNotAlreadyExist = 9, InsertIfNotExists = 10
-        let delete_tree = GroveOp::DeleteTree(TreeType::NormalTree);
+        let delete_tree =
+            GroveOp::DeleteTree(TreeType::NormalTree, SubelementsDeletionBehavior::Error);
         let delete = GroveOp::Delete;
         let insert_or_replace = GroveOp::InsertOrReplace {
             element: Element::new_item(b"test".to_vec()),
@@ -2395,6 +2398,7 @@ mod tests {
             vec![b"parent_sum".to_vec()],
             b"child_tree".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
 
         db.apply_batch(ops, None, None, grove_version)

--- a/grovedb/src/tests/batch_delete_tree_tests.rs
+++ b/grovedb/src/tests/batch_delete_tree_tests.rs
@@ -775,9 +775,173 @@ mod tests {
     }
 
     #[test]
+    fn test_batch_delete_some_children_plus_delete_tree_dont_check() {
+        // Delete SOME children + DeleteTree(DontCheck) on parent.
+        // DontCheck skips the emptiness check, but apply_body rejects
+        // the combination because child ops produce a new root key for
+        // a tree that is being deleted.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"parent",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert parent");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child1",
+            Element::new_item(b"v1".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child1");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child2",
+            Element::new_item(b"v2".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child2");
+
+        // Delete only child1, DontCheck on parent
+        let ops = vec![
+            QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child1".to_vec()),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"parent".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DontCheck,
+            ),
+        ];
+
+        let result = db.apply_batch(ops, None, None, grove_version).unwrap();
+
+        match result {
+            Err(Error::InvalidBatchOperation(msg)) => {
+                assert!(
+                    msg.contains("modification of tree when it will be deleted"),
+                    "unexpected error message: {}",
+                    msg
+                );
+            }
+            Err(e) => panic!("expected InvalidBatchOperation, got: {:?}", e),
+            Ok(()) => {
+                panic!("expected error: child ops produce a root key for a tree being deleted")
+            }
+        }
+    }
+
+    #[test]
+    fn test_batch_delete_some_children_plus_delete_tree_skip() {
+        // Delete SOME children + DeleteTree(Skip) on parent.
+        // The emptiness check finds the tree non-empty (child2 remains),
+        // so the DeleteTree is skipped (filtered out of the batch).
+        // The child Delete op still runs: child1 is removed, parent and
+        // child2 survive.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"parent",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert parent");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child1",
+            Element::new_item(b"v1".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child1");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child2",
+            Element::new_item(b"v2".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child2");
+
+        // Delete only child1, Skip on parent
+        let ops = vec![
+            QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child1".to_vec()),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"parent".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::Skip,
+            ),
+        ];
+
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("Skip mode: DeleteTree filtered out, child delete still runs");
+
+        // Parent should still exist (DeleteTree was skipped)
+        assert!(
+            db.get(EMPTY_PATH, b"parent", None, grove_version)
+                .unwrap()
+                .is_ok(),
+            "parent should still exist"
+        );
+
+        // child1 should be gone (the Delete op ran)
+        assert!(
+            db.get(
+                [b"parent".as_ref()].as_ref(),
+                b"child1",
+                None,
+                grove_version
+            )
+            .unwrap()
+            .is_err(),
+            "child1 should have been deleted"
+        );
+
+        // child2 should still exist
+        assert!(
+            db.get(
+                [b"parent".as_ref()].as_ref(),
+                b"child2",
+                None,
+                grove_version
+            )
+            .unwrap()
+            .is_ok(),
+            "child2 should still exist"
+        );
+    }
+
+    #[test]
     fn test_batch_delete_tree_with_partial_child_delete_still_non_empty() {
         // When only some children are deleted in the same batch, the tree
         // should still be considered non-empty and the delete should fail.
+        // (This is the Error mode variant of the partial-delete scenario.)
         let grove_version = GroveVersion::latest();
         let db = make_empty_grovedb();
 

--- a/grovedb/src/tests/batch_delete_tree_tests.rs
+++ b/grovedb/src/tests/batch_delete_tree_tests.rs
@@ -569,6 +569,147 @@ mod tests {
     }
 
     #[test]
+    fn test_batch_delete_all_children_plus_delete_tree_error_mode() {
+        // Delete ALL children explicitly + DeleteTree(Error) on parent.
+        // is_empty_tree_except accounts for all the child deletes, so the
+        // tree is considered empty and the deletion succeeds.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"parent",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert parent");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child1",
+            Element::new_item(b"v1".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child1");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child2",
+            Element::new_item(b"v2".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child2");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child3",
+            Element::new_item(b"v3".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child3");
+
+        let ops = vec![
+            QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child1".to_vec()),
+            QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child2".to_vec()),
+            QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child3".to_vec()),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"parent".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::Error,
+            ),
+        ];
+
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("delete all children + Error mode parent should succeed");
+
+        assert!(
+            db.get(EMPTY_PATH, b"parent", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "parent should have been deleted"
+        );
+    }
+
+    #[test]
+    fn test_batch_delete_all_children_plus_delete_tree_dont_check() {
+        // Delete ALL children explicitly + DeleteTree(DontCheck) on parent.
+        // DontCheck skips the emptiness check entirely, so it succeeds
+        // regardless. This is the typical pattern: caller cleans up children
+        // first, then uses DontCheck to avoid a redundant emptiness check.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"parent",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert parent");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child1",
+            Element::new_item(b"v1".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child1");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child2",
+            Element::new_item(b"v2".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child2");
+
+        let ops = vec![
+            QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child1".to_vec()),
+            QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child2".to_vec()),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"parent".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DontCheck,
+            ),
+        ];
+
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("delete all children + DontCheck parent should succeed");
+
+        assert!(
+            db.get(EMPTY_PATH, b"parent", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "parent should have been deleted"
+        );
+    }
+
+    #[test]
     fn test_batch_delete_tree_with_partial_child_delete_still_non_empty() {
         // When only some children are deleted in the same batch, the tree
         // should still be considered non-empty and the delete should fail.

--- a/grovedb/src/tests/batch_delete_tree_tests.rs
+++ b/grovedb/src/tests/batch_delete_tree_tests.rs
@@ -1566,6 +1566,193 @@ mod tests {
     }
 
     // ===================================================================
+    // DeleteChildren + child ops in same batch: architectural constraint
+    // ===================================================================
+
+    #[test]
+    fn test_batch_delete_children_rejects_partial_child_delete_in_same_batch() {
+        // The batch system processes bottom-up: child ops first, then parent.
+        // If child ops produce a new root key (calculated_root_key is Some)
+        // for a tree being deleted, apply_body rejects it with
+        // "modification of tree when it will be deleted".
+        //
+        // This means: you cannot mix child-level ops with a DeleteTree of
+        // the parent UNLESS all children are deleted (leaving root_key = None).
+        // DeleteChildren is for deleting non-empty trees when NO other ops
+        // target inside that tree — the cleanup is done post-apply-body.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"parent",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert parent");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child1",
+            Element::new_item(b"val1".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child1");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child2",
+            Element::new_item(b"val2".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child2");
+
+        // Delete only child1 + DeleteTree(DeleteChildren) on parent.
+        // child2 remains, so calculated_root_key is Some → rejected.
+        let ops = vec![
+            QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child1".to_vec()),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"parent".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            ),
+        ];
+
+        let result = db.apply_batch(ops, None, None, grove_version).unwrap();
+
+        match result {
+            Err(Error::InvalidBatchOperation(msg)) => {
+                assert!(
+                    msg.contains("modification of tree when it will be deleted"),
+                    "unexpected error message: {}",
+                    msg
+                );
+            }
+            Err(e) => panic!("expected InvalidBatchOperation, got: {:?}", e),
+            Ok(()) => panic!("expected error: can't mix child ops with DeleteTree in same batch"),
+        }
+    }
+
+    #[test]
+    fn test_batch_delete_children_standalone_deletes_with_nested_subtrees() {
+        // DeleteChildren WITHOUT other child ops in the same batch.
+        // Parent has a child subtree (with deep data). Only the parent's
+        // DeleteTree is in the batch — cleanup is handled post-apply-body.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"parent",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert parent");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"item_child",
+            Element::new_item(b"data".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert item child");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"tree_child",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert tree child");
+
+        db.insert(
+            [b"parent".as_ref(), b"tree_child".as_ref()].as_ref(),
+            b"deep_item",
+            Element::new_item(b"deep_data".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert deep item");
+
+        // Only the parent DeleteTree — no other ops inside the subtree.
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"parent".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DeleteChildren,
+        )];
+
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("DeleteChildren standalone should succeed");
+
+        // Parent should be gone
+        assert!(
+            db.get(EMPTY_PATH, b"parent", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "parent should have been deleted"
+        );
+
+        // Re-insert parent and verify no stale data from tree_child
+        db.insert(
+            EMPTY_PATH,
+            b"parent",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("re-insert parent");
+
+        assert!(
+            db.get(
+                [b"parent".as_ref()].as_ref(),
+                b"tree_child",
+                None,
+                grove_version
+            )
+            .unwrap()
+            .is_err(),
+            "tree_child should not exist in re-inserted parent"
+        );
+
+        assert!(
+            db.get(
+                [b"parent".as_ref(), b"tree_child".as_ref()].as_ref(),
+                b"deep_item",
+                None,
+                grove_version
+            )
+            .unwrap()
+            .is_err(),
+            "deep_item should not leak through after cleanup"
+        );
+    }
+
+    // ===================================================================
     // Non-Merk tree emptiness checks (CommitmentTree, MmrTree, etc.)
     // ===================================================================
 

--- a/grovedb/src/tests/batch_delete_tree_tests.rs
+++ b/grovedb/src/tests/batch_delete_tree_tests.rs
@@ -1063,6 +1063,715 @@ mod tests {
         assert!(l2_get.is_err(), "l2 should not exist in re-inserted tree");
     }
 
+    // ===================================================================
+    // DeleteChildren mode — non-empty tree should be deleted with cleanup
+    // ===================================================================
+
+    #[test]
+    fn test_batch_delete_tree_delete_children_mode_deletes_non_empty_tree() {
+        // When SubelementsDeletionBehavior::DeleteChildren is used,
+        // the emptiness check runs but a non-empty tree should still
+        // be deleted (children cleaned up).
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        // Create a tree with children
+        db.insert(
+            EMPTY_PATH,
+            b"tree_dc",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert tree");
+
+        db.insert(
+            [b"tree_dc".as_ref()].as_ref(),
+            b"child1",
+            Element::new_item(b"val1".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child1");
+
+        db.insert(
+            [b"tree_dc".as_ref()].as_ref(),
+            b"child2",
+            Element::new_item(b"val2".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child2");
+
+        // Delete the non-empty tree with DeleteChildren mode
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"tree_dc".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DeleteChildren,
+        )];
+
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("DeleteChildren mode should delete non-empty tree");
+
+        // Tree should be gone
+        assert!(
+            db.get(EMPTY_PATH, b"tree_dc", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "tree should have been deleted"
+        );
+
+        // Re-insert and verify no stale data
+        db.insert(
+            EMPTY_PATH,
+            b"tree_dc",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("re-insert tree");
+
+        assert!(
+            db.get(
+                [b"tree_dc".as_ref()].as_ref(),
+                b"child1",
+                None,
+                grove_version
+            )
+            .unwrap()
+            .is_err(),
+            "old children should not exist in re-inserted tree"
+        );
+    }
+
+    #[test]
+    fn test_batch_delete_tree_delete_children_mode_empty_tree_succeeds() {
+        // DeleteChildren mode on an empty tree should succeed normally.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"empty_dc",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert empty tree");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"empty_dc".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DeleteChildren,
+        )];
+
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("DeleteChildren on empty tree should succeed");
+
+        assert!(
+            db.get(EMPTY_PATH, b"empty_dc", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "empty tree should have been deleted"
+        );
+    }
+
+    #[test]
+    fn test_partial_batch_delete_tree_delete_children_mode() {
+        // Partial batch path: DeleteChildren on a non-empty tree.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        db.insert(
+            EMPTY_PATH,
+            b"ptree_dc",
+            Element::empty_tree(),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert tree");
+
+        db.insert(
+            [b"ptree_dc".as_ref()].as_ref(),
+            b"child",
+            Element::new_item(b"val".to_vec()),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"ptree_dc".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DeleteChildren,
+        )];
+
+        db.apply_partial_batch(
+            ops,
+            None,
+            |_cost, _left_over_ops| Ok(vec![]),
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("partial batch DeleteChildren should succeed");
+
+        assert!(
+            db.get(EMPTY_PATH, b"ptree_dc", Some(&tx), grove_version)
+                .unwrap()
+                .is_err(),
+            "tree should have been deleted"
+        );
+    }
+
+    // ===================================================================
+    // apply_operations_without_batching: exercises non-batch fallback
+    // ===================================================================
+
+    #[test]
+    fn test_without_batching_delete_tree_dont_check() {
+        // Exercise the non-batch fallback path for DeleteTree with DontCheck.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"nb_tree",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert tree");
+
+        db.insert(
+            [b"nb_tree".as_ref()].as_ref(),
+            b"item",
+            Element::new_item(b"val".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert item");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"nb_tree".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DontCheck,
+        )];
+
+        db.apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap()
+            .expect("non-batch DontCheck should succeed");
+
+        assert!(
+            db.get(EMPTY_PATH, b"nb_tree", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "tree should have been deleted"
+        );
+    }
+
+    #[test]
+    fn test_without_batching_delete_tree_error_mode() {
+        // Exercise the non-batch fallback path for DeleteTree with Error mode.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"nb_err",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert tree");
+
+        db.insert(
+            [b"nb_err".as_ref()].as_ref(),
+            b"item",
+            Element::new_item(b"val".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert item");
+
+        // Error mode on non-empty tree: should fail
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"nb_err".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
+        )];
+
+        let result = db
+            .apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap();
+
+        match result {
+            Err(Error::DeletingNonEmptyTree(_)) => { /* expected */ }
+            Err(e) => panic!("expected DeletingNonEmptyTree, got: {:?}", e),
+            Ok(()) => panic!("expected error but got Ok"),
+        }
+    }
+
+    #[test]
+    fn test_without_batching_delete_tree_delete_children_mode() {
+        // Exercise the non-batch fallback path for DeleteTree with
+        // DeleteChildren mode.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"nb_dc",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert tree");
+
+        db.insert(
+            [b"nb_dc".as_ref()].as_ref(),
+            b"item",
+            Element::new_item(b"val".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert item");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"nb_dc".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DeleteChildren,
+        )];
+
+        db.apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap()
+            .expect("non-batch DeleteChildren should succeed");
+
+        assert!(
+            db.get(EMPTY_PATH, b"nb_dc", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "tree should have been deleted"
+        );
+    }
+
+    #[test]
+    fn test_without_batching_delete_tree_skip_mode() {
+        // Exercise the non-batch fallback for DeleteTree with Skip mode.
+        // Skip mode maps to allow=false, error=false in DeleteOptions,
+        // which makes delete() silently skip non-empty trees.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"nb_skip",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert tree");
+
+        db.insert(
+            [b"nb_skip".as_ref()].as_ref(),
+            b"item",
+            Element::new_item(b"val".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert item");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"nb_skip".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::Skip,
+        )];
+
+        db.apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap()
+            .expect("non-batch Skip should succeed");
+
+        // Tree should still exist (skip mode)
+        assert!(
+            db.get(EMPTY_PATH, b"nb_skip", None, grove_version)
+                .unwrap()
+                .is_ok(),
+            "tree should still exist after skip-mode non-batch delete"
+        );
+    }
+
+    #[test]
+    fn test_without_batching_delete_tree_empty_tree_with_error_mode() {
+        // Error mode on an empty tree should succeed.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"nb_empty",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert tree");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"nb_empty".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
+        )];
+
+        db.apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap()
+            .expect("non-batch Error mode on empty tree should succeed");
+
+        assert!(
+            db.get(EMPTY_PATH, b"nb_empty", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "empty tree should have been deleted"
+        );
+    }
+
+    // ===================================================================
+    // apply_operations_without_batching with BatchApplyOptions (covers
+    // as_delete_options() in options.rs)
+    // ===================================================================
+
+    #[test]
+    fn test_without_batching_delete_item_with_options() {
+        // Exercise as_delete_options() by passing Some(BatchApplyOptions)
+        // when deleting a non-tree element via apply_operations_without_batching.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"my_tree",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert tree");
+
+        db.insert(
+            [b"my_tree".as_ref()].as_ref(),
+            b"item",
+            Element::new_item(b"val".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert item");
+
+        // Delete the item (not a tree) via apply_operations_without_batching
+        // with explicit options to exercise as_delete_options().
+        let ops = vec![QualifiedGroveDbOp::delete_op(
+            vec![b"my_tree".to_vec()],
+            b"item".to_vec(),
+        )];
+
+        let batch_options = Some(BatchApplyOptions::default());
+
+        db.apply_operations_without_batching(ops, batch_options, None, grove_version)
+            .unwrap()
+            .expect("delete item with options should succeed");
+
+        assert!(
+            db.get([b"my_tree".as_ref()].as_ref(), b"item", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "item should have been deleted"
+        );
+    }
+
+    // ===================================================================
+    // Debug formatting
+    // ===================================================================
+
+    #[test]
+    fn test_delete_tree_op_debug_format() {
+        // Verify the Debug impl includes the SubelementsDeletionBehavior.
+        let op = QualifiedGroveDbOp::delete_tree_op(
+            vec![b"root".to_vec()],
+            b"key".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DeleteChildren,
+        );
+        let debug_str = format!("{:?}", op);
+        assert!(
+            debug_str.contains("DeleteChildren"),
+            "debug format should include the behavior variant, got: {}",
+            debug_str
+        );
+
+        let op2 = QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"k".to_vec(),
+            TreeType::SumTree,
+            SubelementsDeletionBehavior::Skip,
+        );
+        let debug_str2 = format!("{:?}", op2);
+        assert!(
+            debug_str2.contains("Skip"),
+            "debug format should include Skip, got: {}",
+            debug_str2
+        );
+    }
+
+    // ===================================================================
+    // Non-Merk tree emptiness checks (CommitmentTree, MmrTree, etc.)
+    // ===================================================================
+
+    #[test]
+    fn test_batch_delete_non_merk_tree_error_when_non_empty() {
+        // Exercise the non-Merk branch of the emptiness check in
+        // apply_batch. CommitmentTree with data should fail with Error mode.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        db.insert(
+            EMPTY_PATH,
+            b"ct_err",
+            Element::empty_commitment_tree(4).expect("valid chunk_power"),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert commitment tree");
+
+        // Populate with one entry
+        db.commitment_tree_insert_raw(
+            EMPTY_PATH,
+            b"ct_err",
+            [1u8; 32],
+            [2u8; 32],
+            vec![0u8; 216],
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert commitment tree data");
+
+        // Try to delete with Error mode — should fail because non-empty
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"ct_err".to_vec(),
+            grovedb_merk::tree_type::TreeType::CommitmentTree(4),
+            SubelementsDeletionBehavior::Error,
+        )];
+
+        let result = db.apply_batch(ops, None, Some(&tx), grove_version).unwrap();
+
+        match result {
+            Err(Error::DeletingNonEmptyTree(_)) => { /* expected */ }
+            Err(e) => panic!("expected DeletingNonEmptyTree, got: {:?}", e),
+            Ok(()) => panic!("expected error but got Ok"),
+        }
+    }
+
+    #[test]
+    fn test_batch_delete_non_merk_tree_skip_when_non_empty() {
+        // Non-Merk tree with Skip mode: should silently skip when non-empty.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        db.insert(
+            EMPTY_PATH,
+            b"ct_skip",
+            Element::empty_commitment_tree(4).expect("valid chunk_power"),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert commitment tree");
+
+        db.commitment_tree_insert_raw(
+            EMPTY_PATH,
+            b"ct_skip",
+            [1u8; 32],
+            [2u8; 32],
+            vec![0u8; 216],
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert commitment tree data");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"ct_skip".to_vec(),
+            grovedb_merk::tree_type::TreeType::CommitmentTree(4),
+            SubelementsDeletionBehavior::Skip,
+        )];
+
+        db.apply_batch(ops, None, Some(&tx), grove_version)
+            .unwrap()
+            .expect("Skip mode should succeed");
+
+        // Tree should still exist
+        assert!(
+            db.get(EMPTY_PATH, b"ct_skip", Some(&tx), grove_version)
+                .unwrap()
+                .is_ok(),
+            "commitment tree should still exist after skipped delete"
+        );
+    }
+
+    #[test]
+    fn test_partial_batch_delete_non_merk_tree_error_when_non_empty() {
+        // Same as above but via partial batch path.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        db.insert(
+            EMPTY_PATH,
+            b"ct_perr",
+            Element::empty_commitment_tree(4).expect("valid chunk_power"),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert commitment tree");
+
+        db.commitment_tree_insert_raw(
+            EMPTY_PATH,
+            b"ct_perr",
+            [1u8; 32],
+            [2u8; 32],
+            vec![0u8; 216],
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert commitment tree data");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"ct_perr".to_vec(),
+            grovedb_merk::tree_type::TreeType::CommitmentTree(4),
+            SubelementsDeletionBehavior::Error,
+        )];
+
+        let result = db
+            .apply_partial_batch(
+                ops,
+                None,
+                |_cost, _left_over_ops| Ok(vec![]),
+                Some(&tx),
+                grove_version,
+            )
+            .unwrap();
+
+        match result {
+            Err(Error::DeletingNonEmptyTree(_)) => { /* expected */ }
+            Err(e) => panic!("expected DeletingNonEmptyTree, got: {:?}", e),
+            Ok(()) => panic!("expected error but got Ok"),
+        }
+    }
+
+    #[test]
+    fn test_batch_delete_non_merk_tree_delete_children_mode() {
+        // Non-Merk tree with DeleteChildren mode: should succeed even
+        // when non-empty and proceed with deletion.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        db.insert(
+            EMPTY_PATH,
+            b"ct_dc",
+            Element::empty_commitment_tree(4).expect("valid chunk_power"),
+            None,
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert commitment tree");
+
+        db.commitment_tree_insert_raw(
+            EMPTY_PATH,
+            b"ct_dc",
+            [1u8; 32],
+            [2u8; 32],
+            vec![0u8; 216],
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert commitment tree data");
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![],
+            b"ct_dc".to_vec(),
+            grovedb_merk::tree_type::TreeType::CommitmentTree(4),
+            SubelementsDeletionBehavior::DeleteChildren,
+        )];
+
+        db.apply_batch(ops, None, Some(&tx), grove_version)
+            .unwrap()
+            .expect("DeleteChildren on non-empty non-Merk tree should succeed");
+
+        assert!(
+            db.get(EMPTY_PATH, b"ct_dc", Some(&tx), grove_version)
+                .unwrap()
+                .is_err(),
+            "commitment tree should have been deleted"
+        );
+    }
+
     #[test]
     fn test_batch_delete_tree_skip_mode_mixed_batch() {
         // Batch with a DeleteTree of a non-empty tree (skipped) mixed with

--- a/grovedb/src/tests/batch_delete_tree_tests.rs
+++ b/grovedb/src/tests/batch_delete_tree_tests.rs
@@ -12,7 +12,7 @@ mod tests {
     use grovedb_version::version::GroveVersion;
 
     use crate::{
-        batch::{BatchApplyOptions, QualifiedGroveDbOp},
+        batch::{BatchApplyOptions, QualifiedGroveDbOp, SubelementsDeletionBehavior},
         tests::{common::EMPTY_PATH, make_empty_grovedb},
         Element, Error,
     };
@@ -53,17 +53,15 @@ mod tests {
         .unwrap()
         .expect("insert child item");
 
-        // Try to delete the non-empty tree via batch with default options
-        // (allow_deleting_non_empty_trees: false, deleting_non_empty_trees_returns_error: true)
+        // Try to delete the non-empty tree via batch with Error mode
         let ops = vec![QualifiedGroveDbOp::delete_tree_op(
             vec![],
             b"parent_tree".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: true,
             ..Default::default()
         });
 
@@ -119,11 +117,10 @@ mod tests {
             vec![],
             b"parent_tree".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::DontCheck,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: true,
-            deleting_non_empty_trees_returns_error: true,
             ..Default::default()
         });
 
@@ -160,11 +157,10 @@ mod tests {
             vec![],
             b"empty_tree".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: true,
             ..Default::default()
         });
 
@@ -226,16 +222,15 @@ mod tests {
         .unwrap()
         .expect("insert item into inner tree");
 
-        // Step 2: Delete the outer tree via batch (with allow_deleting_non_empty_trees)
+        // Step 2: Delete the outer tree via batch (with DontCheck for non-empty subtrees)
         let ops = vec![QualifiedGroveDbOp::delete_tree_op(
             vec![],
             b"outer".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::DontCheck,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: true,
-            deleting_non_empty_trees_returns_error: true,
             ..Default::default()
         });
 
@@ -358,10 +353,10 @@ mod tests {
             vec![],
             b"parent".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::DontCheck,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: true,
             ..Default::default()
         });
 
@@ -432,11 +427,10 @@ mod tests {
             vec![],
             b"skip_tree".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Skip,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: false,
             ..Default::default()
         });
 
@@ -490,11 +484,10 @@ mod tests {
             vec![],
             b"empty_tree".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Skip,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: false,
             ..Default::default()
         });
 
@@ -552,12 +545,15 @@ mod tests {
         // consider the tree empty.
         let ops = vec![
             QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child".to_vec()),
-            QualifiedGroveDbOp::delete_tree_op(vec![], b"parent".to_vec(), TreeType::NormalTree),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"parent".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::Error,
+            ),
         ];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: true,
             ..Default::default()
         });
 
@@ -617,12 +613,15 @@ mod tests {
         // The tree still has child2, so it should fail.
         let ops = vec![
             QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child1".to_vec()),
-            QualifiedGroveDbOp::delete_tree_op(vec![], b"parent".to_vec(), TreeType::NormalTree),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"parent".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::Error,
+            ),
         ];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: true,
             ..Default::default()
         });
 
@@ -680,11 +679,10 @@ mod tests {
             vec![],
             b"tree_a".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: true,
             ..Default::default()
         });
 
@@ -743,11 +741,10 @@ mod tests {
             vec![],
             b"tree_b".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Skip,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: false,
             ..Default::default()
         });
 
@@ -817,10 +814,10 @@ mod tests {
             vec![],
             b"outer".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::DontCheck,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: true,
             ..Default::default()
         });
 
@@ -898,12 +895,15 @@ mod tests {
         // Delete the only child and the parent tree in the same batch
         let ops = vec![
             QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"only_child".to_vec()),
-            QualifiedGroveDbOp::delete_tree_op(vec![], b"parent".to_vec(), TreeType::NormalTree),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"parent".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::Error,
+            ),
         ];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: true,
             ..Default::default()
         });
 
@@ -962,11 +962,10 @@ mod tests {
             vec![],
             b"tree_tx".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: true,
             ..Default::default()
         });
 
@@ -1034,10 +1033,10 @@ mod tests {
             vec![],
             b"l1".to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::DontCheck,
         )];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: true,
             ..Default::default()
         });
 
@@ -1107,8 +1106,18 @@ mod tests {
         // Batch: delete non-empty tree (should be skipped) and delete empty tree
         // (should succeed), plus insert an item
         let ops = vec![
-            QualifiedGroveDbOp::delete_tree_op(vec![], b"non_empty".to_vec(), TreeType::NormalTree),
-            QualifiedGroveDbOp::delete_tree_op(vec![], b"empty_one".to_vec(), TreeType::NormalTree),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"non_empty".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::Skip,
+            ),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"empty_one".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::Skip,
+            ),
             QualifiedGroveDbOp::insert_or_replace_op(
                 vec![],
                 b"new_item".to_vec(),
@@ -1117,8 +1126,6 @@ mod tests {
         ];
 
         let batch_options = Some(BatchApplyOptions {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: false,
             ..Default::default()
         });
 

--- a/grovedb/src/tests/batch_delete_tree_tests.rs
+++ b/grovedb/src/tests/batch_delete_tree_tests.rs
@@ -710,6 +710,71 @@ mod tests {
     }
 
     #[test]
+    fn test_batch_delete_all_children_plus_delete_tree_skip() {
+        // Delete ALL children explicitly + DeleteTree(Skip) on parent.
+        // The emptiness check runs and sees the tree as empty (all children
+        // are in the batch delete set via is_empty_tree_except), so the
+        // deletion proceeds normally — Skip never triggers.
+        let grove_version = GroveVersion::latest();
+        let db = make_empty_grovedb();
+
+        db.insert(
+            EMPTY_PATH,
+            b"parent",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert parent");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child1",
+            Element::new_item(b"v1".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child1");
+
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"child2",
+            Element::new_item(b"v2".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child2");
+
+        let ops = vec![
+            QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child1".to_vec()),
+            QualifiedGroveDbOp::delete_op(vec![b"parent".to_vec()], b"child2".to_vec()),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"parent".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::Skip,
+            ),
+        ];
+
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("delete all children + Skip parent should succeed (tree is empty)");
+
+        assert!(
+            db.get(EMPTY_PATH, b"parent", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "parent should have been deleted since tree was effectively empty"
+        );
+    }
+
+    #[test]
     fn test_batch_delete_tree_with_partial_child_delete_still_non_empty() {
         // When only some children are deleted in the same batch, the tree
         // should still be considered non-empty and the delete should fail.

--- a/grovedb/src/tests/batch_unit_tests.rs
+++ b/grovedb/src/tests/batch_unit_tests.rs
@@ -12,7 +12,9 @@ mod tests {
     use grovedb_version::version::GroveVersion;
 
     use crate::batch::key_info::KeyInfo::KnownKey;
-    use crate::batch::{GroveOp, KeyInfoPath, NonMerkTreeMeta, QualifiedGroveDbOp};
+    use crate::batch::{
+        GroveOp, KeyInfoPath, NonMerkTreeMeta, QualifiedGroveDbOp, SubelementsDeletionBehavior,
+    };
     use crate::reference_path::ReferencePathType;
     use crate::tests::{common::EMPTY_PATH, make_empty_grovedb, make_test_grovedb, TEST_LEAF};
     use crate::Element;
@@ -83,8 +85,8 @@ mod tests {
         };
 
         let all_ops: Vec<GroveOp> = vec![
-            GroveOp::DeleteTree(TreeType::NormalTree), // 0
-            GroveOp::Delete,                           // 2
+            GroveOp::DeleteTree(TreeType::NormalTree, SubelementsDeletionBehavior::Error), // 0
+            GroveOp::Delete,                                                               // 2
             GroveOp::InsertTreeWithRootHash {
                 // 3
                 hash: dummy_hash,
@@ -315,8 +317,12 @@ mod tests {
             path.clone(),
             key.clone(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::Error,
         );
-        assert!(matches!(op.op, GroveOp::DeleteTree(TreeType::NormalTree)));
+        assert!(matches!(
+            op.op,
+            GroveOp::DeleteTree(TreeType::NormalTree, SubelementsDeletionBehavior::Error)
+        ));
     }
 
     #[test]
@@ -372,6 +378,7 @@ mod tests {
                     vec![b"p".to_vec()],
                     b"k".to_vec(),
                     TreeType::NormalTree,
+                    SubelementsDeletionBehavior::Error,
                 ),
                 "Delete Tree",
             ),
@@ -555,6 +562,7 @@ mod tests {
                 vec![b"root".to_vec()],
                 b"subtree".to_vec(),
                 TreeType::NormalTree,
+                SubelementsDeletionBehavior::Error,
             ),
             QualifiedGroveDbOp::insert_or_replace_op(
                 vec![b"root".to_vec(), b"subtree".to_vec()],

--- a/grovedb/src/tests/misc_coverage_tests.rs
+++ b/grovedb/src/tests/misc_coverage_tests.rs
@@ -32,7 +32,7 @@ use crate::{
     batch::{
         estimated_costs::EstimatedCostsType::{AverageCaseCostsType, WorstCaseCostsType},
         key_info::KeyInfo,
-        KeyInfoPath, QualifiedGroveDbOp,
+        KeyInfoPath, QualifiedGroveDbOp, SubelementsDeletionBehavior,
     },
     operations::proof::util::{
         element_hex_to_ascii, hex_to_ascii, optional_element_hex_to_ascii,
@@ -1486,6 +1486,7 @@ fn batch_worst_case_delete_tree_cost() {
         vec![b"leaf".to_vec()],
         b"child_tree".to_vec(),
         TreeType::NormalTree,
+        SubelementsDeletionBehavior::Error,
     )];
 
     let mut paths = HashMap::new();
@@ -1523,6 +1524,7 @@ fn batch_average_case_delete_tree_cost() {
         vec![b"leaf".to_vec()],
         b"child_tree".to_vec(),
         TreeType::NormalTree,
+        SubelementsDeletionBehavior::Error,
     )];
 
     let mut paths = HashMap::new();
@@ -2357,6 +2359,7 @@ fn batch_worst_case_delete_sum_tree_cost() {
         vec![b"leaf".to_vec()],
         b"sum_tree_del".to_vec(),
         TreeType::SumTree,
+        SubelementsDeletionBehavior::Error,
     )];
 
     let mut paths = HashMap::new();
@@ -2394,6 +2397,7 @@ fn batch_average_case_delete_sum_tree_cost() {
         vec![b"leaf".to_vec()],
         b"sum_tree_del".to_vec(),
         TreeType::SumTree,
+        SubelementsDeletionBehavior::Error,
     )];
 
     let mut paths = HashMap::new();


### PR DESCRIPTION
## Summary

- Replaces the batch-level `allow_deleting_non_empty_trees` and `deleting_non_empty_trees_returns_error` flags on `BatchApplyOptions` with a per-operation `IsSubtreeNonEmpty` enum on `GroveOp::DeleteTree`
- New enum variants: `DontCheck`, `Error`, `DeleteChildren`, `Skip`
- `delete_tree_op()` and `delete_estimated_tree_op()` now take a 4th parameter specifying the emptiness policy
- This is a **breaking API change** — all callers of `delete_tree_op` must add the new parameter

## Motivation

PR #599 (batch DeleteTree emptiness enforcement) caused two categories of test failures in Platform:

1. **Fee assertion mismatches** — the batch-level emptiness check opens the child Merk for every `DeleteTree` op, even when the tree IS empty and the check passes. This adds seek/storage costs that change processing fees.

2. **DeletingNonEmptyTree errors** — code that relied on `allow_deleting_non_empty_trees: true` at the batch level now needs a way to express this per-op, since different ops in the same batch may need different policies.

Moving the policy to each `DeleteTree` op solves both: callers that know a tree is empty pass `DontCheck` (zero extra cost), and callers that need to force-delete pass `DontCheck` on just that op rather than the entire batch.

## Migration guide

| Old `BatchApplyOptions` flags | New `IsSubtreeNonEmpty` variant |
|---|---|
| `allow_deleting_non_empty_trees: true` | `IsSubtreeNonEmpty::DontCheck` |
| `allow_deleting_non_empty_trees: false, deleting_non_empty_trees_returns_error: true` (default) | `IsSubtreeNonEmpty::Error` |
| `allow_deleting_non_empty_trees: false, deleting_non_empty_trees_returns_error: false` | `IsSubtreeNonEmpty::Skip` |
| *(new)* | `IsSubtreeNonEmpty::DeleteChildren` |

## Test plan

- [x] All 1375 grovedb lib tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build --features full,estimated_costs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-operation control for delete-tree behavior via a new SubelementsDeletionBehavior with options: DontCheck, Error, DeleteChildren, Skip.

* **Breaking Changes**
  * Delete-tree constructors and operations now require the additional SubelementsDeletionBehavior parameter.
  * Batch-level options for non-empty-tree deletion were removed; deletion semantics are now specified per operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->