### PR TITLE
fix: version-gate commit_batch accumulated costs

### DIFF
--- a/grovedb-version/src/version/merk_versions.rs
+++ b/grovedb-version/src/version/merk_versions.rs
@@ -2,7 +2,15 @@ use versioned_feature_core::FeatureVersion;
 
 #[derive(Clone, Debug, Default)]
 pub struct MerkVersions {
+    pub commit: MerkCommitVersions,
     pub average_case_costs: MerkAverageCaseCostsVersions,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MerkCommitVersions {
+    /// Version 0: commit_batch discards accumulated batch costs (legacy bug)
+    /// Version 1: commit_batch returns accumulated batch costs
+    pub commit: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/grovedb-version/src/version/merk_versions.rs
+++ b/grovedb-version/src/version/merk_versions.rs
@@ -2,12 +2,12 @@ use versioned_feature_core::FeatureVersion;
 
 #[derive(Clone, Debug, Default)]
 pub struct MerkVersions {
-    pub commit: MerkCommitVersions,
+    pub batch: MerkBatchVersions,
     pub average_case_costs: MerkAverageCaseCostsVersions,
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct MerkCommitVersions {
+pub struct MerkBatchVersions {
     /// Version 0: commit_batch discards accumulated batch costs (legacy bug)
     /// Version 1: commit_batch returns accumulated batch costs
     pub commit: FeatureVersion,

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -9,7 +9,7 @@ use crate::version::{
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBVersions,
     },
-    merk_versions::{MerkAverageCaseCostsVersions, MerkCommitVersions, MerkVersions},
+    merk_versions::{MerkAverageCaseCostsVersions, MerkBatchVersions, MerkVersions},
     GroveVersion,
 };
 
@@ -206,7 +206,7 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
         },
     },
     merk_versions: MerkVersions {
-        commit: MerkCommitVersions { commit: 0 },
+        batch: MerkBatchVersions { commit: 0 },
         average_case_costs: MerkAverageCaseCostsVersions {
             add_average_case_merk_propagate: 0,
             sum_tree_estimated_size: 0,

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -9,7 +9,7 @@ use crate::version::{
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBVersions,
     },
-    merk_versions::{MerkAverageCaseCostsVersions, MerkVersions},
+    merk_versions::{MerkAverageCaseCostsVersions, MerkCommitVersions, MerkVersions},
     GroveVersion,
 };
 
@@ -206,6 +206,7 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
         },
     },
     merk_versions: MerkVersions {
+        commit: MerkCommitVersions { commit: 0 },
         average_case_costs: MerkAverageCaseCostsVersions {
             add_average_case_merk_propagate: 0,
             sum_tree_estimated_size: 0,

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -9,7 +9,7 @@ use crate::version::{
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBVersions,
     },
-    merk_versions::{MerkAverageCaseCostsVersions, MerkCommitVersions, MerkVersions},
+    merk_versions::{MerkAverageCaseCostsVersions, MerkBatchVersions, MerkVersions},
     GroveVersion,
 };
 
@@ -206,7 +206,7 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
         },
     },
     merk_versions: MerkVersions {
-        commit: MerkCommitVersions { commit: 0 },
+        batch: MerkBatchVersions { commit: 0 },
         average_case_costs: MerkAverageCaseCostsVersions {
             add_average_case_merk_propagate: 1, // changed
             sum_tree_estimated_size: 1,         // changed

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -9,7 +9,7 @@ use crate::version::{
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBVersions,
     },
-    merk_versions::{MerkAverageCaseCostsVersions, MerkVersions},
+    merk_versions::{MerkAverageCaseCostsVersions, MerkCommitVersions, MerkVersions},
     GroveVersion,
 };
 
@@ -206,6 +206,7 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
         },
     },
     merk_versions: MerkVersions {
+        commit: MerkCommitVersions { commit: 0 },
         average_case_costs: MerkAverageCaseCostsVersions {
             add_average_case_merk_propagate: 1, // changed
             sum_tree_estimated_size: 1,         // changed

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -9,7 +9,7 @@ use crate::version::{
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBVersions,
     },
-    merk_versions::{MerkAverageCaseCostsVersions, MerkCommitVersions, MerkVersions},
+    merk_versions::{MerkAverageCaseCostsVersions, MerkBatchVersions, MerkVersions},
     GroveVersion,
 };
 
@@ -206,7 +206,7 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
         },
     },
     merk_versions: MerkVersions {
-        commit: MerkCommitVersions { commit: 1 }, // return accumulated batch costs
+        batch: MerkBatchVersions { commit: 1 }, // return accumulated batch costs
         average_case_costs: MerkAverageCaseCostsVersions {
             add_average_case_merk_propagate: 1,
             sum_tree_estimated_size: 1,

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -9,7 +9,7 @@ use crate::version::{
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBVersions,
     },
-    merk_versions::{MerkAverageCaseCostsVersions, MerkVersions},
+    merk_versions::{MerkAverageCaseCostsVersions, MerkCommitVersions, MerkVersions},
     GroveVersion,
 };
 
@@ -206,6 +206,7 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
         },
     },
     merk_versions: MerkVersions {
+        commit: MerkCommitVersions { commit: 1 }, // return accumulated batch costs
         average_case_costs: MerkAverageCaseCostsVersions {
             add_average_case_merk_propagate: 1,
             sum_tree_estimated_size: 1,

--- a/merk/src/merk/apply.rs
+++ b/merk/src/merk/apply.rs
@@ -364,7 +364,13 @@ where
             // we set the new root node of the merk tree
             self.tree.set(maybe_tree);
             // commit changes to db
-            self.commit(key_updates, aux, options, old_specialized_cost)
+            self.commit(
+                key_updates,
+                aux,
+                options,
+                old_specialized_cost,
+                grove_version,
+            )
         })
     }
 }

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -384,6 +384,7 @@ where
         aux: &AuxMerkBatch<K>,
         options: Option<MerkOptions>,
         old_specialized_cost: &impl Fn(&Vec<u8>, &Vec<u8>) -> Result<u32, Error>,
