### PR TITLE
ci: self-hosted Mac runner with Ubuntu fallback

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -62,8 +62,38 @@ jobs:
             echo "needs-tests=${{ steps.filter.outputs.any-code }}" >> "$GITHUB_OUTPUT"
           fi
 
-  test:
-    name: Test (${{ matrix.partition }}/3)
+  # Fast path: run all tests on self-hosted Mac runner (no sharding needed)
+  test-mac:
+    name: Test (macOS)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.needs-tests == 'true'
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@cargo-nextest
+      - name: Run all tests
+        run: >
+          cargo llvm-cov nextest
+          --workspace
+          --all-features
+          --lcov --output-path lcov.info
+      - name: Upload coverage
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+  # Fallback: if Mac runner doesn't pick up the job within 15s, run sharded on Ubuntu
+  test-ubuntu:
+    name: Test Ubuntu (${{ matrix.partition }}/3)
     needs: detect-changes
     if: needs.detect-changes.outputs.needs-tests == 'true'
     runs-on: ubuntu-latest
@@ -72,20 +102,41 @@ jobs:
       matrix:
         partition: [1, 2, 3]
     steps:
+      - name: Wait and check if Mac runner is available
+        id: check-mac
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sleep 15
+          MAC_STATUS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            --jq '.jobs[] | select(.name == "Test (macOS)") | .status' 2>/dev/null || echo "unknown")
+          echo "mac-status=$MAC_STATUS" >> "$GITHUB_OUTPUT"
+          if [ "$MAC_STATUS" = "in_progress" ]; then
+            echo "Mac runner picked up the job — skipping Ubuntu fallback"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Mac runner not available (status: $MAC_STATUS) — running on Ubuntu"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@v4
+        if: steps.check-mac.outputs.skip == 'false'
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.check-mac.outputs.skip == 'false'
         with:
           components: llvm-tools
       - uses: Swatinem/rust-cache@v2
+        if: steps.check-mac.outputs.skip == 'false'
         with:
           cache-on-failure: "false"
-          # cargo-llvm-cov uses target/llvm-cov-target/ instead of target/
           workspaces: ". -> target/llvm-cov-target"
       - uses: taiki-e/install-action@cargo-llvm-cov
+        if: steps.check-mac.outputs.skip == 'false'
       - uses: taiki-e/install-action@cargo-nextest
+        if: steps.check-mac.outputs.skip == 'false'
       - name: Run tests (shard ${{ matrix.partition }}/3)
+        if: steps.check-mac.outputs.skip == 'false'
         run: >
           cargo llvm-cov nextest
           --workspace
@@ -93,7 +144,7 @@ jobs:
           --partition count:${{ matrix.partition }}/3
           --lcov --output-path lcov.info
       - name: Upload coverage
-        if: always()
+        if: always() && steps.check-mac.outputs.skip == 'false'
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -1,3 +1,4 @@
+// CI trigger
 //! GroveDB is a database that enables cryptographic proofs for complex queries.
 //!
 //! # Examples


### PR DESCRIPTION
## Summary

- Adds a **fast path** using the self-hosted Apple Silicon runner (`[self-hosted, macOS, ARM64]`) that runs all tests in a single job without sharding
- **Ubuntu fallback**: if the Mac runner doesn't pick up the job within 15 seconds, the existing 3-shard Ubuntu test run proceeds as before
- Both paths produce LLVM coverage and upload to Codecov

## How it works

```
detect-changes
  ├── test-mac        → [self-hosted, macOS, ARM64] — runs all tests, no sharding
  └── test-ubuntu x3  → sleeps 15s, checks if Mac job started
                         ├── Mac running → skip (exit early)
                         └── Mac queued  → run sharded tests as fallback
```

The Ubuntu jobs use the GitHub API to check the Mac job's status:
```bash
gh api repos/.../actions/runs/$RUN_ID/jobs \
  --jq '.jobs[] | select(.name == "Test (macOS)") | .status'
```

If `in_progress` → Mac runner is handling it, Ubuntu skips. If still `queued` → Mac runner unavailable, Ubuntu takes over.

## Why

- Apple Silicon compiles Rust significantly faster than the 4-core Ubuntu runners
- No sharding needed on Mac = simpler, no 3x compilation overhead
- Automatic fallback ensures CI never blocks when the Mac runner is busy

## Test plan

- [ ] When Mac runner is available: Mac job runs tests, Ubuntu jobs skip after 15s
- [ ] When Mac runner is busy: Ubuntu jobs detect queued status and run sharded tests
- [ ] Coverage uploads to Codecov from whichever path runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CI test workflow to implement optimized macOS fast-path execution on self-hosted runners with conditional fallback to sharded Ubuntu tests
  * Added runner availability detection mechanism with 15-second window to determine optimal test execution path
  * Updated coverage upload logic to be conditional based on workflow execution status and runner availability flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->