### PR TITLE
docs: add per-tree-type proof node reference

### DIFF
--- a/docs/book/src/proof-system.md
+++ b/docs/book/src/proof-system.md
@@ -178,9 +178,31 @@ the **role** of the node in the proof. There are four roles:
 
 ### Regular Trees (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
 
-These tree types use `compute_hash` (= `node_hash(kv_hash, left, right)`) for
-all nodes. The feature_type (BasicMerkNode, SummedMerkNode, etc.) is **not**
-included in the hash.
+All five of these tree types use identical proof node types and the same hash
+function: `compute_hash` (= `node_hash(kv_hash, left, right)`). There is **no
+difference** in how they are proved at the merk level.
+
+Each merk node carries a `feature_type` internally (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode), but
+this is **not included in the hash** and **not included in the proof**. The
+aggregate data (sum, count) for these tree types lives in the **parent**
+Element's serialized bytes, which are hash-verified through the parent tree's
+proof:
+
+| Tree type | Element stores | Merk feature_type (not hashed) |
+|-----------|---------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **Where does the sum/count come from?** When a verifier processes a proof
+> for `[root, my_sum_tree]`, the parent tree's proof includes a
+> `KVValueHash` node for key `my_sum_tree`. The `value` field contains the
+> serialized `Element::SumTree(root_key, 42, flags)`. Since this value is
+> hash-verified (its hash is committed to the parent Merkle root), the
+> sum `42` is trustworthy. The merk-level feature_type is irrelevant.
 
 | Role | Node Type | Data | Hash function |
 |------|-----------|------|---------------|
@@ -239,9 +261,10 @@ verification.
 
 > **ProvableCountSumTree note:** Only the **count** is included in the hash. The
 > sum is carried in the feature_type (`ProvableCountedSummedMerkNode(count,
-> sum)`) but is **not hashed**. The sum is informational metadata at the merk
-> proof level; the canonical sum value lives in the parent `Element::CountSumTree`
-> bytes, which are hash-verified in the parent tree's proof.
+> sum)`) but is **not hashed**. Like the regular tree types above, the canonical
+> sum value lives in the parent Element's serialized bytes (e.g.
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`), which are
+> hash-verified in the parent tree's proof.
 
 ### Summary: Node Type → Tree Type Matrix
 

--- a/docs/book/src/proof-system.md
+++ b/docs/book/src/proof-system.md
@@ -164,6 +164,102 @@ Encoded as proof ops:
 | 8 | Push(Hash(frank_node_hash)) | Push frank hash |
 | 9 | Child | frank becomes right child of dave |
 
+## Proof Node Types by Tree Type
+
+Each tree type in GroveDB uses a specific set of proof node types depending on
+the **role** of the node in the proof. There are four roles:
+
+| Role | Description |
+|------|-------------|
+| **Queried** | The node matches the query — full key + value revealed |
+| **On-path** | The node is an ancestor of queried nodes — only kv_hash needed |
+| **Boundary** | Adjacent to a missing key — proves absence |
+| **Distant** | A sibling subtree not on the proof path — only node_hash needed |
+
+### Regular Trees (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+These tree types use `compute_hash` (= `node_hash(kv_hash, left, right)`) for
+all nodes. The feature_type (BasicMerkNode, SummedMerkNode, etc.) is **not**
+included in the hash.
+
+| Role | Node Type | Data | Hash function |
+|------|-----------|------|---------------|
+| Queried item | `KV(key, value)` | Full key + value | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Queried subtree | `KVValueHash(key, value, value_hash)` | Key + element bytes + pre-computed value_hash | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Queried reference | `KVValueHash` at merk level → post-processed to `KVRefValueHash(key, deref_value, ref_hash)` | Key + dereferenced value + reference element hash | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| On-path | `KVHash(kv_hash)` | 32-byte kv_hash only | `node_hash(kv_hash, left, right)` |
+| Boundary | `KVDigest(key, value_hash)` | Key + value_hash (no value) | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Distant | `Hash(node_hash)` | 32-byte hash only | Used directly |
+
+> **Why `KVValueHash` for subtrees?** A subtree's value_hash is
+> `combine_hash(H(element_bytes), child_root_hash)` — the verifier cannot
+> recompute this from the element bytes alone (it would need the child root
+> hash). So the prover provides the pre-computed value_hash.
+>
+> **Why `KV` for items?** An item's value_hash is simply `H(value)`, which the
+> verifier can recompute. Using `KV` is tamper-proof: if the prover changes the
+> value, the hash won't match.
+
+**V1 enhancement — `KVValueHashFeatureTypeWithChildHash`:** In V1 proofs, when a
+queried subtree has no subquery (the query stops at this tree), the GroveDB layer
+upgrades `KVValueHash` to `KVValueHashFeatureTypeWithChildHash(key, value,
+value_hash, feature_type, child_hash)`. This lets the verifier check
+`combine_hash(H(value), child_hash) == value_hash`, preventing an attacker from
+swapping the element bytes while reusing the original value_hash.
+
+> **Security note on feature_type:** For regular (non-provable) trees, the
+> `feature_type` field in `KVValueHashFeatureType` and
+> `KVValueHashFeatureTypeWithChildHash` is decoded but **not used** for hash
+> computation or returned to callers. The canonical tree type lives in the
+> hash-verified Element bytes. This field only matters for ProvableCountTree
+> (see below).
+
+### ProvableCountTree and ProvableCountSumTree
+
+These tree types use `node_hash_with_count(kv_hash, left, right, count)` instead
+of `node_hash`. The **count** is included in the hash, so the verifier needs
+the count for every node to recompute the Merkle root.
+
+| Role | Node Type | Data | Hash function |
+|------|-----------|------|---------------|
+| Queried item | `KVCount(key, value, count)` | Key + value + aggregate count | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Queried subtree | `KVValueHashFeatureType(key, value, value_hash, feature_type)` | Key + element bytes + value_hash + feature_type with count | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Queried reference | `KVValueHashFeatureType` at merk level → post-processed to `KVRefValueHashCount(key, deref_value, ref_hash, count)` | Key + dereferenced value + ref hash + count | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| On-path | `KVHashCount(kv_hash, count)` | 32-byte kv_hash + count | `node_hash_with_count(kv_hash, left, right, count)` |
+| Boundary | `KVDigestCount(key, value_hash, count)` | Key + value_hash + count | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Distant | `Hash(node_hash)` | 32-byte hash only | Used directly |
+
+> **Why does every node carry a count?** Because `node_hash_with_count` is used
+> instead of `node_hash`. Without the count, the verifier cannot reconstruct
+> any intermediate hash on the path to the root — even for non-queried nodes.
+
+**V1 enhancement:** Same as regular trees — queried subtrees without subqueries
+get upgraded to `KVValueHashFeatureTypeWithChildHash` for `combine_hash`
+verification.
+
+> **ProvableCountSumTree note:** Only the **count** is included in the hash. The
+> sum is carried in the feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`) but is **not hashed**. The sum is informational metadata at the merk
+> proof level; the canonical sum value lives in the parent `Element::CountSumTree`
+> bytes, which are hash-verified in the parent tree's proof.
+
+### Summary: Node Type → Tree Type Matrix
+
+| Node Type | Regular Trees | ProvableCount Trees |
+|-----------|:------------:|:-------------------:|
+| `KV` | Queried items | — |
+| `KVCount` | — | Queried items |
+| `KVValueHash` | Queried subtrees | — |
+| `KVValueHashFeatureType` | — | Queried subtrees |
+| `KVRefValueHash` | Queried references | — |
+| `KVRefValueHashCount` | — | Queried references |
+| `KVHash` | On-path | — |
+| `KVHashCount` | — | On-path |
+| `KVDigest` | Boundary/absence | — |
+| `KVDigestCount` | — | Boundary/absence |
+| `Hash` | Distant siblings | Distant siblings |
+| `KVValueHashFeatureTypeWithChildHash` | V1: subtrees without subquery | V1: subtrees without subquery |
+
 ## Multi-Layer Proof Generation
 
 Since GroveDB is a tree of trees, proofs span multiple layers. Each layer proves

--- a/docs/book/src/proof-system.md
+++ b/docs/book/src/proof-system.md
@@ -204,14 +204,19 @@ proof:
 > hash-verified (its hash is committed to the parent Merkle root), the
 > sum `42` is trustworthy. The merk-level feature_type is irrelevant.
 
-| Role | Node Type | Data | Hash function |
-|------|-----------|------|---------------|
-| Queried item | `KV(key, value)` | Full key + value | `node_hash(kv_hash(key, H(value)), left, right)` |
-| Queried subtree | `KVValueHash(key, value, value_hash)` | Key + element bytes + pre-computed value_hash | `node_hash(kv_hash(key, value_hash), left, right)` |
-| Queried reference | `KVValueHash` at merk level → post-processed to `KVRefValueHash(key, deref_value, ref_hash)` | Key + dereferenced value + reference element hash | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
-| On-path | `KVHash(kv_hash)` | 32-byte kv_hash only | `node_hash(kv_hash, left, right)` |
-| Boundary | `KVDigest(key, value_hash)` | Key + value_hash (no value) | `node_hash(kv_hash(key, value_hash), left, right)` |
-| Distant | `Hash(node_hash)` | 32-byte hash only | Used directly |
+| Role | V0 Node Type | V1 Node Type | Hash function |
+|------|-------------|-------------|---------------|
+| Queried item | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Queried non-empty tree (no subquery) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Queried empty tree | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Queried reference | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| On-path | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Boundary | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Distant | `Hash` | `Hash` | Used directly |
+
+> **Non-empty trees WITH a subquery** descend into the child layer — the tree
+> node appears as `KVValueHash` in the parent layer proof and the child layer
+> has its own proof.
 
 > **Why `KVValueHash` for subtrees?** A subtree's value_hash is
 > `combine_hash(H(element_bytes), child_root_hash)` — the verifier cannot
@@ -223,18 +228,20 @@ proof:
 > value, the hash won't match.
 
 **V1 enhancement — `KVValueHashFeatureTypeWithChildHash`:** In V1 proofs, when a
-queried subtree has no subquery (the query stops at this tree), the GroveDB layer
-upgrades `KVValueHash` to `KVValueHashFeatureTypeWithChildHash(key, value,
-value_hash, feature_type, child_hash)`. This lets the verifier check
-`combine_hash(H(value), child_hash) == value_hash`, preventing an attacker from
-swapping the element bytes while reusing the original value_hash.
+queried non-empty tree has no subquery (the query stops at this tree — the tree
+element itself is the result), the GroveDB layer upgrades the merk node to
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)`. This lets the verifier check `combine_hash(H(value), child_hash)
+== value_hash`, preventing an attacker from swapping the element bytes while
+reusing the original value_hash. Empty trees are not upgraded because they have
+no child merk to provide a root hash.
 
 > **Security note on feature_type:** For regular (non-provable) trees, the
 > `feature_type` field in `KVValueHashFeatureType` and
 > `KVValueHashFeatureTypeWithChildHash` is decoded but **not used** for hash
 > computation or returned to callers. The canonical tree type lives in the
 > hash-verified Element bytes. This field only matters for ProvableCountTree
-> (see below).
+> (see below), where it carries the count needed for `node_hash_with_count`.
 
 ### ProvableCountTree and ProvableCountSumTree
 
@@ -242,22 +249,26 @@ These tree types use `node_hash_with_count(kv_hash, left, right, count)` instead
 of `node_hash`. The **count** is included in the hash, so the verifier needs
 the count for every node to recompute the Merkle root.
 
-| Role | Node Type | Data | Hash function |
-|------|-----------|------|---------------|
-| Queried item | `KVCount(key, value, count)` | Key + value + aggregate count | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
-| Queried subtree | `KVValueHashFeatureType(key, value, value_hash, feature_type)` | Key + element bytes + value_hash + feature_type with count | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
-| Queried reference | `KVValueHashFeatureType` at merk level → post-processed to `KVRefValueHashCount(key, deref_value, ref_hash, count)` | Key + dereferenced value + ref hash + count | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
-| On-path | `KVHashCount(kv_hash, count)` | 32-byte kv_hash + count | `node_hash_with_count(kv_hash, left, right, count)` |
-| Boundary | `KVDigestCount(key, value_hash, count)` | Key + value_hash + count | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
-| Distant | `Hash(node_hash)` | 32-byte hash only | Used directly |
+| Role | V0 Node Type | V1 Node Type | Hash function |
+|------|-------------|-------------|---------------|
+| Queried item | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Queried non-empty tree (no subquery) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Queried empty tree | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Queried reference | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| On-path | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Boundary | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Distant | `Hash` | `Hash` | Used directly |
+
+> **Non-empty trees WITH a subquery** descend into the child layer, same as
+> regular trees.
 
 > **Why does every node carry a count?** Because `node_hash_with_count` is used
 > instead of `node_hash`. Without the count, the verifier cannot reconstruct
 > any intermediate hash on the path to the root — even for non-queried nodes.
 
-**V1 enhancement:** Same as regular trees — queried subtrees without subqueries
-get upgraded to `KVValueHashFeatureTypeWithChildHash` for `combine_hash`
-verification.
+**V1 enhancement:** Same as regular trees — queried non-empty trees without
+subqueries get upgraded to `KVValueHashFeatureTypeWithChildHash` for
+`combine_hash` verification.
 
 > **ProvableCountSumTree note:** Only the **count** is included in the hash. The
 > sum is carried in the feature_type (`ProvableCountedSummedMerkNode(count,
@@ -281,7 +292,7 @@ verification.
 | `KVDigest` | Boundary/absence | — |
 | `KVDigestCount` | — | Boundary/absence |
 | `Hash` | Distant siblings | Distant siblings |
-| `KVValueHashFeatureTypeWithChildHash` | V1: subtrees without subquery | V1: subtrees without subquery |
+| `KVValueHashFeatureTypeWithChildHash` | — | Non-empty trees without subquery |
 
 ## Multi-Layer Proof Generation
 

--- a/docs/book/translations/ar/src/proof-system.md
+++ b/docs/book/translations/ar/src/proof-system.md
@@ -163,6 +163,134 @@ graph TD
 | 8 | Push(Hash(frank_node_hash)) | ادفع تجزئة فرانك |
 | 9 | Child | فرانك يصبح ابناً أيمن لديف |
 
+## أنواع عقد البرهان حسب نوع الشجرة
+
+كل نوع شجرة في GroveDB يستخدم مجموعة محددة من أنواع عقد البرهان بناءً على
+**دور** العقدة في البرهان. هناك أربعة أدوار:
+
+| الدور | الوصف |
+|-------|-------|
+| **مُستعلَمة** | العقدة تطابق الاستعلام — المفتاح والقيمة الكاملان مكشوفان |
+| **على المسار** | العقدة سلف للعقد المُستعلَمة — فقط kv_hash مطلوب |
+| **حدّية** | مجاورة لمفتاح مفقود — تُثبت الغياب |
+| **بعيدة** | شجرة فرعية شقيقة ليست على مسار البرهان — فقط node_hash مطلوب |
+
+### الأشجار العادية (Tree، SumTree، BigSumTree، CountTree، CountSumTree)
+
+جميع هذه الأنواع الخمسة من الأشجار تستخدم أنواع عقد برهان متطابقة ونفس دالة
+التجزئة: `compute_hash` (= `node_hash(kv_hash, left, right)`). **لا يوجد فرق**
+في كيفية إثباتها على مستوى merk.
+
+كل عقدة merk تحمل `feature_type` داخلياً (BasicMerkNode،
+SummedMerkNode، BigSummedMerkNode، CountedMerkNode، CountedSummedMerkNode)، لكن
+هذا **غير مُدرج في التجزئة** و**غير مُدرج في البرهان**. البيانات
+التجميعية (المجموع، العدد) لهذه الأنواع من الأشجار تعيش في بايتات
+Element **الأب** المُرمَّزة، والتي يتم التحقق من تجزئتها عبر برهان الشجرة الأب:
+
+| نوع الشجرة | ما يُخزّنه Element | feature_type في Merk (غير مُجزَّأ) |
+|------------|-------------------|----------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **من أين يأتي المجموع/العدد؟** عندما يعالج المُحقّق برهاناً
+> لـ `[root, my_sum_tree]`، برهان الشجرة الأب يتضمن عقدة
+> `KVValueHash` للمفتاح `my_sum_tree`. حقل `value` يحتوي على
+> `Element::SumTree(root_key, 42, flags)` المُرمَّز. بما أن هذه القيمة
+> مُتحقق من تجزئتها (تجزئتها ملتزمة بجذر ميركل الأب)، فإن
+> المجموع `42` موثوق. الـ feature_type على مستوى merk غير ذي صلة.
+
+| الدور | نوع العقدة V0 | نوع العقدة V1 | دالة التجزئة |
+|-------|--------------|--------------|-------------|
+| عنصر مُستعلَم | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| شجرة غير فارغة مُستعلَمة (بدون استعلام فرعي) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| شجرة فارغة مُستعلَمة | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| مرجع مُستعلَم | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| على المسار | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| حدّية | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| بعيدة | `Hash` | `Hash` | تُستخدم مباشرة |
+
+> **الأشجار غير الفارغة مع استعلام فرعي** تنزل إلى طبقة الابن — عقدة الشجرة
+> تظهر كـ `KVValueHash` في برهان الطبقة الأب وطبقة الابن لها برهانها الخاص.
+
+> **لماذا `KVValueHash` للأشجار الفرعية؟** value_hash للشجرة الفرعية هو
+> `combine_hash(H(element_bytes), child_root_hash)` — المُحقّق لا يمكنه
+> إعادة حسابه من بايتات element وحدها (سيحتاج إلى تجزئة جذر الابن). لذا
+> يوفر المُثبِت value_hash المحسوب مسبقاً.
+>
+> **لماذا `KV` للعناصر؟** value_hash للعنصر هو ببساطة `H(value)`، والذي يمكن
+> للمُحقّق إعادة حسابه. استخدام `KV` آمن ضد التلاعب: إذا غيّر المُثبِت
+> القيمة، فلن تتطابق التجزئة.
+
+**تحسين V1 — `KVValueHashFeatureTypeWithChildHash`:** في براهين V1، عندما تكون
+الشجرة غير الفارغة المُستعلَمة بدون استعلام فرعي (الاستعلام يتوقف عند هذه الشجرة —
+عنصر الشجرة نفسه هو النتيجة)، تقوم طبقة GroveDB بترقية عقدة merk إلى
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)`. هذا يسمح للمُحقّق بفحص `combine_hash(H(value), child_hash)
+== value_hash`، مما يمنع المهاجم من تبديل بايتات element مع إعادة استخدام
+value_hash الأصلي. الأشجار الفارغة لا تُرقّى لأنها لا تملك merk ابن
+لتوفير تجزئة جذر.
+
+> **ملاحظة أمنية حول feature_type:** للأشجار العادية (غير القابلة للإثبات)، حقل
+> `feature_type` في `KVValueHashFeatureType` و
+> `KVValueHashFeatureTypeWithChildHash` يتم فك ترميزه لكنه **لا يُستخدم** لحساب
+> التجزئة أو يُعاد للمستدعين. نوع الشجرة الأصلي موجود في بايتات Element
+> المُتحقق من تجزئتها. هذا الحقل مهم فقط لـ ProvableCountTree
+> (انظر أدناه)، حيث يحمل العدد المطلوب لـ `node_hash_with_count`.
+
+### ProvableCountTree وProvableCountSumTree
+
+هذه الأنواع من الأشجار تستخدم `node_hash_with_count(kv_hash, left, right, count)` بدلاً
+من `node_hash`. **العدد** مُدرج في التجزئة، لذا يحتاج المُحقّق
+إلى العدد لكل عقدة لإعادة حساب جذر ميركل.
+
+| الدور | نوع العقدة V0 | نوع العقدة V1 | دالة التجزئة |
+|-------|--------------|--------------|-------------|
+| عنصر مُستعلَم | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| شجرة غير فارغة مُستعلَمة (بدون استعلام فرعي) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| شجرة فارغة مُستعلَمة | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| مرجع مُستعلَم | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| على المسار | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| حدّية | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| بعيدة | `Hash` | `Hash` | تُستخدم مباشرة |
+
+> **الأشجار غير الفارغة مع استعلام فرعي** تنزل إلى طبقة الابن، كما في
+> الأشجار العادية.
+
+> **لماذا تحمل كل عقدة عدداً؟** لأن `node_hash_with_count` تُستخدم بدلاً
+> من `node_hash`. بدون العدد، لا يمكن للمُحقّق إعادة بناء أي تجزئة وسيطة
+> على المسار إلى الجذر — حتى للعقد غير المُستعلَمة.
+
+**تحسين V1:** نفس الأشجار العادية — الأشجار غير الفارغة المُستعلَمة بدون
+استعلامات فرعية تُرقّى إلى `KVValueHashFeatureTypeWithChildHash` للتحقق
+من `combine_hash`.
+
+> **ملاحظة حول ProvableCountSumTree:** فقط **العدد** مُدرج في التجزئة. المجموع
+> محمول في feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`) لكنه **غير مُجزَّأ**. كما في أنواع الأشجار العادية أعلاه، قيمة
+> المجموع الأصلية موجودة في بايتات Element الأب المُرمَّزة (مثلاً
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`)، والتي يتم
+> التحقق من تجزئتها في برهان الشجرة الأب.
+
+### ملخص: مصفوفة نوع العقدة → نوع الشجرة
+
+| نوع العقدة | الأشجار العادية | أشجار ProvableCount |
+|-----------|:--------------:|:------------------:|
+| `KV` | عناصر مُستعلَمة | — |
+| `KVCount` | — | عناصر مُستعلَمة |
+| `KVValueHash` | أشجار فرعية مُستعلَمة | — |
+| `KVValueHashFeatureType` | — | أشجار فرعية مُستعلَمة |
+| `KVRefValueHash` | مراجع مُستعلَمة | — |
+| `KVRefValueHashCount` | — | مراجع مُستعلَمة |
+| `KVHash` | على المسار | — |
+| `KVHashCount` | — | على المسار |
+| `KVDigest` | حدّية/غياب | — |
+| `KVDigestCount` | — | حدّية/غياب |
+| `Hash` | أشقاء بعيدون | أشقاء بعيدون |
+| `KVValueHashFeatureTypeWithChildHash` | — | أشجار غير فارغة بدون استعلام فرعي |
+
 ## توليد البراهين متعددة الطبقات
 
 بما أن GroveDB هو شجرة من الأشجار، فالبراهين تمتد عبر طبقات متعددة. كل طبقة تُثبت

