### PR TITLE
fix: restrict self-hosted macOS CI to internal PRs only

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -66,7 +66,10 @@ jobs:
   test-mac:
     name: Test (macOS)
     needs: detect-changes
-    if: needs.detect-changes.outputs.needs-tests == 'true'
+    if: >-
+      needs.detect-changes.outputs.needs-tests == 'true'
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Gates the `test-mac` self-hosted runner job so it only runs for pushes, `workflow_dispatch`, or PRs **from the same repository**
- Fork PRs are excluded — they fall through to the sandboxed Ubuntu fallback runners
- Fixes a CI supply-chain risk where hostile fork PRs could execute arbitrary code on the self-hosted macOS runner

## Details

The condition `github.event.pull_request.head.repo.full_name == github.repository` ensures only PRs from internal branches (not forks) trigger the self-hosted runner. This is the standard GitHub-recommended pattern for protecting self-hosted runners.

## Test plan
- [ ] Internal PR: `test-mac` job should still run normally
- [ ] Fork PR (simulated): `test-mac` job should be skipped, `test-ubuntu` fallback should run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to optimize macOS testing execution for pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->