### PR TITLE
ci: compile tests once, share archive across shards

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -62,10 +62,39 @@ jobs:
             echo "needs-tests=${{ steps.filter.outputs.any-code }}" >> "$GITHUB_OUTPUT"
           fi
 
-  test:
-    name: Test (${{ matrix.partition }}/3)
+  build-tests:
+    name: Build Tests
     needs: detect-changes
     if: needs.detect-changes.outputs.needs-tests == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: "false"
+          workspaces: ". -> target/llvm-cov-target"
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@cargo-nextest
+      - name: Build and archive tests
+        run: >
+          cargo llvm-cov nextest-archive
+          --workspace
+          --all-features
+          --archive-file tests.tar.zst
+      - name: Upload test archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextest-archive
+          path: tests.tar.zst
+
+  test:
+    name: Test (${{ matrix.partition }}/3)
+    needs: build-tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -78,22 +107,58 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: "false"
-          # cargo-llvm-cov uses target/llvm-cov-target/ instead of target/
-          workspaces: ". -> target/llvm-cov-target"
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@cargo-nextest
+      - name: Download test archive
+        uses: actions/download-artifact@v4
+        with:
+          name: nextest-archive
       - name: Run tests (shard ${{ matrix.partition }}/3)
         run: >
           cargo llvm-cov nextest
+          --no-report
           --workspace
           --all-features
+          --archive-file tests.tar.zst
           --partition count:${{ matrix.partition }}/3
+      - name: Upload profraw data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: profraw-${{ matrix.partition }}
+          path: target/llvm-cov-target/
+          include-hidden-files: true
+
+  coverage-report:
+    name: Coverage Report
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@cargo-nextest
+      - name: Download test archive
+        uses: actions/download-artifact@v4
+        with:
+          name: nextest-archive
+      - name: Download profraw data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: profraw-*
+          path: target/llvm-cov-target/
+          merge-multiple: true
+      - name: Generate coverage report
+        run: >
+          cargo llvm-cov report
+          --nextest-archive-file tests.tar.zst
           --lcov --output-path lcov.info
       - name: Upload coverage
-        if: always()
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info

--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -95,6 +95,7 @@ jobs:
   test:
     name: Test (${{ matrix.partition }}/3)
     needs: build-tests
+    if: needs.build-tests.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -131,8 +132,8 @@ jobs:
 
   coverage-report:
     name: Coverage Report
-    needs: test
-    if: always()
+    needs: [build-tests, test]
+    if: always() && needs.build-tests.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -118,8 +118,6 @@ jobs:
         run: >
           cargo llvm-cov nextest
           --no-report
-          --workspace
-          --all-features
           --archive-file tests.tar.zst
           --partition count:${{ matrix.partition }}/3
       - name: Upload profraw data

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -1,3 +1,4 @@
+// CI: trigger test pipeline for workflow validation
 //! GroveDB is a database that enables cryptographic proofs for complex queries.
 //!
 //! # Examples


### PR DESCRIPTION
## Summary

- Split the monolithic test job into three stages: **build → test (3 shards) → coverage report**
- Uses `cargo llvm-cov nextest-archive` to compile instrumented binaries once and produce a nextest archive (`tests.tar.zst`)
- Each test shard downloads the archive and runs its partition without recompilation
- A final `coverage-report` job merges `.profraw` data from all shards and generates the combined lcov report for Codecov

This should reduce total CI compute time since compilation (the most expensive step) now happens once instead of three times.

## How it works

| Job | What it does | Depends on |
|-----|-------------|------------|
| `build-tests` | Compiles workspace with LLVM instrumentation, creates `tests.tar.zst` | `detect-changes` |
| `test` (x3) | Downloads archive, runs sharded tests (`--partition count:N/3`), uploads `.profraw` data | `build-tests` |
| `coverage-report` | Downloads archive + all profraw data, runs `cargo llvm-cov report`, uploads to Codecov | `test` |

## Test plan

- [ ] CI passes on this PR (the workflow runs against itself)
- [ ] Coverage report appears on Codecov
- [ ] Compare total CI wall time vs previous approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reorganized CI/CD infrastructure for streamlined test execution and coverage reporting
  * Optimized test artifact handling with partitioned execution for improved efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->