--- a/docs/book/translations/cs/src/proof-system.md
+++ b/docs/book/translations/cs/src/proof-system.md
@@ -164,6 +164,136 @@ Zakodovano jako operace dukazu:
 | 8 | Push(Hash(frank_node_hash)) | Vlozit hash frank |
 | 9 | Child | frank se stane pravym potomkem dave |
 
+## Typy uzlu dukazu podle typu stromu
+
+Kazdy typ stromu v GroveDB pouziva specifickou sadu typu uzlu dukazu v zavislosti
+na **roli** uzlu v dukazu. Existuji ctyri role:
+
+| Role | Popis |
+|------|-------|
+| **Dotazovany** | Uzel odpovida dotazu — odhalen uplny klic + hodnota |
+| **Na ceste** | Uzel je predkem dotazovanych uzlu — potreba pouze kv_hash |
+| **Hranicni** | Sousedi s chybejicim klicem — dokazuje neexistenci |
+| **Vzdáleny** | Sourozenecky podstrom mimo cestu dukazu — potreba pouze node_hash |
+
+### Bezne stromy (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Vsech pet techto typu stromu pouziva identicke typy uzlu dukazu a stejnou
+hashovaci funkci: `compute_hash` (= `node_hash(kv_hash, left, right)`). **Neni
+zadny rozdil** v tom, jak jsou dokazovany na urovni merk.
+
+Kazdy uzel merk nese `feature_type` interne (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode), ale
+ten **neni zahrnut v hashi** a **neni zahrnut v dukazu**. Agregovana
+data (soucet, pocet) pro tyto typy stromu ziji v serializovanych bajtech
+**rodicovskeho** Elementu, ktere jsou overeny hashem prostrednictvim dukazu
+rodicovskeho stromu:
+
+| Typ stromu | Element uklada | feature_type v Merk (nehashovany) |
+|-----------|----------------|----------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **Odkud pochazi soucet/pocet?** Kdyz overovatel zpracovava dukaz
+> pro `[root, my_sum_tree]`, dukaz rodicovskeho stromu obsahuje uzel
+> `KVValueHash` pro klic `my_sum_tree`. Pole `value` obsahuje
+> serializovany `Element::SumTree(root_key, 42, flags)`. Protoze je tato hodnota
+> overena hashem (jeji hash je vlozen do rodicovskeho Merklova korene),
+> soucet `42` je duveryhod ny. feature_type na urovni merk je irelevantni.
+
+| Role | Typ uzlu V0 | Typ uzlu V1 | Hashovaci funkce |
+|------|------------|------------|-----------------|
+| Dotazovana polozka | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Dotazovany neprazdny strom (bez poddotazu) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Dotazovany prazdny strom | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Dotazovana reference | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| Na ceste | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Hranicni | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Vzdáleny | `Hash` | `Hash` | Pouzit primo |
+
+> **Neprazdne stromy S poddotazem** sestupuji do podrizene vrstvy — uzel stromu
+> se objevi jako `KVValueHash` v dukazu rodicovske vrstvy a podrizena vrstva
+> ma svuj vlastni dukaz.
+
+> **Proc `KVValueHash` pro podstromy?** value_hash podstromu je
+> `combine_hash(H(element_bytes), child_root_hash)` — overovatel to nemuze
+> prepocitat pouze z bajtu element (potreboval by korenovy hash potomka). Takze
+> dokazovatel poskytne predvypocteny value_hash.
+>
+> **Proc `KV` pro polozky?** value_hash polozky je jednoduche `H(value)`, ktere
+> overovatel muze prepocitat. Pouziti `KV` je odolne vuci manipulaci: pokud
+> dokazovatel zmeni hodnotu, hash nebude souhlasit.
+
+**Vylepseni V1 — `KVValueHashFeatureTypeWithChildHash`:** V dukazech V1, kdyz
+dotazovany neprazdny strom nema poddotaz (dotaz konci u tohoto stromu — prvek
+stromu samotny je vysledek), vrstva GroveDB upgraduje uzel merk na
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)`. To umoznuje overovateli zkontrolovat `combine_hash(H(value), child_hash)
+== value_hash`, cimz brani utocnikovi v zamene bajtu elementu pri
+znovupouziti puvodniho value_hash. Prazdne stromy nejsou upgradevany, protoze
+nemaji podrizeny merk, ktery by poskytl korenovy hash.
+
+> **Bezpecnostni poznamka k feature_type:** Pro bezne (nedokazatelne) stromy je
+> pole `feature_type` v `KVValueHashFeatureType` a
+> `KVValueHashFeatureTypeWithChildHash` dekodovano, ale **nepouzivano** pro vypocet
+> hashe ani vraceno volajicim. Kanonicky typ stromu je v bajtech Element
+> overenych hashem. Toto pole je dulezite pouze pro ProvableCountTree
+> (viz nize), kde nese pocet potrebny pro `node_hash_with_count`.
+
+### ProvableCountTree a ProvableCountSumTree
+
+Tyto typy stromu pouzivaji `node_hash_with_count(kv_hash, left, right, count)` misto
+`node_hash`. **Pocet** je zahrnut v hashi, takze overovatel potrebuje
+pocet pro kazdy uzel k prepocitani Merklova korene.
+
+| Role | Typ uzlu V0 | Typ uzlu V1 | Hashovaci funkce |
+|------|------------|------------|-----------------|
+| Dotazovana polozka | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Dotazovany neprazdny strom (bez poddotazu) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Dotazovany prazdny strom | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Dotazovana reference | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| Na ceste | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Hranicni | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Vzdáleny | `Hash` | `Hash` | Pouzit primo |
+
+> **Neprazdne stromy S poddotazem** sestupuji do podrizene vrstvy, stejne jako
+> bezne stromy.
+
+> **Proc kazdy uzel nese pocet?** Protoze se pouziva `node_hash_with_count` misto
+> `node_hash`. Bez poctu overovatel nemuze rekonstruovat zadny prubezny hash
+> na ceste ke koreni — ani pro nedotazovane uzly.
+
+**Vylepseni V1:** Stejne jako u beznych stromu — dotazovane neprazdne stromy bez
+poddotazu jsou upgradevany na `KVValueHashFeatureTypeWithChildHash` pro
+overeni `combine_hash`.
+
+> **Poznamka k ProvableCountSumTree:** Pouze **pocet** je zahrnut v hashi. Soucet
+> je prenaseny v feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`), ale **neni hashovany**. Stejne jako u beznych typu stromu vyse, kanonicka
+> hodnota souctu zije v serializovanych bajtech rodicovskeho Elementu (napr.
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`), ktere jsou
+> overeny hashem v dukazu rodicovskeho stromu.
+
+### Souhrn: Matice typ uzlu → typ stromu
+
+| Typ uzlu | Bezne stromy | Stromy ProvableCount |
+|----------|:----------:|:-------------------:|
+| `KV` | Dotazovane polozky | — |
+| `KVCount` | — | Dotazovane polozky |
+| `KVValueHash` | Dotazovane podstromy | — |
+| `KVValueHashFeatureType` | — | Dotazovane podstromy |
+| `KVRefValueHash` | Dotazovane reference | — |
+| `KVRefValueHashCount` | — | Dotazovane reference |
+| `KVHash` | Na ceste | — |
+| `KVHashCount` | — | Na ceste |
+| `KVDigest` | Hranice/neexistence | — |
+| `KVDigestCount` | — | Hranice/neexistence |
+| `Hash` | Vzdáleni sourozenci | Vzdáleni sourozenci |
+| `KVValueHashFeatureTypeWithChildHash` | — | Neprazdne stromy bez poddotazu |
+
 ## Vicevrstvove generovani dukazu
 
 Protoze GroveDB je strom stromu, dukazy zahrnuji vice vrstev. Kazda vrstva

--- a/docs/book/translations/de/src/proof-system.md
+++ b/docs/book/translations/de/src/proof-system.md
@@ -164,6 +164,135 @@ Als Beweis-Ops kodiert:
 | 8 | Push(Hash(frank_node_hash)) | Frank-Hash legen |
 | 9 | Child | Frank wird rechtes Kind von Dave |
 
+## Beweis-Knotentypen nach Baumtyp
+
+Jeder Baumtyp in GroveDB verwendet eine bestimmte Menge von Beweis-Knotentypen, abhängig
+von der **Rolle** des Knotens im Beweis. Es gibt vier Rollen:
+
+| Rolle | Beschreibung |
+|-------|-------------|
+| **Abgefragt** | Der Knoten entspricht der Abfrage — vollständiger Schlüssel + Wert offengelegt |
+| **Auf dem Pfad** | Der Knoten ist ein Vorfahre abgefragter Knoten — nur kv_hash benötigt |
+| **Grenzknoten** | Benachbart zu einem fehlenden Schlüssel — beweist Abwesenheit |
+| **Entfernt** | Ein Geschwister-Teilbaum nicht auf dem Beweispfad — nur node_hash benötigt |
+
+### Reguläre Bäume (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Alle fünf dieser Baumtypen verwenden identische Beweis-Knotentypen und dieselbe Hash-
+Funktion: `compute_hash` (= `node_hash(kv_hash, left, right)`). Es gibt **keinen
+Unterschied** darin, wie sie auf der Merk-Ebene bewiesen werden.
+
+Jeder Merk-Knoten trägt intern einen `feature_type` (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode), aber
+dieser ist **nicht im Hash enthalten** und **nicht im Beweis enthalten**. Die
+aggregierten Daten (Summe, Zähler) für diese Baumtypen befinden sich in den serialisierten
+Bytes des **Eltern**-Elements, die durch den Beweis des Elternbaums hash-verifiziert werden:
+
+| Baumtyp | Element speichert | Merk feature_type (nicht gehasht) |
+|---------|------------------|----------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **Woher kommt die Summe/der Zähler?** Wenn ein Verifizierer einen Beweis
+> für `[root, my_sum_tree]` verarbeitet, enthält der Beweis des Elternbaums einen
+> `KVValueHash`-Knoten für den Schlüssel `my_sum_tree`. Das `value`-Feld enthält den
+> serialisierten `Element::SumTree(root_key, 42, flags)`. Da dieser Wert
+> hash-verifiziert ist (sein Hash ist in den Eltern-Merkle-Root eingebunden),
+> ist die Summe `42` vertrauenswürdig. Der feature_type auf Merk-Ebene ist irrelevant.
+
+| Rolle | V0-Knotentyp | V1-Knotentyp | Hash-Funktion |
+|-------|-------------|-------------|--------------|
+| Abgefragtes Element | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Abgefragter nicht-leerer Baum (ohne Unterabfrage) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Abgefragter leerer Baum | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Abgefragte Referenz | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| Auf dem Pfad | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Grenzknoten | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Entfernt | `Hash` | `Hash` | Direkt verwendet |
+
+> **Nicht-leere Bäume MIT Unterabfrage** steigen in die Kind-Schicht ab — der Baumknoten
+> erscheint als `KVValueHash` im Beweis der Elternschicht und die Kind-Schicht
+> hat ihren eigenen Beweis.
+
+> **Warum `KVValueHash` für Teilbäume?** Der value_hash eines Teilbaums ist
+> `combine_hash(H(element_bytes), child_root_hash)` — der Verifizierer kann dies nicht
+> allein aus den Element-Bytes neu berechnen (er bräuchte den Kind-Wurzel-Hash). Daher
+> liefert der Beweisersteller den vorberechneten value_hash.
+>
+> **Warum `KV` für Elemente?** Der value_hash eines Elements ist einfach `H(value)`, den der
+> Verifizierer neu berechnen kann. Die Verwendung von `KV` ist manipulationssicher: Wenn der
+> Beweisersteller den Wert ändert, stimmt der Hash nicht überein.
+
+**V1-Erweiterung — `KVValueHashFeatureTypeWithChildHash`:** In V1-Beweisen wird,
+wenn ein abgefragter nicht-leerer Baum keine Unterabfrage hat (die Abfrage endet bei diesem
+Baum — das Baum-Element selbst ist das Ergebnis), der Merk-Knoten von der GroveDB-
+Schicht auf `KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)` aufgewertet. Dies ermöglicht dem Verifizierer die Prüfung
+`combine_hash(H(value), child_hash) == value_hash`, was verhindert, dass ein Angreifer die
+Element-Bytes austauscht und dabei den ursprünglichen value_hash wiederverwendet. Leere Bäume
+werden nicht aufgewertet, da sie keinen Kind-Merk haben, der einen Wurzel-Hash liefern könnte.
+
+> **Sicherheitshinweis zu feature_type:** Für reguläre (nicht-beweisbare) Bäume wird das
+> `feature_type`-Feld in `KVValueHashFeatureType` und
+> `KVValueHashFeatureTypeWithChildHash` dekodiert, aber **nicht** für die
+> Hash-Berechnung verwendet oder an Aufrufer zurückgegeben. Der kanonische Baumtyp befindet sich
+> in den hash-verifizierten Element-Bytes. Dieses Feld ist nur für ProvableCountTree
+> relevant (siehe unten), wo es den für `node_hash_with_count` benötigten Zähler trägt.
+
+### ProvableCountTree und ProvableCountSumTree
+
+Diese Baumtypen verwenden `node_hash_with_count(kv_hash, left, right, count)` anstelle
+von `node_hash`. Der **Zähler** ist im Hash enthalten, sodass der Verifizierer den
+Zähler für jeden Knoten benötigt, um den Merkle-Root neu zu berechnen.
+
+| Rolle | V0-Knotentyp | V1-Knotentyp | Hash-Funktion |
+|-------|-------------|-------------|--------------|
+| Abgefragtes Element | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Abgefragter nicht-leerer Baum (ohne Unterabfrage) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Abgefragter leerer Baum | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Abgefragte Referenz | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| Auf dem Pfad | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Grenzknoten | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Entfernt | `Hash` | `Hash` | Direkt verwendet |
+
+> **Nicht-leere Bäume MIT Unterabfrage** steigen in die Kind-Schicht ab, genau wie
+> reguläre Bäume.
+
+> **Warum trägt jeder Knoten einen Zähler?** Weil `node_hash_with_count` anstelle
+> von `node_hash` verwendet wird. Ohne den Zähler kann der Verifizierer keinen
+> Zwischen-Hash auf dem Pfad zur Wurzel rekonstruieren — selbst für nicht-abgefragte Knoten.
+
+**V1-Erweiterung:** Wie bei regulären Bäumen — abgefragte nicht-leere Bäume ohne
+Unterabfragen werden auf `KVValueHashFeatureTypeWithChildHash` aufgewertet, um die
+`combine_hash`-Verifikation zu ermöglichen.
+
+> **Hinweis zu ProvableCountSumTree:** Nur der **Zähler** ist im Hash enthalten. Die
+> Summe wird im feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`) mitgeführt, ist aber **nicht gehasht**. Wie bei den regulären Baumtypen oben
+> befindet sich der kanonische Summenwert in den serialisierten Bytes des Eltern-Elements
+> (z.B. `Element::ProvableCountSumTree(root_key, count, sum, flags)`), die im
+> Beweis des Elternbaums hash-verifiziert werden.
+
+### Zusammenfassung: Knotentyp-zu-Baumtyp-Matrix
+
+| Knotentyp | Reguläre Bäume | ProvableCount-Bäume |
+|-----------|:-------------:|:-------------------:|
+| `KV` | Abgefragte Elemente | — |
+| `KVCount` | — | Abgefragte Elemente |
+| `KVValueHash` | Abgefragte Teilbäume | — |
+| `KVValueHashFeatureType` | — | Abgefragte Teilbäume |
+| `KVRefValueHash` | Abgefragte Referenzen | — |
+| `KVRefValueHashCount` | — | Abgefragte Referenzen |
+| `KVHash` | Auf dem Pfad | — |
+| `KVHashCount` | — | Auf dem Pfad |
+| `KVDigest` | Grenz-/Abwesenheit | — |
+| `KVDigestCount` | — | Grenz-/Abwesenheit |
+| `Hash` | Entfernte Geschwister | Entfernte Geschwister |
+| `KVValueHashFeatureTypeWithChildHash` | — | Nicht-leere Bäume ohne Unterabfrage |
+
 ## Mehrschicht-Beweiserzeugung
 
 Da GroveDB ein Baum von Bäumen ist, erstrecken sich Beweise über mehrere Schichten. Jede Schicht beweist