+        grove_version: &GroveVersion,
     ) -> CostResult<(), Error>
     where
         K: AsRef<[u8]>,
@@ -501,10 +502,17 @@ where
         }
 
         // write to db
-        self.storage
-            .commit_batch(batch)
-            .map_err(StorageError)
-            .add_cost(cost)
+        let commit_result = self.storage.commit_batch(batch).map_err(StorageError);
+        if grove_version.merk_versions.commit.commit >= 1 {
+            // V1+: preserve accumulated batch costs (seek counts, storage costs)
+            commit_result.add_cost(cost)
+        } else {
+            // V0: discard batch costs (legacy behavior)
+            CostContext {
+                value: commit_result.value,
+                cost,
+            }
+        }
     }
 
     /// Walk

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -503,7 +503,7 @@ where
 
         // write to db
         let commit_result = self.storage.commit_batch(batch).map_err(StorageError);
-        if grove_version.merk_versions.commit.commit >= 1 {
+        if grove_version.merk_versions.batch.commit >= 1 {
             // V1+: preserve accumulated batch costs (seek counts, storage costs)
             commit_result.add_cost(cost)
         } else {


### PR DESCRIPTION
## Summary

- Version-gates the commit_batch cost fix from 4a0731e so it only applies to protocol version 3+
- V1/V2 (`commit: 0`): discard batch costs from `commit_batch` (legacy behavior matching pre-fix)
- V3 (`commit: 1`): preserve accumulated batch costs (seek counts, storage costs)
- Adds `MerkCommitVersions` struct to `MerkVersions` and passes `grove_version` through `Merk::commit`

## Test plan

- [x] `cargo build` clean
- [x] `cargo test -p grovedb-merk` — 344 passed
- [x] `cargo test -p grovedb --lib` — 1403 passed
- [x] `cargo test -p grovedb-version` — 47 passed
- [x] `cargo clippy -- -D warnings` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced version metadata for batch commits so the system can track batch-related commit behavior per release.

* **Refactor**
  * Commit handling is now version-aware: newer versions include accumulated batch costs in commit reports, while older versions preserve legacy cost reporting. Initialization of the new version metadata is included for supported releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->