--- a/docs/book/translations/es/src/proof-system.md
+++ b/docs/book/translations/es/src/proof-system.md
@@ -164,6 +164,136 @@ Codificado como operaciones de prueba:
 | 8 | Push(Hash(frank_node_hash)) | Poner hash de frank |
 | 9 | Child | frank se convierte en hijo derecho de dave |
 
+## Tipos de Nodos de Prueba por Tipo de Árbol
+
+Cada tipo de árbol en GroveDB utiliza un conjunto específico de tipos de nodos de prueba
+dependiendo del **rol** del nodo en la prueba. Hay cuatro roles:
+
+| Rol | Descripción |
+|-----|-------------|
+| **Consultado** | El nodo coincide con la consulta — clave + valor completos revelados |
+| **En la ruta** | El nodo es un ancestro de nodos consultados — solo se necesita kv_hash |
+| **Frontera** | Adyacente a una clave faltante — prueba ausencia |
+| **Distante** | Un subárbol hermano que no está en la ruta de prueba — solo se necesita node_hash |
+
+### Árboles Regulares (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Los cinco tipos de árboles utilizan tipos de nodos de prueba idénticos y la misma
+función hash: `compute_hash` (= `node_hash(kv_hash, left, right)`). **No hay
+diferencia** en cómo se prueban a nivel de merk.
+
+Cada nodo merk lleva un `feature_type` internamente (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode), pero
+este **no se incluye en el hash** y **no se incluye en la prueba**. Los datos
+agregados (suma, conteo) para estos tipos de árboles residen en los bytes serializados
+del Element **padre**, los cuales se verifican por hash a través de la prueba del
+árbol padre:
+
+| Tipo de árbol | Element almacena | feature_type en Merk (no hasheado) |
+|--------------|-----------------|-----------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **¿De dónde viene la suma/conteo?** Cuando un verificador procesa una prueba
+> para `[root, my_sum_tree]`, la prueba del árbol padre incluye un nodo
+> `KVValueHash` para la clave `my_sum_tree`. El campo `value` contiene el
+> `Element::SumTree(root_key, 42, flags)` serializado. Como este valor está
+> verificado por hash (su hash está comprometido en la raíz Merkle del padre),
+> la suma `42` es confiable. El feature_type a nivel de merk es irrelevante.
+
+| Rol | Tipo de Nodo V0 | Tipo de Nodo V1 | Función hash |
+|-----|----------------|----------------|-------------|
+| Elemento consultado | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Árbol no vacío consultado (sin subconsulta) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Árbol vacío consultado | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Referencia consultada | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| En la ruta | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Frontera | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Distante | `Hash` | `Hash` | Usado directamente |
+
+> **Los árboles no vacíos CON subconsulta** descienden a la capa hija — el nodo
+> del árbol aparece como `KVValueHash` en la prueba de la capa padre y la capa hija
+> tiene su propia prueba.
+
+> **¿Por qué `KVValueHash` para subárboles?** El value_hash de un subárbol es
+> `combine_hash(H(element_bytes), child_root_hash)` — el verificador no puede
+> recalcularlo solo con los bytes del element (necesitaría el hash raíz hijo). Por eso
+> el probador proporciona el value_hash precalculado.
+>
+> **¿Por qué `KV` para elementos?** El value_hash de un elemento es simplemente `H(value)`,
+> que el verificador puede recalcular. Usar `KV` es a prueba de manipulación: si el
+> probador cambia el valor, el hash no coincidirá.
+
+**Mejora V1 — `KVValueHashFeatureTypeWithChildHash`:** En las pruebas V1, cuando un
+árbol no vacío consultado no tiene subconsulta (la consulta se detiene en este árbol —
+el elemento del árbol mismo es el resultado), la capa GroveDB actualiza el nodo merk a
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)`. Esto permite al verificador comprobar `combine_hash(H(value), child_hash)
+== value_hash`, previniendo que un atacante intercambie los bytes del element mientras
+reutiliza el value_hash original. Los árboles vacíos no se actualizan porque no tienen
+un merk hijo que proporcione un hash raíz.
+
+> **Nota de seguridad sobre feature_type:** Para árboles regulares (no probables), el
+> campo `feature_type` en `KVValueHashFeatureType` y
+> `KVValueHashFeatureTypeWithChildHash` se decodifica pero **no se usa** para el cálculo
+> del hash ni se devuelve a los llamadores. El tipo de árbol canónico reside en los bytes
+> de Element verificados por hash. Este campo solo importa para ProvableCountTree
+> (ver abajo), donde lleva el conteo necesario para `node_hash_with_count`.
+
+### ProvableCountTree y ProvableCountSumTree
+
+Estos tipos de árboles usan `node_hash_with_count(kv_hash, left, right, count)` en lugar
+de `node_hash`. El **conteo** se incluye en el hash, por lo que el verificador necesita
+el conteo de cada nodo para recalcular la raíz Merkle.
+
+| Rol | Tipo de Nodo V0 | Tipo de Nodo V1 | Función hash |
+|-----|----------------|----------------|-------------|
+| Elemento consultado | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Árbol no vacío consultado (sin subconsulta) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Árbol vacío consultado | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Referencia consultada | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| En la ruta | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Frontera | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Distante | `Hash` | `Hash` | Usado directamente |
+
+> **Los árboles no vacíos CON subconsulta** descienden a la capa hija, igual que los
+> árboles regulares.
+
+> **¿Por qué cada nodo lleva un conteo?** Porque se usa `node_hash_with_count` en lugar
+> de `node_hash`. Sin el conteo, el verificador no puede reconstruir ningún hash
+> intermedio en la ruta hacia la raíz — incluso para nodos no consultados.
+
+**Mejora V1:** Igual que los árboles regulares — los árboles no vacíos consultados sin
+subconsultas se actualizan a `KVValueHashFeatureTypeWithChildHash` para la
+verificación de `combine_hash`.
+
+> **Nota sobre ProvableCountSumTree:** Solo el **conteo** se incluye en el hash. La
+> suma se transporta en el feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`) pero **no se hashea**. Al igual que los tipos de árboles regulares anteriores, el
+> valor canónico de la suma reside en los bytes serializados del Element padre (ej.
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`), los cuales se
+> verifican por hash en la prueba del árbol padre.
+
+### Resumen: Matriz Tipo de Nodo a Tipo de Árbol
+
+| Tipo de Nodo | Árboles Regulares | Árboles ProvableCount |
+|-------------|:-----------------:|:---------------------:|
+| `KV` | Elementos consultados | — |
+| `KVCount` | — | Elementos consultados |
+| `KVValueHash` | Subárboles consultados | — |
+| `KVValueHashFeatureType` | — | Subárboles consultados |
+| `KVRefValueHash` | Referencias consultadas | — |
+| `KVRefValueHashCount` | — | Referencias consultadas |
+| `KVHash` | En la ruta | — |
+| `KVHashCount` | — | En la ruta |
+| `KVDigest` | Frontera/ausencia | — |
+| `KVDigestCount` | — | Frontera/ausencia |
+| `Hash` | Hermanos distantes | Hermanos distantes |
+| `KVValueHashFeatureTypeWithChildHash` | — | Árboles no vacíos sin subconsulta |
+
 ## Generación de Pruebas Multi-Capa
 
 Dado que GroveDB es un árbol de árboles, las pruebas abarcan múltiples capas. Cada capa prueba

--- a/docs/book/translations/fr/src/proof-system.md
+++ b/docs/book/translations/fr/src/proof-system.md
@@ -164,6 +164,136 @@ Encodé comme opérations de preuve :
 | 8 | Push(Hash(frank_node_hash)) | Empiler le hachage de frank |
 | 9 | Child | frank devient enfant droit de dave |
 
+## Types de noeuds de preuve par type d'arbre
+
+Chaque type d'arbre dans GroveDB utilise un ensemble specifique de types de noeuds de preuve
+selon le **role** du noeud dans la preuve. Il existe quatre roles :
+
+| Role | Description |
+|------|-------------|
+| **Interroge** | Le noeud correspond a la requete — cle + valeur completes revelees |
+| **Sur le chemin** | Le noeud est un ancetre des noeuds interroges — seul le kv_hash est necessaire |
+| **Frontiere** | Adjacent a une cle manquante — prouve l'absence |
+| **Distant** | Un sous-arbre frere hors du chemin de preuve — seul le node_hash est necessaire |
+
+### Arbres reguliers (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Ces cinq types d'arbres utilisent des types de noeuds de preuve identiques et la meme
+fonction de hachage : `compute_hash` (= `node_hash(kv_hash, left, right)`). Il n'y a
+**aucune difference** dans la facon dont ils sont prouves au niveau merk.
+
+Chaque noeud merk porte un `feature_type` en interne (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode), mais
+celui-ci n'est **pas inclus dans le hachage** et **pas inclus dans la preuve**. Les
+donnees d'agregation (somme, comptage) pour ces types d'arbres resident dans les
+octets serialises de l'Element **parent**, qui sont verifies par hachage via la
+preuve de l'arbre parent :
+
+| Type d'arbre | Element stocke | feature_type Merk (non hache) |
+|-----------|---------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **D'ou vient la somme/le comptage ?** Lorsqu'un verificateur traite une preuve
+> pour `[root, my_sum_tree]`, la preuve de l'arbre parent inclut un noeud
+> `KVValueHash` pour la cle `my_sum_tree`. Le champ `value` contient
+> l'`Element::SumTree(root_key, 42, flags)` serialise. Puisque cette valeur est
+> verifiee par hachage (son hachage est engage dans la racine Merkle parente), la
+> somme `42` est fiable. Le feature_type au niveau merk est sans importance.
+
+| Role | Type de noeud V0 | Type de noeud V1 | Fonction de hachage |
+|------|-------------|-------------|---------------|
+| Element interroge | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Arbre non-vide interroge (sans sous-requete) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Arbre vide interroge | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Reference interrogee | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| Sur le chemin | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Frontiere | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Distant | `Hash` | `Hash` | Utilise directement |
+
+> **Les arbres non-vides AVEC une sous-requete** descendent dans la couche enfant — le noeud
+> d'arbre apparait comme `KVValueHash` dans la preuve de la couche parente et la couche
+> enfant possede sa propre preuve.
+
+> **Pourquoi `KVValueHash` pour les sous-arbres ?** Le value_hash d'un sous-arbre est
+> `combine_hash(H(element_bytes), child_root_hash)` — le verificateur ne peut pas
+> le recalculer a partir des seuls octets de l'element (il aurait besoin du hachage racine
+> enfant). Le prouveur fournit donc le value_hash pre-calcule.
+>
+> **Pourquoi `KV` pour les elements ?** Le value_hash d'un element est simplement `H(value)`,
+> que le verificateur peut recalculer. Utiliser `KV` est a l'epreuve de la falsification : si
+> le prouveur modifie la valeur, le hachage ne correspondra pas.
+
+**Amelioration V1 — `KVValueHashFeatureTypeWithChildHash` :** Dans les preuves V1, lorsqu'un
+arbre non-vide interroge n'a pas de sous-requete (la requete s'arrete a cet arbre — l'element
+arbre lui-meme est le resultat), la couche GroveDB met a niveau le noeud merk en
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)`. Cela permet au verificateur de verifier `combine_hash(H(value), child_hash)
+== value_hash`, empechant un attaquant d'echanger les octets de l'element tout en
+reutilisant le value_hash original. Les arbres vides ne sont pas mis a niveau car ils n'ont
+pas de merk enfant pour fournir un hachage racine.
+
+> **Note de securite sur feature_type :** Pour les arbres reguliers (non prouvables), le
+> champ `feature_type` dans `KVValueHashFeatureType` et
+> `KVValueHashFeatureTypeWithChildHash` est decode mais **non utilise** pour le
+> calcul de hachage ni renvoye aux appelants. Le type d'arbre canonique reside dans les
+> octets de l'Element verifies par hachage. Ce champ n'a d'importance que pour ProvableCountTree
+> (voir ci-dessous), ou il porte le comptage necessaire pour `node_hash_with_count`.
+
+### ProvableCountTree et ProvableCountSumTree
+
+Ces types d'arbres utilisent `node_hash_with_count(kv_hash, left, right, count)` au lieu
+de `node_hash`. Le **comptage** est inclus dans le hachage, donc le verificateur a besoin
+du comptage de chaque noeud pour recalculer la racine Merkle.
+
+| Role | Type de noeud V0 | Type de noeud V1 | Fonction de hachage |
+|------|-------------|-------------|---------------|
+| Element interroge | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Arbre non-vide interroge (sans sous-requete) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Arbre vide interroge | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Reference interrogee | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| Sur le chemin | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Frontiere | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Distant | `Hash` | `Hash` | Utilise directement |
+
+> **Les arbres non-vides AVEC une sous-requete** descendent dans la couche enfant, comme
+> les arbres reguliers.
+
+> **Pourquoi chaque noeud porte-t-il un comptage ?** Parce que `node_hash_with_count` est
+> utilise au lieu de `node_hash`. Sans le comptage, le verificateur ne peut reconstruire
+> aucun hachage intermediaire sur le chemin vers la racine — meme pour les noeuds non interroges.
+
+**Amelioration V1 :** Identique aux arbres reguliers — les arbres non-vides interroges sans
+sous-requete sont mis a niveau vers `KVValueHashFeatureTypeWithChildHash` pour la
+verification de `combine_hash`.
+
+> **Note sur ProvableCountSumTree :** Seul le **comptage** est inclus dans le hachage. La
+> somme est portee dans le feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`) mais n'est **pas hachee**. Comme les types d'arbres reguliers ci-dessus, la valeur
+> canonique de la somme reside dans les octets serialises de l'Element parent (par ex.
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`), qui sont
+> verifies par hachage dans la preuve de l'arbre parent.
+
+### Resume : matrice type de noeud → type d'arbre
+
+| Type de noeud | Arbres reguliers | Arbres ProvableCount |
+|-----------|:------------:|:-------------------:|
+| `KV` | Elements interroges | — |
+| `KVCount` | — | Elements interroges |
+| `KVValueHash` | Sous-arbres interroges | — |
+| `KVValueHashFeatureType` | — | Sous-arbres interroges |
+| `KVRefValueHash` | References interrogees | — |
+| `KVRefValueHashCount` | — | References interrogees |
+| `KVHash` | Sur le chemin | — |
+| `KVHashCount` | — | Sur le chemin |
+| `KVDigest` | Frontiere/absence | — |
+| `KVDigestCount` | — | Frontiere/absence |
+| `Hash` | Freres distants | Freres distants |
+| `KVValueHashFeatureTypeWithChildHash` | — | Arbres non-vides sans sous-requete |
+
 ## Génération de preuves multi-couches
 
 Comme GroveDB est un arbre d'arbres, les preuves s'étendent sur plusieurs couches. Chaque couche prouve

--- a/docs/book/translations/id/src/proof-system.md
+++ b/docs/book/translations/id/src/proof-system.md
@@ -164,6 +164,135 @@ Di-encode sebagai operasi proof:
 | 8 | Push(Hash(frank_node_hash)) | Dorong hash frank |
 | 9 | Child | frank menjadi anak kanan dave |
 
+## Tipe Node Proof berdasarkan Tipe Pohon
+
+Setiap tipe pohon di GroveDB menggunakan sekumpulan tipe node proof tertentu tergantung
+pada **peran** node dalam proof. Ada empat peran:
+
+| Peran | Deskripsi |
+|------|-------------|
+| **Di-query** | Node cocok dengan query — key + value lengkap diungkap |
+| **Di jalur** | Node adalah ancestor dari node yang di-query — hanya kv_hash yang diperlukan |
+| **Batas** | Berdekatan dengan key yang hilang — membuktikan ketiadaan |
+| **Jauh** | Subtree saudara yang tidak di jalur proof — hanya node_hash yang diperlukan |
+
+### Pohon Reguler (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Kelima tipe pohon ini menggunakan tipe node proof yang identik dan fungsi hash yang
+sama: `compute_hash` (= `node_hash(kv_hash, left, right)`). **Tidak ada
+perbedaan** dalam cara mereka dibuktikan di tingkat merk.
+
+Setiap node merk membawa `feature_type` secara internal (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode), tetapi
+ini **tidak disertakan dalam hash** dan **tidak disertakan dalam proof**. Data
+agregat (sum, count) untuk tipe pohon ini berada di byte terserialisasi Element
+**induk**, yang diverifikasi hash-nya melalui proof pohon induk:
+
+| Tipe pohon | Element menyimpan | feature_type Merk (tidak di-hash) |
+|-----------|---------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **Dari mana sum/count berasal?** Ketika verifier memproses proof
+> untuk `[root, my_sum_tree]`, proof pohon induk menyertakan node
+> `KVValueHash` untuk key `my_sum_tree`. Field `value` berisi
+> `Element::SumTree(root_key, 42, flags)` yang terserialisasi. Karena value ini
+> diverifikasi hash-nya (hash-nya di-commit ke root Merkle induk), sum
+> `42` dapat dipercaya. feature_type di tingkat merk tidak relevan.
+
+| Peran | Tipe Node V0 | Tipe Node V1 | Fungsi hash |
+|------|-------------|-------------|---------------|
+| Item yang di-query | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Pohon non-kosong yang di-query (tanpa subquery) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Pohon kosong yang di-query | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Referensi yang di-query | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| Di jalur | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Batas | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Jauh | `Hash` | `Hash` | Digunakan langsung |
+
+> **Pohon non-kosong DENGAN subquery** turun ke lapisan anak — node
+> pohon muncul sebagai `KVValueHash` di proof lapisan induk dan lapisan
+> anak memiliki proof-nya sendiri.
+
+> **Mengapa `KVValueHash` untuk subtree?** value_hash subtree adalah
+> `combine_hash(H(element_bytes), child_root_hash)` — verifier tidak dapat
+> menghitung ulang ini dari byte element saja (ia memerlukan hash root
+> anak). Jadi prover menyediakan value_hash yang sudah dihitung.
+>
+> **Mengapa `KV` untuk item?** value_hash item hanyalah `H(value)`, yang
+> dapat dihitung ulang oleh verifier. Menggunakan `KV` tahan terhadap manipulasi: jika
+> prover mengubah value, hash tidak akan cocok.
+
+**Peningkatan V1 — `KVValueHashFeatureTypeWithChildHash`:** Dalam proof V1, ketika
+pohon non-kosong yang di-query tidak memiliki subquery (query berhenti di pohon ini —
+element pohon itu sendiri adalah hasilnya), lapisan GroveDB meng-upgrade node merk menjadi
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)`. Ini memungkinkan verifier memeriksa `combine_hash(H(value), child_hash)
+== value_hash`, mencegah penyerang menukar byte element sambil
+menggunakan kembali value_hash asli. Pohon kosong tidak di-upgrade karena mereka tidak
+memiliki merk anak untuk menyediakan hash root.
+
+> **Catatan keamanan tentang feature_type:** Untuk pohon reguler (non-provable), field
+> `feature_type` dalam `KVValueHashFeatureType` dan
+> `KVValueHashFeatureTypeWithChildHash` didekode tetapi **tidak digunakan** untuk
+> komputasi hash atau dikembalikan ke pemanggil. Tipe pohon kanonik berada di byte
+> Element yang diverifikasi hash-nya. Field ini hanya penting untuk ProvableCountTree
+> (lihat di bawah), di mana ia membawa count yang diperlukan untuk `node_hash_with_count`.
+
+### ProvableCountTree dan ProvableCountSumTree
+
+Tipe pohon ini menggunakan `node_hash_with_count(kv_hash, left, right, count)` alih-alih
+`node_hash`. **Count** disertakan dalam hash, jadi verifier memerlukan
+count untuk setiap node guna menghitung ulang root Merkle.
+
+| Peran | Tipe Node V0 | Tipe Node V1 | Fungsi hash |
+|------|-------------|-------------|---------------|
+| Item yang di-query | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Pohon non-kosong yang di-query (tanpa subquery) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Pohon kosong yang di-query | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Referensi yang di-query | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| Di jalur | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Batas | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Jauh | `Hash` | `Hash` | Digunakan langsung |
+
+> **Pohon non-kosong DENGAN subquery** turun ke lapisan anak, sama seperti
+> pohon reguler.
+
+> **Mengapa setiap node membawa count?** Karena `node_hash_with_count` digunakan
+> alih-alih `node_hash`. Tanpa count, verifier tidak dapat merekonstruksi
+> hash perantara mana pun di jalur menuju root — bahkan untuk node yang tidak di-query.
+
+**Peningkatan V1:** Sama seperti pohon reguler — pohon non-kosong yang di-query tanpa
+subquery di-upgrade ke `KVValueHashFeatureTypeWithChildHash` untuk
+verifikasi `combine_hash`.
+
+> **Catatan ProvableCountSumTree:** Hanya **count** yang disertakan dalam hash. Sum
+> dibawa dalam feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`) tetapi **tidak di-hash**. Seperti tipe pohon reguler di atas, nilai
+> sum kanonik berada di byte terserialisasi Element induk (misalnya
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`), yang
+> diverifikasi hash-nya dalam proof pohon induk.
+
+### Ringkasan: Matriks Tipe Node → Tipe Pohon
+
+| Tipe Node | Pohon Reguler | Pohon ProvableCount |
+|-----------|:------------:|:-------------------:|
+| `KV` | Item yang di-query | — |
+| `KVCount` | — | Item yang di-query |
+| `KVValueHash` | Subtree yang di-query | — |
+| `KVValueHashFeatureType` | — | Subtree yang di-query |
+| `KVRefValueHash` | Referensi yang di-query | — |
+| `KVRefValueHashCount` | — | Referensi yang di-query |
+| `KVHash` | Di jalur | — |
+| `KVHashCount` | — | Di jalur |
+| `KVDigest` | Batas/ketiadaan | — |
+| `KVDigestCount` | — | Batas/ketiadaan |
+| `Hash` | Saudara jauh | Saudara jauh |
+| `KVValueHashFeatureTypeWithChildHash` | — | Pohon non-kosong tanpa subquery |
+
 ## Generasi Proof Multi-Lapisan
 
 Karena GroveDB adalah pohon dari pohon-pohon, proof mencakup beberapa lapisan. Setiap lapisan membuktikan

--- a/docs/book/translations/it/src/proof-system.md
+++ b/docs/book/translations/it/src/proof-system.md
@@ -160,6 +160,136 @@ Codificato come operazioni di prova:
 | 8 | Push(Hash(frank_node_hash)) | Inserisci hash di frank |
 | 9 | Child | frank diventa figlio destro di dave |
 
+## Tipi di nodo di prova per tipo di albero
+
+Ogni tipo di albero in GroveDB utilizza un insieme specifico di tipi di nodo di prova
+a seconda del **ruolo** del nodo nella prova. Ci sono quattro ruoli:
+
+| Ruolo | Descrizione |
+|------|-------------|
+| **Interrogato** | Il nodo corrisponde alla query — chiave + valore completi rivelati |
+| **Sul percorso** | Il nodo e un antenato dei nodi interrogati — solo kv_hash necessario |
+| **Confine** | Adiacente a una chiave mancante — dimostra l'assenza |
+| **Distante** | Un sotto-albero fratello non sul percorso di prova — solo node_hash necessario |
+
+### Alberi regolari (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Tutti e cinque questi tipi di albero usano tipi di nodo di prova identici e la stessa
+funzione hash: `compute_hash` (= `node_hash(kv_hash, left, right)`). **Non c'e
+differenza** nel modo in cui vengono provati a livello merk.
+
+Ogni nodo merk porta un `feature_type` internamente (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode), ma
+questo **non e incluso nell'hash** e **non e incluso nella prova**. I dati
+aggregati (somma, conteggio) per questi tipi di albero risiedono nei byte
+serializzati dell'Element **genitore**, che sono verificati tramite hash nella
+prova dell'albero genitore:
+
+| Tipo di albero | L'Element memorizza | feature_type Merk (non hashed) |
+|-----------|---------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **Da dove viene la somma/il conteggio?** Quando un verificatore elabora una prova
+> per `[root, my_sum_tree]`, la prova dell'albero genitore include un nodo
+> `KVValueHash` per la chiave `my_sum_tree`. Il campo `value` contiene
+> l'`Element::SumTree(root_key, 42, flags)` serializzato. Poiche questo valore e
+> verificato tramite hash (il suo hash e impegnato nella radice Merkle genitore), la
+> somma `42` e affidabile. Il feature_type a livello merk e irrilevante.
+
+| Ruolo | Tipo nodo V0 | Tipo nodo V1 | Funzione hash |
+|------|-------------|-------------|---------------|
+| Elemento interrogato | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Albero non-vuoto interrogato (senza subquery) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Albero vuoto interrogato | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Riferimento interrogato | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| Sul percorso | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Confine | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Distante | `Hash` | `Hash` | Usato direttamente |
+
+> **Gli alberi non-vuoti CON una subquery** scendono nel livello figlio — il nodo
+> albero appare come `KVValueHash` nella prova del livello genitore e il livello
+> figlio ha la propria prova.
+
+> **Perche `KVValueHash` per i sotto-alberi?** Il value_hash di un sotto-albero e
+> `combine_hash(H(element_bytes), child_root_hash)` — il verificatore non puo
+> ricalcolarlo dai soli byte dell'elemento (avrebbe bisogno dell'hash radice
+> figlio). Quindi il provatore fornisce il value_hash pre-calcolato.
+>
+> **Perche `KV` per gli elementi?** Il value_hash di un elemento e semplicemente `H(value)`,
+> che il verificatore puo ricalcolare. Usare `KV` e a prova di manomissione: se il
+> provatore modifica il valore, l'hash non corrispondera.
+
+**Miglioramento V1 — `KVValueHashFeatureTypeWithChildHash`:** Nelle prove V1, quando un
+albero non-vuoto interrogato non ha subquery (la query si ferma a questo albero — l'elemento
+albero stesso e il risultato), il livello GroveDB aggiorna il nodo merk a
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)`. Questo permette al verificatore di controllare `combine_hash(H(value), child_hash)
+== value_hash`, impedendo a un attaccante di scambiare i byte dell'elemento
+riutilizzando il value_hash originale. Gli alberi vuoti non vengono aggiornati perche non
+hanno un merk figlio per fornire un hash radice.
+
+> **Nota di sicurezza su feature_type:** Per gli alberi regolari (non provabili), il
+> campo `feature_type` in `KVValueHashFeatureType` e
+> `KVValueHashFeatureTypeWithChildHash` viene decodificato ma **non utilizzato** per il
+> calcolo dell'hash ne restituito ai chiamanti. Il tipo di albero canonico risiede nei
+> byte dell'Element verificati tramite hash. Questo campo e importante solo per ProvableCountTree
+> (vedi sotto), dove trasporta il conteggio necessario per `node_hash_with_count`.
+
+### ProvableCountTree e ProvableCountSumTree
+
+Questi tipi di albero usano `node_hash_with_count(kv_hash, left, right, count)` al posto
+di `node_hash`. Il **conteggio** e incluso nell'hash, quindi il verificatore ha bisogno
+del conteggio di ogni nodo per ricalcolare la radice Merkle.
+
+| Ruolo | Tipo nodo V0 | Tipo nodo V1 | Funzione hash |
+|------|-------------|-------------|---------------|
+| Elemento interrogato | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Albero non-vuoto interrogato (senza subquery) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Albero vuoto interrogato | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Riferimento interrogato | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| Sul percorso | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Confine | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Distante | `Hash` | `Hash` | Usato direttamente |
+
+> **Gli alberi non-vuoti CON una subquery** scendono nel livello figlio, come
+> gli alberi regolari.
+
+> **Perche ogni nodo trasporta un conteggio?** Perche si usa `node_hash_with_count`
+> al posto di `node_hash`. Senza il conteggio, il verificatore non puo ricostruire
+> nessun hash intermedio sul percorso verso la radice — nemmeno per i nodi non interrogati.
+
+**Miglioramento V1:** Identico agli alberi regolari — gli alberi non-vuoti interrogati senza
+subquery vengono aggiornati a `KVValueHashFeatureTypeWithChildHash` per la
+verifica di `combine_hash`.
+
+> **Nota su ProvableCountSumTree:** Solo il **conteggio** e incluso nell'hash. La
+> somma e trasportata nel feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`) ma **non e sottoposta a hash**. Come i tipi di albero regolari sopra, il valore
+> canonico della somma risiede nei byte serializzati dell'Element genitore (es.
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`), che sono
+> verificati tramite hash nella prova dell'albero genitore.
+
+### Riepilogo: Matrice tipo di nodo → tipo di albero
+
+| Tipo di nodo | Alberi regolari | Alberi ProvableCount |
+|-----------|:------------:|:-------------------:|
+| `KV` | Elementi interrogati | — |
+| `KVCount` | — | Elementi interrogati |
+| `KVValueHash` | Sotto-alberi interrogati | — |
+| `KVValueHashFeatureType` | — | Sotto-alberi interrogati |
+| `KVRefValueHash` | Riferimenti interrogati | — |
+| `KVRefValueHashCount` | — | Riferimenti interrogati |
+| `KVHash` | Sul percorso | — |
+| `KVHashCount` | — | Sul percorso |
+| `KVDigest` | Confine/assenza | — |
+| `KVDigestCount` | — | Confine/assenza |
+| `Hash` | Fratelli distanti | Fratelli distanti |
+| `KVValueHashFeatureTypeWithChildHash` | — | Alberi non-vuoti senza subquery |
+
 ## Generazione di prove multi-livello
 
 Poiche GroveDB e un albero di alberi, le prove attraversano piu livelli. Ogni livello dimostra la porzione rilevante di un albero Merk, e i livelli sono collegati dal meccanismo del value_hash combinato:

--- a/docs/book/translations/ja/src/proof-system.md
+++ b/docs/book/translations/ja/src/proof-system.md
@@ -160,6 +160,133 @@ graph TD
 | 8 | Push(Hash(frank_node_hash)) | frank のハッシュをプッシュ |
 | 9 | Child | frank が dave の右の子になる |
 
+## ツリータイプ別の証明ノード型
+
+GroveDB の各ツリータイプは、証明内のノードの**役割**に応じて特定の証明ノード型の
+セットを使用します。4つの役割があります：
+
+| 役割 | 説明 |
+|------|-------------|
+| **クエリ対象** | ノードがクエリに一致 — 完全な key + value が公開される |
+| **パス上** | クエリ対象ノードの祖先 — kv_hash のみが必要 |
+| **境界** | 欠落キーに隣接 — 不在を証明 |
+| **遠方** | 証明パス上にない兄弟サブツリー — node_hash のみが必要 |
+
+### 通常のツリー（Tree, SumTree, BigSumTree, CountTree, CountSumTree）
+
+これら5つのツリータイプはすべて同一の証明ノード型と同じハッシュ関数を使用します：
+`compute_hash`（= `node_hash(kv_hash, left, right)`）。merk レベルでの
+証明方法に**違いはありません**。
+
+各 merk ノードは内部的に `feature_type` を持ちます（BasicMerkNode、
+SummedMerkNode、BigSummedMerkNode、CountedMerkNode、CountedSummedMerkNode）が、
+これは**ハッシュに含まれず**、**証明にも含まれません**。これらのツリータイプの
+集約データ（sum、count）は**親** Element のシリアライズされたバイトに存在し、
+親ツリーの証明を通じてハッシュ検証されます：
+
+| ツリータイプ | Element が格納するもの | Merk の feature_type（ハッシュされない） |
+|-----------|---------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **sum/count はどこから来るのか？** 検証者が `[root, my_sum_tree]` の証明を
+> 処理するとき、親ツリーの証明にはキー `my_sum_tree` の `KVValueHash` ノードが
+> 含まれます。`value` フィールドにはシリアライズされた
+> `Element::SumTree(root_key, 42, flags)` が含まれます。この値はハッシュ検証
+> されているため（そのハッシュは親の Merkle ルートにコミットされている）、sum `42` は
+> 信頼できます。merk レベルの feature_type は無関係です。
+
+| 役割 | V0 ノード型 | V1 ノード型 | ハッシュ関数 |
+|------|-------------|-------------|---------------|
+| クエリ対象アイテム | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| クエリ対象の非空ツリー（サブクエリなし） | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| クエリ対象の空ツリー | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| クエリ対象の参照 | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| パス上 | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| 境界 | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| 遠方 | `Hash` | `Hash` | 直接使用 |
+
+> **サブクエリ付きの非空ツリー**は子レイヤーに降りていきます — ツリーノードは親
+> レイヤーの証明で `KVValueHash` として表示され、子レイヤーは独自の証明を持ちます。
+
+> **なぜサブツリーに `KVValueHash` を使うのか？** サブツリーの value_hash は
+> `combine_hash(H(element_bytes), child_root_hash)` です — 検証者はエレメント
+> バイトのみからこれを再計算できません（子のルートハッシュが必要です）。そのため
+> 証明者が事前計算された value_hash を提供します。
+>
+> **なぜアイテムに `KV` を使うのか？** アイテムの value_hash は単に `H(value)` であり、
+> 検証者が再計算できます。`KV` を使用すると改ざん防止になります：証明者が値を変更
+> すると、ハッシュが一致しなくなります。
+
+**V1 の改善 — `KVValueHashFeatureTypeWithChildHash`：** V1 証明では、クエリ対象の
+非空ツリーにサブクエリがない場合（クエリがこのツリーで停止 — ツリーエレメント自体が
+結果）、GroveDB レイヤーは merk ノードを
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)` にアップグレードします。これにより検証者は `combine_hash(H(value), child_hash)
+== value_hash` を確認でき、攻撃者がオリジナルの value_hash を再利用しながらエレメント
+バイトを差し替えることを防止します。空のツリーはルートハッシュを提供する子 merk が
+ないため、アップグレードされません。
+
+> **feature_type に関するセキュリティノート：** 通常の（非 provable な）ツリーでは、
+> `KVValueHashFeatureType` および `KVValueHashFeatureTypeWithChildHash` の
+> `feature_type` フィールドはデコードされますが、ハッシュ計算に**使用されず**、
+> 呼び出し元にも返されません。正規のツリータイプはハッシュ検証された Element バイトに
+> 存在します。このフィールドは ProvableCountTree（下記参照）でのみ重要であり、
+> `node_hash_with_count` に必要な count を運びます。
+
+### ProvableCountTree と ProvableCountSumTree
+
+これらのツリータイプは `node_hash` の代わりに `node_hash_with_count(kv_hash, left, right, count)`
+を使用します。**count** がハッシュに含まれるため、検証者は Merkle ルートを再計算する
+ために各ノードの count が必要です。
+
+| 役割 | V0 ノード型 | V1 ノード型 | ハッシュ関数 |
+|------|-------------|-------------|---------------|
+| クエリ対象アイテム | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| クエリ対象の非空ツリー（サブクエリなし） | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| クエリ対象の空ツリー | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| クエリ対象の参照 | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| パス上 | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| 境界 | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| 遠方 | `Hash` | `Hash` | 直接使用 |
+
+> **サブクエリ付きの非空ツリー**は通常のツリーと同様に子レイヤーに降りていきます。
+
+> **なぜ各ノードが count を持つのか？** `node_hash` の代わりに `node_hash_with_count`
+> が使用されるためです。count がなければ、検証者はルートへのパス上の中間ハッシュを
+> 再構築できません — クエリ対象でないノードでも同様です。
+
+**V1 の改善：** 通常のツリーと同じです — サブクエリなしのクエリ対象非空ツリーは
+`combine_hash` 検証のために `KVValueHashFeatureTypeWithChildHash` にアップグレード
+されます。
+
+> **ProvableCountSumTree に関する注意：** **count** のみがハッシュに含まれます。sum は
+> feature_type（`ProvableCountedSummedMerkNode(count, sum)`）で運ばれますが、
+> **ハッシュされません**。上記の通常のツリータイプと同様に、正規の sum 値は
+> 親 Element のシリアライズされたバイト（例：
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`）に存在し、
+> 親ツリーの証明でハッシュ検証されます。
+
+### まとめ：ノード型 → ツリータイプ マトリックス
+
+| ノード型 | 通常のツリー | ProvableCount ツリー |
+|-----------|:------------:|:-------------------:|
+| `KV` | クエリ対象アイテム | — |
+| `KVCount` | — | クエリ対象アイテム |
+| `KVValueHash` | クエリ対象サブツリー | — |
+| `KVValueHashFeatureType` | — | クエリ対象サブツリー |
+| `KVRefValueHash` | クエリ対象参照 | — |
+| `KVRefValueHashCount` | — | クエリ対象参照 |
+| `KVHash` | パス上 | — |
+| `KVHashCount` | — | パス上 |
+| `KVDigest` | 境界/不在 | — |
+| `KVDigestCount` | — | 境界/不在 |
+| `Hash` | 遠方の兄弟 | 遠方の兄弟 |
+| `KVValueHashFeatureTypeWithChildHash` | — | サブクエリなし非空ツリー |
+
 ## マルチレイヤー証明生成
 
 GroveDB はツリーのツリーであるため、証明は複数のレイヤーにまたがります。各レイヤーは1つの Merk ツリーの関連部分を証明し、レイヤーは combined value_hash メカニズムによって接続されます：

--- a/docs/book/translations/ko/src/proof-system.md
+++ b/docs/book/translations/ko/src/proof-system.md
@@ -160,6 +160,92 @@ graph TD
 | 8 | Push(Hash(frank_node_hash)) | frank 해시 푸시 |
 | 9 | Child | frank가 dave의 오른쪽 자식이 됨 |
 
+## 트리 타입별 증명 노드 타입
+
+GroveDB의 각 트리 타입은 증명에서 노드의 **역할**에 따라 특정 증명 노드 타입 집합을 사용합니다. 네 가지 역할이 있습니다:
+
+| 역할 | 설명 |
+|------|------|
+| **쿼리됨** | 노드가 쿼리와 일치 — 전체 키 + 값 공개 |
+| **경로에 있음** | 노드가 쿼리된 노드의 조상 — kv_hash만 필요 |
+| **경계** | 누락된 키에 인접 — 부재 증명 |
+| **먼** | 증명 경로에 없는 형제 서브트리 — node_hash만 필요 |
+
+### 일반 트리 (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+이 다섯 가지 트리 타입은 모두 동일한 증명 노드 타입과 동일한 해시 함수 `compute_hash` (= `node_hash(kv_hash, left, right)`)를 사용합니다. Merk 레벨에서 증명 방식에 **차이가 없습니다**.
+
+각 merk 노드는 내부적으로 `feature_type`(BasicMerkNode, SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode)을 가지지만, 이것은 **해시에 포함되지 않으며** **증명에도 포함되지 않습니다**. 이러한 트리 타입의 집계 데이터(합계, 카운트)는 **부모** Element의 직렬화된 바이트에 있으며, 부모 트리의 증명을 통해 해시 검증됩니다:
+
+| 트리 타입 | Element 저장 내용 | Merk feature_type (해시되지 않음) |
+|-----------|-----------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **합계/카운트는 어디서 오는가?** 검증자가 `[root, my_sum_tree]`에 대한 증명을 처리할 때, 부모 트리의 증명에는 키 `my_sum_tree`에 대한 `KVValueHash` 노드가 포함됩니다. `value` 필드는 직렬화된 `Element::SumTree(root_key, 42, flags)`를 담고 있습니다. 이 값은 해시 검증되므로(해시가 부모 머클 루트에 커밋됨), 합계 `42`는 신뢰할 수 있습니다. Merk 레벨의 feature_type은 무관합니다.
+
+| 역할 | V0 노드 타입 | V1 노드 타입 | 해시 함수 |
+|------|-------------|-------------|-----------|
+| 쿼리된 항목 | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| 쿼리된 비어있지 않은 트리 (서브쿼리 없음) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| 쿼리된 빈 트리 | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| 쿼리된 참조 | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| 경로에 있음 | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| 경계 | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| 먼 | `Hash` | `Hash` | 직접 사용 |
+
+> **서브쿼리가 있는 비어있지 않은 트리**는 자식 레이어로 하강합니다 — 트리 노드는 부모 레이어 증명에서 `KVValueHash`로 나타나며 자식 레이어는 자체 증명을 갖습니다.
+
+> **서브트리에 `KVValueHash`를 사용하는 이유는?** 서브트리의 value_hash는 `combine_hash(H(element_bytes), child_root_hash)`입니다 — 검증자는 엘리먼트 바이트만으로는 이를 재계산할 수 없습니다(자식 루트 해시가 필요합니다). 따라서 증명자가 미리 계산된 value_hash를 제공합니다.
+>
+> **항목에 `KV`를 사용하는 이유는?** 항목의 value_hash는 단순히 `H(value)`이며, 검증자가 재계산할 수 있습니다. `KV` 사용은 위변조 방지됩니다: 증명자가 값을 변경하면 해시가 일치하지 않습니다.
+
+**V1 개선 — `KVValueHashFeatureTypeWithChildHash`:** V1 증명에서, 서브쿼리가 없는 쿼리된 비어있지 않은 트리(쿼리가 이 트리에서 멈추는 경우 — 트리 엘리먼트 자체가 결과)의 경우, GroveDB 레이어는 merk 노드를 `KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type, child_hash)`로 업그레이드합니다. 이를 통해 검증자가 `combine_hash(H(value), child_hash) == value_hash`를 확인할 수 있으며, 공격자가 원래 value_hash를 재사용하면서 엘리먼트 바이트를 교체하는 것을 방지합니다. 빈 트리는 루트 해시를 제공할 자식 merk가 없으므로 업그레이드되지 않습니다.
+
+> **feature_type에 대한 보안 참고:** 일반(증명 불가) 트리의 경우, `KVValueHashFeatureType` 및 `KVValueHashFeatureTypeWithChildHash`의 `feature_type` 필드는 디코딩되지만 해시 계산에 **사용되지 않으며** 호출자에게 반환되지도 않습니다. 정규 트리 타입은 해시 검증된 Element 바이트에 있습니다. 이 필드는 ProvableCountTree(아래 참조)에서만 중요하며, 여기서 `node_hash_with_count`에 필요한 카운트를 전달합니다.
+
+### ProvableCountTree 및 ProvableCountSumTree
+
+이 트리 타입들은 `node_hash` 대신 `node_hash_with_count(kv_hash, left, right, count)`를 사용합니다. **카운트**가 해시에 포함되므로, 검증자는 머클 루트를 재계산하기 위해 모든 노드의 카운트가 필요합니다.
+
+| 역할 | V0 노드 타입 | V1 노드 타입 | 해시 함수 |
+|------|-------------|-------------|-----------|
+| 쿼리된 항목 | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| 쿼리된 비어있지 않은 트리 (서브쿼리 없음) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| 쿼리된 빈 트리 | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| 쿼리된 참조 | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| 경로에 있음 | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| 경계 | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| 먼 | `Hash` | `Hash` | 직접 사용 |
+
+> **서브쿼리가 있는 비어있지 않은 트리**는 일반 트리와 동일하게 자식 레이어로 하강합니다.
+
+> **모든 노드에 카운트가 있는 이유는?** `node_hash` 대신 `node_hash_with_count`가 사용되기 때문입니다. 카운트가 없으면 검증자는 루트로 가는 경로에서 어떤 중간 해시도 재구성할 수 없습니다 — 쿼리되지 않은 노드도 마찬가지입니다.
+
+**V1 개선:** 일반 트리와 동일합니다 — 서브쿼리가 없는 쿼리된 비어있지 않은 트리는 `combine_hash` 검증을 위해 `KVValueHashFeatureTypeWithChildHash`로 업그레이드됩니다.
+
+> **ProvableCountSumTree 참고:** **카운트**만 해시에 포함됩니다. 합계는 feature_type(`ProvableCountedSummedMerkNode(count, sum)`)에 전달되지만 **해시되지 않습니다**. 위의 일반 트리 타입과 마찬가지로, 정규 합계 값은 부모 Element의 직렬화된 바이트(예: `Element::ProvableCountSumTree(root_key, count, sum, flags)`)에 있으며, 부모 트리의 증명에서 해시 검증됩니다.
+
+### 요약: 노드 타입 → 트리 타입 매트릭스
+
+| 노드 타입 | 일반 트리 | ProvableCount 트리 |
+|-----------|:--------:|:-----------------:|
+| `KV` | 쿼리된 항목 | — |
+| `KVCount` | — | 쿼리된 항목 |
+| `KVValueHash` | 쿼리된 서브트리 | — |
+| `KVValueHashFeatureType` | — | 쿼리된 서브트리 |
+| `KVRefValueHash` | 쿼리된 참조 | — |
+| `KVRefValueHashCount` | — | 쿼리된 참조 |
+| `KVHash` | 경로에 있음 | — |
+| `KVHashCount` | — | 경로에 있음 |
+| `KVDigest` | 경계/부재 | — |
+| `KVDigestCount` | — | 경계/부재 |
+| `Hash` | 먼 형제 | 먼 형제 |
+| `KVValueHashFeatureTypeWithChildHash` | — | 서브쿼리 없는 비어있지 않은 트리 |
+
 ## 다중 레이어 증명 생성
 
 GroveDB는 트리의 트리이므로, 증명은 여러 레이어에 걸칩니다. 각 레이어는 하나의 Merk 트리의 관련 부분을 증명하며, 레이어들은 결합된 value_hash 메커니즘으로 연결됩니다:

--- a/docs/book/translations/pl/src/proof-system.md
+++ b/docs/book/translations/pl/src/proof-system.md
@@ -164,6 +164,140 @@ Zakodowane jako operacje dowodu:
 | 8 | Push(Hash(frank_node_hash)) | Poloz hasz frank |
 | 9 | Child | frank staje sie prawym potomkiem dave |
 
+## Typy wezlow dowodowych wedlug typu drzewa
+
+Kazdy typ drzewa w GroveDB uzywa okreslonego zestawu typow wezlow dowodowych
+w zaleznosci od **roli** wezla w dowodzie. Istnieja cztery role:
+
+| Rola | Opis |
+|------|------|
+| **Odpytywany** | Wezel pasuje do zapytania — pelny klucz + wartosc ujawnione |
+| **Na sciezce** | Wezel jest przodkiem odpytywanych wezlow — potrzebny tylko kv_hash |
+| **Graniczny** | Sasiaduje z brakujacym kluczem — dowodzi nieobecnosci |
+| **Odlegly** | Poddrzewo rodzenstwa nie na sciezce dowodu — potrzebny tylko node_hash |
+
+### Zwykle drzewa (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Wszystkie piec typow drzew uzywa identycznych typow wezlow dowodowych i tej
+samej funkcji haszujacej: `compute_hash` (= `node_hash(kv_hash, left, right)`).
+**Nie ma roznicy** w sposobie ich dowodzenia na poziomie merk.
+
+Kazdy wezel merk wewnetrznie niesie `feature_type` (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode),
+ale jest on **nie wlaczony w hasz** i **nie wlaczony w dowod**. Dane
+zagregowane (suma, licznik) dla tych typow drzew znajduja sie w
+zserializowanych bajtach **nadrzednego** Element, ktore sa weryfikowane haszem
+przez dowod drzewa nadrzednego:
+
+| Typ drzewa | Element przechowuje | Merk feature_type (nie haszowany) |
+|-----------|---------------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **Skad pochodzi suma/licznik?** Gdy weryfikator przetwarza dowod dla
+> `[root, my_sum_tree]`, dowod drzewa nadrzednego zawiera wezel `KVValueHash`
+> dla klucza `my_sum_tree`. Pole `value` zawiera zserializowany
+> `Element::SumTree(root_key, 42, flags)`. Poniewaz ta wartosc jest
+> weryfikowana haszem (jej hasz jest zatwierdzony w nadrzednym korzeniu
+> Merkle), suma `42` jest wiarygodna. feature_type na poziomie merk jest
+> nieistotny.
+
+| Rola | Typ wezla V0 | Typ wezla V1 | Funkcja haszujaca |
+|------|-------------|-------------|---------------|
+| Odpytywany element | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Odpytywane niepuste drzewo (bez subquery) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Odpytywane puste drzewo | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Odpytywana referencja | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| Na sciezce | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Graniczny | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Odlegly | `Hash` | `Hash` | Uzywany bezposrednio |
+
+> **Niepuste drzewa Z subquery** schodza do warstwy potomnej — wezel drzewa
+> pojawia sie jako `KVValueHash` w dowodzie warstwy nadrzednej, a warstwa
+> potomna ma wlasny dowod.
+
+> **Dlaczego `KVValueHash` dla poddrzew?** value_hash poddrzewa to
+> `combine_hash(H(element_bytes), child_root_hash)` — weryfikator nie moze
+> tego przeliczyc z samych bajtow elementu (potrzebowalby hasza korzenia
+> potomnego). Dlatego dowodzacy dostarcza wstepnie obliczony value_hash.
+>
+> **Dlaczego `KV` dla elementow?** value_hash elementu to po prostu
+> `H(value)`, ktory weryfikator moze przeliczyc. Uzycie `KV` jest odporne na
+> manipulacje: jezeli dowodzacy zmieni wartosc, hasz nie bedzie pasowac.
+
+**Ulepszenie V1 — `KVValueHashFeatureTypeWithChildHash`:** W dowodach V1,
+gdy odpytywane niepuste drzewo nie ma subquery (zapytanie zatrzymuje sie na
+tym drzewie — element drzewa sam jest wynikiem), warstwa GroveDB uaktualnia
+wezel merk do `KVValueHashFeatureTypeWithChildHash(key, value, value_hash,
+feature_type, child_hash)`. Pozwala to weryfikatorowi sprawdzic
+`combine_hash(H(value), child_hash) == value_hash`, zapobiegajac podmianie
+bajtow elementu przez atakujacego przy ponownym uzyciu oryginalnego
+value_hash. Puste drzewa nie sa uaktualniane, poniewaz nie maja potomnego
+merk dostarczajacego hasz korzenia.
+
+> **Uwaga bezpieczenstwa dotyczaca feature_type:** Dla zwyklych (nie-provable)
+> drzew, pole `feature_type` w `KVValueHashFeatureType` i
+> `KVValueHashFeatureTypeWithChildHash` jest dekodowane, ale **nie uzywane**
+> do obliczania hasza ani zwracane do wywolujacych. Kanoniczny typ drzewa
+> znajduje sie w bajtach Element weryfikowanych haszem. To pole ma znaczenie
+> tylko dla ProvableCountTree (patrz ponizej), gdzie przenosi licznik
+> potrzebny do `node_hash_with_count`.
+
+### ProvableCountTree i ProvableCountSumTree
+
+Te typy drzew uzywaja `node_hash_with_count(kv_hash, left, right, count)`
+zamiast `node_hash`. **Licznik** jest wlaczony w hasz, wiec weryfikator
+potrzebuje licznika dla kazdego wezla, aby przeliczyc korzen Merkle.
+
+| Rola | Typ wezla V0 | Typ wezla V1 | Funkcja haszujaca |
+|------|-------------|-------------|---------------|
+| Odpytywany element | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Odpytywane niepuste drzewo (bez subquery) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Odpytywane puste drzewo | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Odpytywana referencja | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| Na sciezce | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Graniczny | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Odlegly | `Hash` | `Hash` | Uzywany bezposrednio |
+
+> **Niepuste drzewa Z subquery** schodza do warstwy potomnej, tak samo jak
+> zwykle drzewa.
+
+> **Dlaczego kazdy wezel niesie licznik?** Poniewaz uzywa sie
+> `node_hash_with_count` zamiast `node_hash`. Bez licznika weryfikator nie
+> moze odtworzyc zadnego posredniego hasza na sciezce do korzenia — nawet
+> dla nie-odpytywanych wezlow.
+
+**Ulepszenie V1:** Tak samo jak dla zwyklych drzew — odpytywane niepuste
+drzewa bez subquery sa uaktualniane do
+`KVValueHashFeatureTypeWithChildHash` w celu weryfikacji `combine_hash`.
+
+> **Uwaga o ProvableCountSumTree:** Tylko **licznik** jest wlaczony w hasz.
+> Suma jest przenoszona w feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`), ale **nie jest haszowana**. Podobnie jak powyzsze zwykle typy drzew,
+> kanoniczna wartosc sumy znajduje sie w zserializowanych bajtach nadrzednego
+> Element (np. `Element::ProvableCountSumTree(root_key, count, sum, flags)`),
+> ktore sa weryfikowane haszem w dowodzie drzewa nadrzednego.
+
+### Podsumowanie: Macierz typ wezla → typ drzewa
+
+| Typ wezla | Zwykle drzewa | Drzewa ProvableCount |
+|-----------|:------------:|:-------------------:|
+| `KV` | Odpytywane elementy | — |
+| `KVCount` | — | Odpytywane elementy |
+| `KVValueHash` | Odpytywane poddrzewa | — |
+| `KVValueHashFeatureType` | — | Odpytywane poddrzewa |
+| `KVRefValueHash` | Odpytywane referencje | — |
+| `KVRefValueHashCount` | — | Odpytywane referencje |
+| `KVHash` | Na sciezce | — |
+| `KVHashCount` | — | Na sciezce |
+| `KVDigest` | Granica/nieobecnosc | — |
+| `KVDigestCount` | — | Granica/nieobecnosc |
+| `Hash` | Odlegle rodzenstwo | Odlegle rodzenstwo |
+| `KVValueHashFeatureTypeWithChildHash` | — | Niepuste drzewa bez subquery |
+
 ## Generowanie dowodow wielowarstwowych
 
 Poniewaz GroveDB jest drzewem drzew, dowody obejmuja wiele warstw. Kazda warstwa

--- a/docs/book/translations/pt/src/proof-system.md
+++ b/docs/book/translations/pt/src/proof-system.md
@@ -164,6 +164,139 @@ Codificado como ops de prova:
 | 8 | Push(Hash(frank_node_hash)) | Empurrar hash de frank |
 | 9 | Child | frank se torna filho direito de dave |
 
+## Tipos de No de Prova por Tipo de Arvore
+
+Cada tipo de arvore no GroveDB usa um conjunto especifico de tipos de no de
+prova dependendo do **papel** do no na prova. Existem quatro papeis:
+
+| Papel | Descricao |
+|-------|-----------|
+| **Consultado** | O no corresponde a consulta — chave + valor completos revelados |
+| **No caminho** | O no e um ancestral dos nos consultados — apenas kv_hash necessario |
+| **Limite** | Adjacente a uma chave ausente — prova ausencia |
+| **Distante** | Uma subarvore irma fora do caminho da prova — apenas node_hash necessario |
+
+### Arvores Regulares (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Todos os cinco tipos de arvore usam tipos de no de prova identicos e a mesma
+funcao de hash: `compute_hash` (= `node_hash(kv_hash, left, right)`). **Nao ha
+diferenca** em como sao provadas no nivel merk.
+
+Cada no merk carrega internamente um `feature_type` (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode),
+mas isso **nao e incluido no hash** e **nao e incluido na prova**. Os dados
+agregados (soma, contagem) para esses tipos de arvore residem nos bytes
+serializados do Element **pai**, que sao verificados por hash atraves da
+prova da arvore pai:
+
+| Tipo de arvore | Element armazena | Merk feature_type (nao incluido no hash) |
+|---------------|-----------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **De onde vem a soma/contagem?** Quando um verificador processa uma prova
+> para `[root, my_sum_tree]`, a prova da arvore pai inclui um no
+> `KVValueHash` para a chave `my_sum_tree`. O campo `value` contem o
+> `Element::SumTree(root_key, 42, flags)` serializado. Como esse valor e
+> verificado por hash (seu hash e comprometido na raiz Merkle pai), a
+> soma `42` e confiavel. O feature_type no nivel merk e irrelevante.
+
+| Papel | Tipo de No V0 | Tipo de No V1 | Funcao de hash |
+|-------|-------------|-------------|---------------|
+| Item consultado | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Arvore nao vazia consultada (sem subquery) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Arvore vazia consultada | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Referencia consultada | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| No caminho | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Limite | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Distante | `Hash` | `Hash` | Usado diretamente |
+
+> **Arvores nao vazias COM subquery** descem para a camada filha — o no da
+> arvore aparece como `KVValueHash` na prova da camada pai e a camada filha
+> tem sua propria prova.
+
+> **Por que `KVValueHash` para subarvores?** O value_hash de uma subarvore e
+> `combine_hash(H(element_bytes), child_root_hash)` — o verificador nao pode
+> recomputar isso apenas com os bytes do elemento (precisaria do hash raiz
+> filho). Portanto, o provador fornece o value_hash pre-computado.
+>
+> **Por que `KV` para itens?** O value_hash de um item e simplesmente
+> `H(value)`, que o verificador pode recomputar. Usar `KV` e a prova de
+> adulteracao: se o provador alterar o valor, o hash nao correspondera.
+
+**Melhoria V1 — `KVValueHashFeatureTypeWithChildHash`:** Em provas V1, quando
+uma arvore nao vazia consultada nao tem subquery (a consulta para nesta arvore
+— o elemento da arvore em si e o resultado), a camada GroveDB atualiza o no
+merk para `KVValueHashFeatureTypeWithChildHash(key, value, value_hash,
+feature_type, child_hash)`. Isso permite que o verificador verifique
+`combine_hash(H(value), child_hash) == value_hash`, impedindo que um atacante
+troque os bytes do elemento reutilizando o value_hash original. Arvores vazias
+nao sao atualizadas porque nao tem um merk filho para fornecer um hash raiz.
+
+> **Nota de seguranca sobre feature_type:** Para arvores regulares (nao
+> provaveis), o campo `feature_type` em `KVValueHashFeatureType` e
+> `KVValueHashFeatureTypeWithChildHash` e decodificado mas **nao usado** para
+> computacao de hash nem retornado aos chamadores. O tipo canonico da arvore
+> reside nos bytes do Element verificados por hash. Este campo so importa para
+> ProvableCountTree (veja abaixo), onde carrega a contagem necessaria para
+> `node_hash_with_count`.
+
+### ProvableCountTree e ProvableCountSumTree
+
+Esses tipos de arvore usam `node_hash_with_count(kv_hash, left, right, count)`
+em vez de `node_hash`. A **contagem** e incluida no hash, portanto o
+verificador precisa da contagem de cada no para recomputar a raiz Merkle.
+
+| Papel | Tipo de No V0 | Tipo de No V1 | Funcao de hash |
+|-------|-------------|-------------|---------------|
+| Item consultado | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Arvore nao vazia consultada (sem subquery) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Arvore vazia consultada | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Referencia consultada | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| No caminho | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Limite | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Distante | `Hash` | `Hash` | Usado diretamente |
+
+> **Arvores nao vazias COM subquery** descem para a camada filha, assim como
+> as arvores regulares.
+
+> **Por que cada no carrega uma contagem?** Porque `node_hash_with_count` e
+> usado em vez de `node_hash`. Sem a contagem, o verificador nao pode
+> reconstruir nenhum hash intermediario no caminho ate a raiz — mesmo para nos
+> nao consultados.
+
+**Melhoria V1:** Igual as arvores regulares — arvores nao vazias consultadas
+sem subquery sao atualizadas para `KVValueHashFeatureTypeWithChildHash` para
+verificacao de `combine_hash`.
+
+> **Nota sobre ProvableCountSumTree:** Apenas a **contagem** e incluida no
+> hash. A soma e transportada no feature_type
+> (`ProvableCountedSummedMerkNode(count, sum)`) mas **nao e incluida no
+> hash**. Assim como os tipos de arvore regulares acima, o valor canonico da
+> soma reside nos bytes serializados do Element pai (por exemplo,
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`), que sao
+> verificados por hash na prova da arvore pai.
+
+### Resumo: Matriz Tipo de No → Tipo de Arvore
+
+| Tipo de No | Arvores Regulares | Arvores ProvableCount |
+|-----------|:------------:|:-------------------:|
+| `KV` | Itens consultados | — |
+| `KVCount` | — | Itens consultados |
+| `KVValueHash` | Subarvores consultadas | — |
+| `KVValueHashFeatureType` | — | Subarvores consultadas |
+| `KVRefValueHash` | Referencias consultadas | — |
+| `KVRefValueHashCount` | — | Referencias consultadas |
+| `KVHash` | No caminho | — |
+| `KVHashCount` | — | No caminho |
+| `KVDigest` | Limite/ausencia | — |
+| `KVDigestCount` | — | Limite/ausencia |
+| `Hash` | Irmaos distantes | Irmaos distantes |
+| `KVValueHashFeatureTypeWithChildHash` | — | Arvores nao vazias sem subquery |
+
 ## Geracao de Provas Multicamada
 
 Como o GroveDB e uma arvore de arvores, as provas abrangem multiplas camadas. Cada camada

--- a/docs/book/translations/ru/src/proof-system.md
+++ b/docs/book/translations/ru/src/proof-system.md
@@ -160,6 +160,141 @@ graph TD
 | 8 | Push(Hash(frank_node_hash)) | Помещаем хеш frank |
 | 9 | Child | frank становится правым потомком dave |
 
+## Типы узлов доказательств по типам деревьев
+
+Каждый тип дерева в GroveDB использует определённый набор типов узлов
+доказательств в зависимости от **роли** узла в доказательстве. Существуют
+четыре роли:
+
+| Роль | Описание |
+|------|----------|
+| **Запрашиваемый** | Узел соответствует запросу — полный ключ + значение раскрыты |
+| **На пути** | Узел является предком запрашиваемых узлов — нужен только kv_hash |
+| **Граничный** | Соседствует с отсутствующим ключом — доказывает отсутствие |
+| **Дальний** | Поддерево-сосед вне пути доказательства — нужен только node_hash |
+
+### Обычные деревья (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Все пять типов деревьев используют идентичные типы узлов доказательств и одну
+и ту же хеш-функцию: `compute_hash` (= `node_hash(kv_hash, left, right)`).
+**Нет никакой разницы** в том, как они доказываются на уровне merk.
+
+Каждый узел merk внутренне несёт `feature_type` (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode),
+но он **не включается в хеш** и **не включается в доказательство**.
+Агрегированные данные (сумма, счётчик) для этих типов деревьев находятся в
+сериализованных байтах **родительского** Element, которые верифицируются
+хешем через доказательство родительского дерева:
+
+| Тип дерева | Element хранит | Merk feature_type (не хешируется) |
+|-----------|---------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **Откуда берётся сумма/счётчик?** Когда верификатор обрабатывает
+> доказательство для `[root, my_sum_tree]`, доказательство родительского
+> дерева содержит узел `KVValueHash` для ключа `my_sum_tree`. Поле `value`
+> содержит сериализованный `Element::SumTree(root_key, 42, flags)`. Поскольку
+> это значение верифицировано хешем (его хеш зафиксирован в родительском
+> корне Меркла), сумма `42` заслуживает доверия. feature_type на уровне merk
+> не имеет значения.
+
+| Роль | Тип узла V0 | Тип узла V1 | Хеш-функция |
+|------|-------------|-------------|-------------|
+| Запрашиваемый элемент | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Запрашиваемое непустое дерево (без subquery) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Запрашиваемое пустое дерево | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Запрашиваемая ссылка | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| На пути | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Граничный | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Дальний | `Hash` | `Hash` | Используется напрямую |
+
+> **Непустые деревья С subquery** спускаются в дочерний уровень — узел
+> дерева появляется как `KVValueHash` в доказательстве родительского уровня,
+> а дочерний уровень имеет собственное доказательство.
+
+> **Почему `KVValueHash` для поддеревьев?** value_hash поддерева равен
+> `combine_hash(H(element_bytes), child_root_hash)` — верификатор не может
+> пересчитать его только из байтов элемента (ему нужен хеш корня дочернего
+> дерева). Поэтому доказывающий предоставляет предвычисленный value_hash.
+>
+> **Почему `KV` для элементов?** value_hash элемента — это просто `H(value)`,
+> который верификатор может пересчитать. Использование `KV` защищено от
+> подделки: если доказывающий изменит значение, хеш не совпадёт.
+
+**Улучшение V1 — `KVValueHashFeatureTypeWithChildHash`:** В доказательствах V1,
+когда запрашиваемое непустое дерево не имеет subquery (запрос останавливается
+на этом дереве — сам элемент дерева является результатом), уровень GroveDB
+обновляет узел merk до `KVValueHashFeatureTypeWithChildHash(key, value,
+value_hash, feature_type, child_hash)`. Это позволяет верификатору проверить
+`combine_hash(H(value), child_hash) == value_hash`, предотвращая подмену
+атакующим байтов элемента при повторном использовании исходного value_hash.
+Пустые деревья не обновляются, поскольку у них нет дочернего merk для
+предоставления корневого хеша.
+
+> **Замечание по безопасности о feature_type:** Для обычных (не-provable)
+> деревьев поле `feature_type` в `KVValueHashFeatureType` и
+> `KVValueHashFeatureTypeWithChildHash` декодируется, но **не используется**
+> при вычислении хеша и не возвращается вызывающим. Каноничный тип дерева
+> находится в верифицированных хешем байтах Element. Это поле имеет значение
+> только для ProvableCountTree (см. ниже), где оно несёт счётчик, необходимый
+> для `node_hash_with_count`.
+
+### ProvableCountTree и ProvableCountSumTree
+
+Эти типы деревьев используют `node_hash_with_count(kv_hash, left, right, count)`
+вместо `node_hash`. **Счётчик** включается в хеш, поэтому верификатору нужен
+счётчик каждого узла для пересчёта корня Меркла.
+
+| Роль | Тип узла V0 | Тип узла V1 | Хеш-функция |
+|------|-------------|-------------|-------------|
+| Запрашиваемый элемент | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Запрашиваемое непустое дерево (без subquery) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Запрашиваемое пустое дерево | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Запрашиваемая ссылка | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| На пути | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Граничный | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Дальний | `Hash` | `Hash` | Используется напрямую |
+
+> **Непустые деревья С subquery** спускаются в дочерний уровень, так же как
+> и обычные деревья.
+
+> **Почему каждый узел несёт счётчик?** Потому что используется
+> `node_hash_with_count` вместо `node_hash`. Без счётчика верификатор не может
+> восстановить ни один промежуточный хеш на пути к корню — даже для
+> незапрашиваемых узлов.
+
+**Улучшение V1:** Так же, как для обычных деревьев — запрашиваемые непустые
+деревья без subquery обновляются до `KVValueHashFeatureTypeWithChildHash` для
+верификации `combine_hash`.
+
+> **Примечание о ProvableCountSumTree:** Только **счётчик** включается в хеш.
+> Сумма передаётся в feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`), но **не хешируется**. Как и для обычных типов деревьев выше,
+> каноничное значение суммы находится в сериализованных байтах родительского
+> Element (например, `Element::ProvableCountSumTree(root_key, count, sum,
+> flags)`), которые верифицируются хешем в доказательстве родительского дерева.
+
+### Сводка: Матрица тип узла → тип дерева
+
+| Тип узла | Обычные деревья | Деревья ProvableCount |
+|----------|:--------------:|:--------------------:|
+| `KV` | Запрашиваемые элементы | — |
+| `KVCount` | — | Запрашиваемые элементы |
+| `KVValueHash` | Запрашиваемые поддеревья | — |
+| `KVValueHashFeatureType` | — | Запрашиваемые поддеревья |
+| `KVRefValueHash` | Запрашиваемые ссылки | — |
+| `KVRefValueHashCount` | — | Запрашиваемые ссылки |
+| `KVHash` | На пути | — |
+| `KVHashCount` | — | На пути |
+| `KVDigest` | Граница/отсутствие | — |
+| `KVDigestCount` | — | Граница/отсутствие |
+| `Hash` | Дальние соседи | Дальние соседи |
+| `KVValueHashFeatureTypeWithChildHash` | — | Непустые деревья без subquery |
+
 ## Генерация многоуровневых доказательств
 
 Поскольку GroveDB — это дерево деревьев, доказательства охватывают несколько уровней. Каждый уровень доказывает соответствующую часть одного дерева Merk, и уровни связаны механизмом комбинированного value_hash:

--- a/docs/book/translations/th/src/proof-system.md
+++ b/docs/book/translations/th/src/proof-system.md
@@ -160,6 +160,134 @@ graph TD
 | 8 | Push(Hash(frank_node_hash)) | ดัน frank hash |
 | 9 | Child | frank กลายเป็นลูกขวาของ dave |
 
+## ประเภท Proof Node ตามประเภทต้นไม้
+
+ต้นไม้แต่ละประเภทใน GroveDB ใช้ชุด proof node ที่เฉพาะเจาะจง ขึ้นอยู่กับ
+**บทบาท** ของ node ใน proof มีสี่บทบาท:
+
+| บทบาท | คำอธิบาย |
+|------|-------------|
+| **Queried** | node ตรงกับ query — เปิดเผย key + value เต็ม |
+| **On-path** | node เป็นบรรพบุรุษของ node ที่ถูกสืบค้น — ต้องการเพียง kv_hash |
+| **Boundary** | อยู่ติดกับ key ที่หายไป — พิสูจน์การไม่มีอยู่ |
+| **Distant** | subtree พี่น้องที่ไม่อยู่บน proof path — ต้องการเพียง node_hash |
+
+### ต้นไม้ปกติ (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+ต้นไม้ทั้งห้าประเภทนี้ใช้ proof node ประเภทเดียวกันและฟังก์ชันแฮชเดียวกัน:
+`compute_hash` (= `node_hash(kv_hash, left, right)`) **ไม่มีความแตกต่าง**
+ในวิธีการพิสูจน์ที่ระดับ merk
+
+แต่ละ merk node มี `feature_type` ภายใน (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode) แต่
+สิ่งนี้**ไม่รวมอยู่ในแฮช**และ**ไม่รวมอยู่ใน proof** ข้อมูลรวม (sum, count)
+สำหรับต้นไม้ประเภทเหล่านี้อยู่ในไบต์ที่ serialize ของ Element **แม่** ซึ่งถูกตรวจสอบแฮช
+ผ่าน proof ของต้นไม้แม่:
+
+| ประเภทต้นไม้ | Element เก็บ | Merk feature_type (ไม่ถูกแฮช) |
+|-----------|---------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **sum/count มาจากไหน?** เมื่อผู้ตรวจสอบประมวลผล proof
+> สำหรับ `[root, my_sum_tree]` proof ของต้นไม้แม่จะมี
+> node `KVValueHash` สำหรับ key `my_sum_tree` ฟิลด์ `value` มี
+> `Element::SumTree(root_key, 42, flags)` ที่ serialize แล้ว เนื่องจากค่านี้
+> ถูกตรวจสอบแฮช (แฮชของมันถูกผูกพันกับ Merkle root ของแม่) ค่า sum `42`
+> จึงเชื่อถือได้ feature_type ระดับ merk ไม่เกี่ยวข้อง
+
+| บทบาท | ประเภท Node V0 | ประเภท Node V1 | ฟังก์ชันแฮช |
+|------|-------------|-------------|---------------|
+| รายการที่ถูกสืบค้น | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| ต้นไม้ที่ไม่ว่างที่ถูกสืบค้น (ไม่มี subquery) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| ต้นไม้ว่างที่ถูกสืบค้น | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| reference ที่ถูกสืบค้น | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| On-path | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Boundary | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Distant | `Hash` | `Hash` | ใช้โดยตรง |
+
+> **ต้นไม้ที่ไม่ว่างที่มี subquery** จะลงไปยังชั้นลูก — node ต้นไม้ปรากฏเป็น
+> `KVValueHash` ใน proof ชั้นแม่ และชั้นลูกมี proof ของตัวเอง
+
+> **ทำไมใช้ `KVValueHash` สำหรับ subtree?** value_hash ของ subtree คือ
+> `combine_hash(H(element_bytes), child_root_hash)` — ผู้ตรวจสอบไม่สามารถ
+> คำนวณสิ่งนี้ใหม่จากไบต์ element อย่างเดียว (จะต้องการ child root
+> hash) ดังนั้น prover จึงให้ value_hash ที่คำนวณไว้แล้ว
+>
+> **ทำไมใช้ `KV` สำหรับรายการ?** value_hash ของรายการคือ `H(value)` ซึ่ง
+> ผู้ตรวจสอบคำนวณใหม่ได้ การใช้ `KV` ป้องกันการปลอมแปลง: ถ้า prover เปลี่ยน
+> ค่า แฮชจะไม่ตรงกัน
+
+**การปรับปรุง V1 — `KVValueHashFeatureTypeWithChildHash`:** ใน proof V1 เมื่อ
+ต้นไม้ที่ไม่ว่างที่ถูกสืบค้นไม่มี subquery (query หยุดที่ต้นไม้นี้ — element ต้นไม้
+เป็นผลลัพธ์) ชั้น GroveDB จะอัปเกรด merk node เป็น
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)` สิ่งนี้ให้ผู้ตรวจสอบตรวจสอบ `combine_hash(H(value), child_hash)
+== value_hash` ป้องกันผู้โจมตีจากการสลับไบต์ element ในขณะที่ใช้
+value_hash เดิมซ้ำ ต้นไม้ว่างจะไม่ถูกอัปเกรดเพราะไม่มี child merk
+ที่จะให้ root hash
+
+> **หมายเหตุด้านความปลอดภัยเกี่ยวกับ feature_type:** สำหรับต้นไม้ปกติ (ที่ไม่ใช่ provable)
+> ฟิลด์ `feature_type` ใน `KVValueHashFeatureType` และ
+> `KVValueHashFeatureTypeWithChildHash` ถูก decode แต่**ไม่ถูกใช้**สำหรับ
+> การคำนวณแฮชหรือส่งคืนให้ผู้เรียก ประเภทต้นไม้ที่เป็นทางการอยู่ในไบต์ Element
+> ที่ตรวจสอบแฮชแล้ว ฟิลด์นี้สำคัญเฉพาะสำหรับ ProvableCountTree
+> (ดูด้านล่าง) ที่มันบรรจุ count ที่ต้องการสำหรับ `node_hash_with_count`
+
+### ProvableCountTree และ ProvableCountSumTree
+
+ต้นไม้ประเภทเหล่านี้ใช้ `node_hash_with_count(kv_hash, left, right, count)` แทน
+`node_hash` **count** ถูกรวมอยู่ในแฮช ดังนั้นผู้ตรวจสอบต้องการ
+count สำหรับทุก node เพื่อคำนวณ Merkle root ใหม่
+
+| บทบาท | ประเภท Node V0 | ประเภท Node V1 | ฟังก์ชันแฮช |
+|------|-------------|-------------|---------------|
+| รายการที่ถูกสืบค้น | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| ต้นไม้ที่ไม่ว่างที่ถูกสืบค้น (ไม่มี subquery) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| ต้นไม้ว่างที่ถูกสืบค้น | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| reference ที่ถูกสืบค้น | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| On-path | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Boundary | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Distant | `Hash` | `Hash` | ใช้โดยตรง |
+
+> **ต้นไม้ที่ไม่ว่างที่มี subquery** จะลงไปยังชั้นลูก เช่นเดียวกับ
+> ต้นไม้ปกติ
+
+> **ทำไมทุก node ต้องมี count?** เพราะใช้ `node_hash_with_count` แทน
+> `node_hash` หากไม่มี count ผู้ตรวจสอบไม่สามารถสร้าง
+> แฮชกลางใด ๆ บน path ไปยัง root ได้ — แม้แต่สำหรับ node ที่ไม่ถูกสืบค้น
+
+**การปรับปรุง V1:** เหมือนกับต้นไม้ปกติ — ต้นไม้ที่ไม่ว่างที่ถูกสืบค้นที่ไม่มี
+subquery จะถูกอัปเกรดเป็น `KVValueHashFeatureTypeWithChildHash` สำหรับ
+การตรวจสอบ `combine_hash`
+
+> **หมายเหตุ ProvableCountSumTree:** เฉพาะ **count** เท่านั้นที่รวมอยู่ในแฮช
+> sum ถูกบรรจุใน feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`) แต่**ไม่ถูกแฮช** เช่นเดียวกับต้นไม้ปกติข้างต้น ค่า sum
+> ที่เป็นทางการอยู่ในไบต์ที่ serialize ของ Element แม่ (เช่น
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`) ซึ่งถูก
+> ตรวจสอบแฮชใน proof ของต้นไม้แม่
+
+### สรุป: เมทริกซ์ประเภท Node → ประเภทต้นไม้
+
+| ประเภท Node | ต้นไม้ปกติ | ProvableCount Trees |
+|-----------|:------------:|:-------------------:|
+| `KV` | รายการที่ถูกสืบค้น | — |
+| `KVCount` | — | รายการที่ถูกสืบค้น |
+| `KVValueHash` | subtree ที่ถูกสืบค้น | — |
+| `KVValueHashFeatureType` | — | subtree ที่ถูกสืบค้น |
+| `KVRefValueHash` | reference ที่ถูกสืบค้น | — |
+| `KVRefValueHashCount` | — | reference ที่ถูกสืบค้น |
+| `KVHash` | On-path | — |
+| `KVHashCount` | — | On-path |
+| `KVDigest` | Boundary/absence | — |
+| `KVDigestCount` | — | Boundary/absence |
+| `Hash` | sibling ที่ห่างไกล | sibling ที่ห่างไกล |
+| `KVValueHashFeatureTypeWithChildHash` | — | ต้นไม้ที่ไม่ว่างที่ไม่มี subquery |
+
 ## การสร้าง Proof หลายชั้น
 
 เนื่องจาก GroveDB เป็นต้นไม้ของต้นไม้ proof จึงครอบคลุมหลายชั้น (layer) แต่ละชั้นพิสูจน์ส่วนที่เกี่ยวข้องของ Merk tree หนึ่งต้น และชั้นต่าง ๆ ถูกเชื่อมกันด้วยกลไก combined value_hash:

--- a/docs/book/translations/tr/src/proof-system.md
+++ b/docs/book/translations/tr/src/proof-system.md
@@ -160,6 +160,137 @@ Ispat islemleri olarak kodlanmis hali:
 | 8 | Push(Hash(frank_dugum_hash)) | frank hash'ini it |
 | 9 | Child | frank dave'in sag cocugu olur |
 
+## Agac Tipine Gore Ispat Dugum Tipleri
+
+GroveDB'deki her agac tipi, dugumlerin ispattaki **rolune** bagli olarak belirli bir
+ispat dugum tipleri kumesi kullanir. Dort rol vardir:
+
+| Rol | Aciklama |
+|------|-------------|
+| **Queried** | Dugum sorguyla eslesir — tam anahtar + deger aciga cikarilir |
+| **On-path** | Dugum sorgulanan dugumlerin atasidir — yalnizca kv_hash gerekir |
+| **Boundary** | Eksik bir anahtara bitisiktir — yoklugu kanitlar |
+| **Distant** | Ispat yolunda olmayan kardes alt agac — yalnizca node_hash gerekir |
+
+### Normal Agaclar (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Bu bes agac tipinin tumunde ayni ispat dugum tipleri ve ayni hash fonksiyonu
+kullanilir: `compute_hash` (= `node_hash(kv_hash, left, right)`). Merk seviyesinde
+kanitlanma bicimlerinde **hicbir fark yoktur**.
+
+Her merk dugumu dahili olarak bir `feature_type` tasir (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode), ancak
+bu **hash'e dahil edilmez** ve **ispata dahil edilmez**. Bu agac tipleri icin
+toplam veri (sum, count) **ust** Element'in seriestirilmis baytlarinda bulunur
+ve ust agacin ispati araciligiyla hash-dogrulanir:
+
+| Agac tipi | Element'in depoladigi | Merk feature_type (hash'lenmez) |
+|-----------|---------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **sum/count nereden gelir?** Dogrulayici `[root, my_sum_tree]` icin bir
+> ispati islerken, ust agacin ispati `my_sum_tree` anahtari icin bir
+> `KVValueHash` dugumu icerir. `value` alani seriestirilmis
+> `Element::SumTree(root_key, 42, flags)` icerir. Bu deger hash-dogrulandigi
+> icin (hash'i ust Merkle root'a baglanmistir), `42` sum degeri
+> guvenilirdir. Merk seviyesindeki feature_type onemli degildir.
+
+| Rol | V0 Dugum Tipi | V1 Dugum Tipi | Hash fonksiyonu |
+|------|-------------|-------------|---------------|
+| Sorgulanan oge | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Sorgulanan bos olmayan agac (subquery yok) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Sorgulanan bos agac | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Sorgulanan referans | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| On-path | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Boundary | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Distant | `Hash` | `Hash` | Dogrudan kullanilir |
+
+> **subquery'li bos olmayan agaclar** cocuk katmana iner — agac dugumu
+> ust katman ispatinda `KVValueHash` olarak gorunur ve cocuk katmanin
+> kendi ispati vardir.
+
+> **Neden alt agaclar icin `KVValueHash`?** Bir alt agacin value_hash'i
+> `combine_hash(H(element_bytes), child_root_hash)` seklindedir — dogrulayici
+> bunu yalnizca element baytlarindan yeniden hesaplayamaz (child root
+> hash'e ihtiyaci olurdu). Bu yuzden saglayici onceden hesaplanmis value_hash'i
+> sunar.
+>
+> **Neden ogeler icin `KV`?** Bir ogenin value_hash'i basitce `H(value)` olup
+> dogrulayici bunu yeniden hesaplayabilir. `KV` kullanmak degistirilmeye karsi
+> guvenlidir: saglayici degeri degistirirse hash eslesmez.
+
+**V1 gelistirmesi — `KVValueHashFeatureTypeWithChildHash`:** V1 ispatlarinda,
+sorgulanan bos olmayan bir agacin subquery'si olmadiginda (sorgu bu agacta durur —
+agac elementinin kendisi sonuctur), GroveDB katmani merk dugumunu
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)` olarak yukseltir. Bu, dogrulayicinin `combine_hash(H(value), child_hash)
+== value_hash` kontrolu yapmasini saglar ve bir saldirganin orijinal value_hash'i
+yeniden kullanarak element baytlarini degistirmesini onler. Bos agaclar
+yukseltilmez cunku kok hash saglayacak bir cocuk merk'leri yoktur.
+
+> **feature_type hakkinda guvenlik notu:** Normal (provable olmayan) agaclar icin,
+> `KVValueHashFeatureType` ve `KVValueHashFeatureTypeWithChildHash` icindeki
+> `feature_type` alani decode edilir ancak hash hesaplamasinda veya cagiranlara
+> donuste **kullanilmaz**. Kanonik agac tipi hash-dogrulanmis Element
+> baytlarinda yasir. Bu alan yalnizca ProvableCountTree (asagiya bakin)
+> icin onemlidir; burada `node_hash_with_count` icin gereken count'u tasir.
+
+### ProvableCountTree ve ProvableCountSumTree
+
+Bu agac tipleri `node_hash` yerine `node_hash_with_count(kv_hash, left, right, count)`
+kullanir. **count** hash'e dahil edildigi icin, dogrulayicinin Merkle root'u
+yeniden hesaplamak icin her dugum icin count'a ihtiyaci vardir.
+
+| Rol | V0 Dugum Tipi | V1 Dugum Tipi | Hash fonksiyonu |
+|------|-------------|-------------|---------------|
+| Sorgulanan oge | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Sorgulanan bos olmayan agac (subquery yok) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Sorgulanan bos agac | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Sorgulanan referans | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| On-path | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Boundary | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Distant | `Hash` | `Hash` | Dogrudan kullanilir |
+
+> **subquery'li bos olmayan agaclar** normal agaclarda oldugu gibi cocuk
+> katmana iner.
+
+> **Neden her dugum bir count tasir?** Cunku `node_hash` yerine
+> `node_hash_with_count` kullanilir. count olmadan, dogrulayici root'a giden
+> yoldaki hicbir ara hash'i yeniden olusturamaz — sorgulanmayan dugumler icin
+> bile.
+
+**V1 gelistirmesi:** Normal agaclarla ayni — subquery'siz sorgulanan bos olmayan
+agaclar, `combine_hash` dogrulamasi icin `KVValueHashFeatureTypeWithChildHash`
+olarak yukseltilir.
+
+> **ProvableCountSumTree notu:** Yalnizca **count** hash'e dahil edilir.
+> sum, feature_type icinde (`ProvableCountedSummedMerkNode(count,
+> sum)`) tasinir ancak **hash'lenmez**. Yukardaki normal agac tipleri gibi,
+> kanonik sum degeri ust Element'in seriestirilmis baytlarinda (ornegin
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`) yasir ve
+> ust agacin ispatinda hash-dogrulanir.
+
+### Ozet: Dugum Tipi → Agac Tipi Matrisi
+
+| Dugum Tipi | Normal Agaclar | ProvableCount Agaclari |
+|-----------|:------------:|:-------------------:|
+| `KV` | Sorgulanan ogeler | — |
+| `KVCount` | — | Sorgulanan ogeler |
+| `KVValueHash` | Sorgulanan alt agaclar | — |
+| `KVValueHashFeatureType` | — | Sorgulanan alt agaclar |
+| `KVRefValueHash` | Sorgulanan referanslar | — |
+| `KVRefValueHashCount` | — | Sorgulanan referanslar |
+| `KVHash` | On-path | — |
+| `KVHashCount` | — | On-path |
+| `KVDigest` | Boundary/absence | — |
+| `KVDigestCount` | — | Boundary/absence |
+| `Hash` | Uzak kardesler | Uzak kardesler |
+| `KVValueHashFeatureTypeWithChildHash` | — | subquery'siz bos olmayan agaclar |
+
 ## Cok Katmanli Ispat Uretimi
 
 GroveDB agaclar agaci oldugu icin, ispatlar birden fazla katmani kapsar. Her katman bir Merk agacinin ilgili bolumunu kanitlar ve katmanlar birlesik value_hash mekanizmasiyla birbirine baglanir:

--- a/docs/book/translations/vi/src/proof-system.md
+++ b/docs/book/translations/vi/src/proof-system.md
@@ -160,6 +160,134 @@ Mã hóa thành các thao tác proof:
 | 8 | Push(Hash(frank_node_hash)) | Đẩy hash frank |
 | 9 | Child | frank trở thành con phải của dave |
 
+## Các kiểu Proof Node theo kiểu cây
+
+Mỗi kiểu cây trong GroveDB sử dụng một tập hợp kiểu proof node cụ thể tùy thuộc
+vào **vai trò** của nút trong bằng chứng. Có bốn vai trò:
+
+| Vai trò | Mô tả |
+|------|-------------|
+| **Queried** | Nút khớp với truy vấn — tiết lộ đầy đủ key + value |
+| **On-path** | Nút là tổ tiên của các nút được truy vấn — chỉ cần kv_hash |
+| **Boundary** | Liền kề với khóa bị thiếu — chứng minh sự vắng mặt |
+| **Distant** | Cây con anh em không nằm trên đường dẫn bằng chứng — chỉ cần node_hash |
+
+### Cây thông thường (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+Cả năm kiểu cây này đều sử dụng cùng kiểu proof node và cùng hàm băm:
+`compute_hash` (= `node_hash(kv_hash, left, right)`). **Không có sự khác biệt**
+nào trong cách chúng được chứng minh ở cấp độ merk.
+
+Mỗi nút merk mang một `feature_type` nội bộ (BasicMerkNode,
+SummedMerkNode, BigSummedMerkNode, CountedMerkNode, CountedSummedMerkNode), nhưng
+điều này **không được bao gồm trong hash** và **không được bao gồm trong bằng chứng**.
+Dữ liệu tổng hợp (sum, count) cho các kiểu cây này nằm trong byte serialize
+của Element **cha**, được xác minh hash thông qua bằng chứng cây cha:
+
+| Kiểu cây | Element lưu trữ | Merk feature_type (không được hash) |
+|-----------|---------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **sum/count đến từ đâu?** Khi bên xác minh xử lý bằng chứng cho
+> `[root, my_sum_tree]`, bằng chứng cây cha bao gồm nút
+> `KVValueHash` cho khóa `my_sum_tree`. Trường `value` chứa
+> `Element::SumTree(root_key, 42, flags)` đã serialize. Vì giá trị này
+> được xác minh hash (hash của nó được cam kết vào Merkle root cha),
+> giá trị sum `42` là đáng tin cậy. feature_type ở cấp merk không liên quan.
+
+| Vai trò | Kiểu Node V0 | Kiểu Node V1 | Hàm băm |
+|------|-------------|-------------|---------------|
+| Mục được truy vấn | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| Cây không rỗng được truy vấn (không có subquery) | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Cây rỗng được truy vấn | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Tham chiếu được truy vấn | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| On-path | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Boundary | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Distant | `Hash` | `Hash` | Dùng trực tiếp |
+
+> **Cây không rỗng CÓ subquery** đi xuống tầng con — nút cây xuất hiện dưới
+> dạng `KVValueHash` trong bằng chứng tầng cha và tầng con có bằng chứng riêng.
+
+> **Tại sao dùng `KVValueHash` cho cây con?** value_hash của cây con là
+> `combine_hash(H(element_bytes), child_root_hash)` — bên xác minh không thể
+> tính lại điều này chỉ từ byte element (sẽ cần child root hash). Vì vậy
+> prover cung cấp value_hash đã tính trước.
+>
+> **Tại sao dùng `KV` cho mục?** value_hash của mục đơn giản là `H(value)`,
+> bên xác minh có thể tính lại được. Dùng `KV` chống giả mạo: nếu prover
+> thay đổi giá trị, hash sẽ không khớp.
+
+**Cải tiến V1 — `KVValueHashFeatureTypeWithChildHash`:** Trong bằng chứng V1, khi
+cây không rỗng được truy vấn không có subquery (truy vấn dừng tại cây này — chính
+element cây là kết quả), tầng GroveDB nâng cấp nút merk thành
+`KVValueHashFeatureTypeWithChildHash(key, value, value_hash, feature_type,
+child_hash)`. Điều này cho phép bên xác minh kiểm tra `combine_hash(H(value), child_hash)
+== value_hash`, ngăn chặn kẻ tấn công hoán đổi byte element trong khi
+tái sử dụng value_hash gốc. Cây rỗng không được nâng cấp vì chúng không có
+merk con để cung cấp root hash.
+
+> **Ghi chú bảo mật về feature_type:** Đối với cây thông thường (không phải provable),
+> trường `feature_type` trong `KVValueHashFeatureType` và
+> `KVValueHashFeatureTypeWithChildHash` được decode nhưng **không được dùng** cho
+> tính toán hash hoặc trả về cho bên gọi. Kiểu cây chính thức nằm trong byte
+> Element đã xác minh hash. Trường này chỉ quan trọng với ProvableCountTree
+> (xem bên dưới), nơi nó mang count cần thiết cho `node_hash_with_count`.
+
+### ProvableCountTree và ProvableCountSumTree
+
+Các kiểu cây này sử dụng `node_hash_with_count(kv_hash, left, right, count)` thay
+vì `node_hash`. **count** được bao gồm trong hash, nên bên xác minh cần
+count cho mọi nút để tính lại Merkle root.
+
+| Vai trò | Kiểu Node V0 | Kiểu Node V1 | Hàm băm |
+|------|-------------|-------------|---------------|
+| Mục được truy vấn | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| Cây không rỗng được truy vấn (không có subquery) | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Cây rỗng được truy vấn | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| Tham chiếu được truy vấn | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| On-path | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Boundary | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Distant | `Hash` | `Hash` | Dùng trực tiếp |
+
+> **Cây không rỗng CÓ subquery** đi xuống tầng con, giống như cây
+> thông thường.
+
+> **Tại sao mọi nút đều mang count?** Vì sử dụng `node_hash_with_count` thay
+> vì `node_hash`. Không có count, bên xác minh không thể tái tạo bất kỳ hash
+> trung gian nào trên đường đến root — kể cả với nút không được truy vấn.
+
+**Cải tiến V1:** Giống cây thông thường — cây không rỗng được truy vấn không có
+subquery được nâng cấp thành `KVValueHashFeatureTypeWithChildHash` để
+xác minh `combine_hash`.
+
+> **Ghi chú ProvableCountSumTree:** Chỉ **count** được bao gồm trong hash.
+> sum được mang trong feature_type (`ProvableCountedSummedMerkNode(count,
+> sum)`) nhưng **không được hash**. Giống các kiểu cây thông thường ở trên,
+> giá trị sum chính thức nằm trong byte serialize của Element cha (ví dụ
+> `Element::ProvableCountSumTree(root_key, count, sum, flags)`), được
+> xác minh hash trong bằng chứng cây cha.
+
+### Tóm tắt: Ma trận kiểu Node -> Kiểu cây
+
+| Kiểu Node | Cây thông thường | ProvableCount Trees |
+|-----------|:------------:|:-------------------:|
+| `KV` | Mục được truy vấn | — |
+| `KVCount` | — | Mục được truy vấn |
+| `KVValueHash` | Cây con được truy vấn | — |
+| `KVValueHashFeatureType` | — | Cây con được truy vấn |
+| `KVRefValueHash` | Tham chiếu được truy vấn | — |
+| `KVRefValueHashCount` | — | Tham chiếu được truy vấn |
+| `KVHash` | On-path | — |
+| `KVHashCount` | — | On-path |
+| `KVDigest` | Boundary/absence | — |
+| `KVDigestCount` | — | Boundary/absence |
+| `Hash` | Anh em xa | Anh em xa |
+| `KVValueHashFeatureTypeWithChildHash` | — | Cây không rỗng không có subquery |
+
 ## Tạo bằng chứng đa tầng
 
 Vì GroveDB là cây chứa cây, bằng chứng trải rộng nhiều tầng. Mỗi tầng chứng minh phần liên quan của một cây Merk, và các tầng được kết nối bởi cơ chế combined value_hash:

--- a/docs/book/translations/zh/src/proof-system.md
+++ b/docs/book/translations/zh/src/proof-system.md
@@ -160,6 +160,125 @@ graph TD
 | 8 | Push(Hash(frank_node_hash)) | 压入 frank 哈希 |
 | 9 | Child | frank 成为 dave 的右子节点 |
 
+## 按树类型划分的证明节点类型
+
+GroveDB 中的每种树类型根据节点在证明中的**角色**使用一组特定的证明节点类型。
+共有四种角色：
+
+| 角色 | 描述 |
+|------|-------------|
+| **Queried** | 节点匹配查询 — 完整揭示 key + value |
+| **On-path** | 节点是被查询节点的祖先 — 仅需要 kv_hash |
+| **Boundary** | 与缺失键相邻 — 证明不存在性 |
+| **Distant** | 不在证明路径上的兄弟子树 — 仅需要 node_hash |
+
+### 常规树 (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+
+这五种树类型使用完全相同的证明节点类型和相同的哈希函数：
+`compute_hash` (= `node_hash(kv_hash, left, right)`)。在 merk 层面的证明方式
+**没有任何区别**。
+
+每个 merk 节点内部携带一个 `feature_type`（BasicMerkNode、
+SummedMerkNode、BigSummedMerkNode、CountedMerkNode、CountedSummedMerkNode），
+但这**不包含在哈希中**且**不包含在证明中**。这些树类型的聚合数据（sum、count）
+存在于**父** Element 的序列化字节中，通过父树的证明进行哈希验证：
+
+| 树类型 | Element 存储内容 | Merk feature_type（不参与哈希） |
+|-----------|---------------|-------------------------------|
+| Tree | `Element::Tree(root_key, flags)` | `BasicMerkNode` |
+| SumTree | `Element::SumTree(root_key, sum, flags)` | `SummedMerkNode(sum)` |
+| BigSumTree | `Element::BigSumTree(root_key, sum, flags)` | `BigSummedMerkNode(sum)` |
+| CountTree | `Element::CountTree(root_key, count, flags)` | `CountedMerkNode(count)` |
+| CountSumTree | `Element::CountSumTree(root_key, count, sum, flags)` | `CountedSummedMerkNode(count, sum)` |
+
+> **sum/count 从何而来？** 当验证者处理 `[root, my_sum_tree]` 的证明时，
+> 父树的证明包含键 `my_sum_tree` 的 `KVValueHash` 节点。`value` 字段包含
+> 序列化的 `Element::SumTree(root_key, 42, flags)`。由于此值经过哈希验证
+>（其哈希已承诺至父 Merkle root），sum 值 `42` 是可信的。merk 层级的
+> feature_type 无关紧要。
+
+| 角色 | V0 节点类型 | V1 节点类型 | 哈希函数 |
+|------|-------------|-------------|---------------|
+| 被查询的项 | `KV` | `KV` | `node_hash(kv_hash(key, H(value)), left, right)` |
+| 被查询的非空树（无 subquery） | `KVValueHash` | `KVValueHashFeatureTypeWithChildHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| 被查询的空树 | `KVValueHash` | `KVValueHash` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| 被查询的引用 | `KVRefValueHash` | `KVRefValueHash` | `node_hash(kv_hash(key, combine_hash(ref_hash, H(deref_value))), left, right)` |
+| On-path | `KVHash` | `KVHash` | `node_hash(kv_hash, left, right)` |
+| Boundary | `KVDigest` | `KVDigest` | `node_hash(kv_hash(key, value_hash), left, right)` |
+| Distant | `Hash` | `Hash` | 直接使用 |
+
+> **有 subquery 的非空树**会下降到子层 — 树节点在父层证明中显示为
+> `KVValueHash`，子层有自己的证明。
+
+> **为什么子树使用 `KVValueHash`？** 子树的 value_hash 是
+> `combine_hash(H(element_bytes), child_root_hash)` — 验证者无法仅从
+> element 字节重新计算（需要 child root hash）。因此证明者提供预先计算的
+> value_hash。
+>
+> **为什么项使用 `KV`？** 项的 value_hash 就是 `H(value)`，验证者可以重新
+> 计算。使用 `KV` 是防篡改的：如果证明者更改了值，哈希将不匹配。
+
+**V1 增强 — `KVValueHashFeatureTypeWithChildHash`：** 在 V1 证明中，当被查询的
+非空树没有 subquery（查询在此树停止 — 树元素本身就是结果）时，GroveDB 层将
+merk 节点升级为 `KVValueHashFeatureTypeWithChildHash(key, value, value_hash,
+feature_type, child_hash)`。这使验证者可以检查 `combine_hash(H(value),
+child_hash) == value_hash`，防止攻击者在重用原始 value_hash 的同时替换
+element 字节。空树不会被升级，因为没有子 merk 提供 root hash。
+
+> **关于 feature_type 的安全说明：** 对于常规（非 provable）树，
+> `KVValueHashFeatureType` 和 `KVValueHashFeatureTypeWithChildHash` 中的
+> `feature_type` 字段会被解码但**不用于**哈希计算或返回给调用者。规范的
+> 树类型存在于经过哈希验证的 Element 字节中。此字段仅对 ProvableCountTree
+>（见下文）有意义，其中它携带 `node_hash_with_count` 所需的 count。
+
+### ProvableCountTree 和 ProvableCountSumTree
+
+这些树类型使用 `node_hash_with_count(kv_hash, left, right, count)` 替代
+`node_hash`。**count** 包含在哈希中，因此验证者需要每个节点的 count 才能
+重新计算 Merkle root。
+
+| 角色 | V0 节点类型 | V1 节点类型 | 哈希函数 |
+|------|-------------|-------------|---------------|
+| 被查询的项 | `KVCount` | `KVCount` | `node_hash_with_count(kv_hash(key, H(value)), left, right, count)` |
+| 被查询的非空树（无 subquery） | `KVValueHashFeatureType` | `KVValueHashFeatureTypeWithChildHash` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| 被查询的空树 | `KVValueHashFeatureType` | `KVValueHashFeatureType` | `node_hash_with_count(kv_hash(key, value_hash), left, right, feature_type.count())` |
+| 被查询的引用 | `KVRefValueHashCount` | `KVRefValueHashCount` | `node_hash_with_count(kv_hash(key, combine_hash(...)), left, right, count)` |
+| On-path | `KVHashCount` | `KVHashCount` | `node_hash_with_count(kv_hash, left, right, count)` |
+| Boundary | `KVDigestCount` | `KVDigestCount` | `node_hash_with_count(kv_hash(key, value_hash), left, right, count)` |
+| Distant | `Hash` | `Hash` | 直接使用 |
+
+> **有 subquery 的非空树**会下降到子层，与常规树相同。
+
+> **为什么每个节点都携带 count？** 因为使用了 `node_hash_with_count` 替代
+> `node_hash`。没有 count，验证者无法重构到 root 路径上的任何中间哈希
+> — 即使对于未查询的节点也是如此。
+
+**V1 增强：** 与常规树相同 — 被查询的无 subquery 非空树会被升级为
+`KVValueHashFeatureTypeWithChildHash` 以进行 `combine_hash` 验证。
+
+> **ProvableCountSumTree 说明：** 只有 **count** 包含在哈希中。sum 携带在
+> feature_type 中（`ProvableCountedSummedMerkNode(count, sum)`）但**不参与哈希**。
+> 与上述常规树类型一样，规范的 sum 值存在于父 Element 的序列化字节中
+>（如 `Element::ProvableCountSumTree(root_key, count, sum, flags)`），
+> 在父树的证明中经过哈希验证。
+
+### 总结：节点类型 -> 树类型矩阵
+
+| 节点类型 | 常规树 | ProvableCount 树 |
+|-----------|:------------:|:-------------------:|
+| `KV` | 被查询的项 | — |
+| `KVCount` | — | 被查询的项 |
+| `KVValueHash` | 被查询的子树 | — |
+| `KVValueHashFeatureType` | — | 被查询的子树 |
+| `KVRefValueHash` | 被查询的引用 | — |
+| `KVRefValueHashCount` | — | 被查询的引用 |
+| `KVHash` | On-path | — |
+| `KVHashCount` | — | On-path |
+| `KVDigest` | Boundary/absence | — |
+| `KVDigestCount` | — | Boundary/absence |
+| `Hash` | 远端兄弟 | 远端兄弟 |
+| `KVValueHashFeatureTypeWithChildHash` | — | 无 subquery 的非空树 |
+
 ## 多层证明生成
 
 由于 GroveDB 是树的树，证明跨越多个层。每一层证明一棵 Merk 树的相关部分，各层通过组合 value_hash 机制连接：

--- a/grovedb-element/src/element_type.rs
+++ b/grovedb-element/src/element_type.rs
@@ -145,22 +145,27 @@ impl ElementType {
     ///
     /// All use `node_hash(kv_hash, left, right)` — feature_type is NOT hashed.
     ///
-    /// | Role          | Node type       |
-    /// |---------------|-----------------|
-    /// | Queried item  | `Kv`            |
-    /// | Queried tree  | `KvValueHash`   |
-    /// | Queried ref   | `KvRefValueHash`|
+    /// | Role                               | Node type (V0)  | Node type (V1)                       |
+    /// |------------------------------------|-----------------|--------------------------------------|
+    /// | Queried item                       | `Kv`            | `Kv`                                 |
+    /// | Queried non-empty tree (no subqry) | `KvValueHash`   | `KvValueHashFeatureTypeWithChildHash`|
+    /// | Queried empty tree                 | `KvValueHash`   | `KvValueHash`                        |
+    /// | Queried ref                        | `KvRefValueHash`| `KvRefValueHash`                     |
+    ///
+    /// Note: non-empty trees WITH a subquery descend into the child layer;
+    /// the tree node appears as `KvValueHash` in the parent layer proof.
     ///
     /// ## ProvableCountTree / ProvableCountSumTree
     ///
     /// Use `node_hash_with_count(kv_hash, left, right, count)` — the count
     /// IS included in the hash, so every proof node must carry it.
     ///
-    /// | Role          | Node type                |
-    /// |---------------|--------------------------|
-    /// | Queried item  | `KvCount`                |
-    /// | Queried tree  | `KvValueHashFeatureType` |
-    /// | Queried ref   | `KvRefValueHashCount`    |
+    /// | Role                               | Node type (V0)           | Node type (V1)                       |
+    /// |------------------------------------|--------------------------|--------------------------------------|
+    /// | Queried item                       | `KvCount`                | `KvCount`                            |
+    /// | Queried non-empty tree (no subqry) | `KvValueHashFeatureType` | `KvValueHashFeatureTypeWithChildHash`|
+    /// | Queried empty tree                 | `KvValueHashFeatureType` | `KvValueHashFeatureType`             |
+    /// | Queried ref                        | `KvRefValueHashCount`    | `KvRefValueHashCount`                |
     ///
     /// Non-queried and boundary nodes are handled separately in the merk
     /// proof generation code (`KVHash`/`KVHashCount`, `KVDigest`/`KVDigestCount`).

--- a/grovedb-element/src/element_type.rs
+++ b/grovedb-element/src/element_type.rs
@@ -141,12 +141,31 @@ impl ElementType {
     /// Returns the type of proof node that should be used for this element
     /// type, given the parent tree type.
     ///
-    /// The parent tree type affects which proof node to use:
-    /// - In regular trees: Items use `Kv`, trees/references use `KvValueHash`
-    /// - In ProvableCountTree or ProvableCountSumTree:
-    ///   - Items use `KvCount` (value hash + count in node hash)
-    ///   - Subtrees use `KvValueHashFeatureType` (combined hash + count)
-    ///   - References use `KvRefValueHashCount` (combined hash + count)
+    /// ## Regular trees (Tree, SumTree, BigSumTree, CountTree, CountSumTree)
+    ///
+    /// All use `node_hash(kv_hash, left, right)` — feature_type is NOT hashed.
+    ///
+    /// | Role          | Node type       |
+    /// |---------------|-----------------|
+    /// | Queried item  | `Kv`            |
+    /// | Queried tree  | `KvValueHash`   |
+    /// | Queried ref   | `KvRefValueHash`|
+    ///
+    /// ## ProvableCountTree / ProvableCountSumTree
+    ///
+    /// Use `node_hash_with_count(kv_hash, left, right, count)` — the count
+    /// IS included in the hash, so every proof node must carry it.
+    ///
+    /// | Role          | Node type                |
+    /// |---------------|--------------------------|
+    /// | Queried item  | `KvCount`                |
+    /// | Queried tree  | `KvValueHashFeatureType` |
+    /// | Queried ref   | `KvRefValueHashCount`    |
+    ///
+    /// Non-queried and boundary nodes are handled separately in the merk
+    /// proof generation code (`KVHash`/`KVHashCount`, `KVDigest`/`KVDigestCount`).
+    ///
+    /// See also: docs/book/src/proof-system.md "Proof Node Types by Tree Type"
     ///
     /// # Arguments
     /// * `parent_tree_type` - The type of tree containing this element, or


### PR DESCRIPTION
## Summary

Adds comprehensive documentation explaining which proof node types are used for each tree type and why.

### Book (`docs/book/src/proof-system.md`)

New section "Proof Node Types by Tree Type" covering:

- **Four node roles**: queried, on-path, boundary, distant
- **Regular trees** (Tree, SumTree, etc.): `KV`, `KVValueHash`, `KVHash`, `KVDigest`, `Hash` — all use `node_hash()`, feature_type not hashed
- **ProvableCountTree/ProvableCountSumTree**: `KVCount`, `KVValueHashFeatureType`, `KVHashCount`, `KVDigestCount`, `Hash` — all use `node_hash_with_count()`, count included in hash
- **V1 `KVValueHashFeatureTypeWithChildHash`** enhancement for combine_hash verification
- **Security notes** on feature_type: unused for regular trees (canonical type lives in hash-verified Element bytes), required for provable count trees (count drives hash function selection)
- **Summary matrix** mapping all 12 node types to tree types

### Code (`grovedb-element/src/element_type.rs`)

Expanded doc comment on `ElementType::proof_node_type()` with tables matching the book.

## Test plan

- [x] `cargo build` passes
- [x] `mdbook build` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced proof system documentation with detailed explanations of node types, their roles across different tree variants, data storage mechanisms, and hashing strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->