### PR TITLE
fix: remove ProveOptions from V1 proofs

### DIFF
--- a/grovedb/src/debugger.rs
+++ b/grovedb/src/debugger.rs
@@ -370,7 +370,8 @@ fn proof_to_grovedbg(proof: GroveDBProof) -> Result<grovedbg_types::Proof, crate
         }),
         GroveDBProof::V1(p) => Ok(grovedbg_types::Proof {
             root_layer: v1_proof_layer_to_grovedbg(p.root_layer)?,
-            prove_options: prove_options_to_grovedbg(p.prove_options),
+            // V1 proofs no longer embed ProveOptions; use default for debugger
+            prove_options: prove_options_to_grovedbg(ProveOptions::default()),
         }),
     }
 }

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -853,11 +853,7 @@ impl GroveDb {
             )
         );
 
-        Ok(GroveDBProof::V1(GroveDBProofV1 {
-            root_layer,
-            prove_options,
-        }))
-        .wrap_with_cost(cost)
+        Ok(GroveDBProof::V1(GroveDBProofV1 { root_layer })).wrap_with_cost(cost)
     }
 
     /// V1 version of prove_subqueries that returns `LayerProof` and handles

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -41,18 +41,19 @@ use crate::{
 
 /// Options controlling proof generation behavior.
 ///
-/// # Security note
+/// # Security note (V0 proofs only)
 ///
-/// `ProveOptions` is serialized as part of the proof via `bincode::Encode` /
-/// `bincode::Decode`. During verification the verifier deserializes these
-/// options from the proof bytes, which means **the values come from the
-/// (potentially untrusted) prover**. A malicious prover could craft a proof
-/// with `decrease_limit_on_empty_sub_query_result` set to `true` even when
-/// the original query used `false`, causing the verifier to consume its
-/// result limit faster and therefore return fewer results than actually
-/// exist. Verifiers that need to guard against this should compare the
-/// deserialized options against the expected values for the query being
-/// verified.
+/// In [`GroveDBProofV0`], `ProveOptions` is serialized as part of the proof
+/// via `bincode::Encode` / `bincode::Decode`. During verification the
+/// verifier deserializes these options from the proof bytes, which means
+/// **the values come from the (potentially untrusted) prover**. A malicious
+/// prover could craft a proof with `decrease_limit_on_empty_sub_query_result`
+/// set to `true` even when the original query used `false`, causing the
+/// verifier to consume its result limit faster and therefore return fewer
+/// results than actually exist.
+///
+/// [`GroveDBProofV1`] does **not** embed `ProveOptions`. The verifier uses
+/// [`ProveOptions::default()`] instead, closing this attack vector.
 #[derive(Debug, Clone, Copy, Encode, Decode)]
 pub struct ProveOptions {
     /// This tells the proof system to decrease the available limit of the query
@@ -68,16 +69,12 @@ pub struct ProveOptions {
     /// system as the proof system goes through millions of subtrees and
     /// eventually runs out of memory.
     ///
-    /// # Security note
+    /// # Security note (V0 proofs only)
     ///
-    /// This field is embedded in the serialized proof and deserialized by the
-    /// verifier. Because it originates from the prover, it must be treated as
-    /// **untrusted input**. A malicious prover can set this to `true`
-    /// regardless of the original query intent, which causes the verifier to
-    /// count empty subtrees against the query limit and thereby return fewer
-    /// results than it should. Applications that need to defend against
-    /// result-truncation attacks should validate this value after
-    /// deserialization.
+    /// In V0 proofs this field is embedded in the serialized proof and
+    /// deserialized by the verifier. Because it originates from the prover, it
+    /// must be treated as **untrusted input**. V1 proofs do not embed this
+    /// field; the verifier uses [`ProveOptions::default()`] instead.
     pub decrease_limit_on_empty_sub_query_result: bool,
 }
 
@@ -410,12 +407,15 @@ pub struct GroveDBProofV0 {
 }
 
 /// Current (v1) GroveDB proof supporting multiple tree backing store types.
+///
+/// Unlike [`GroveDBProofV0`], V1 proofs do **not** embed [`ProveOptions`].
+/// The verifier uses [`ProveOptions::default()`] instead of trusting
+/// prover-supplied options, which closes the result-truncation attack
+/// vector described in the [`ProveOptions`] security note.
 #[derive(Encode, Decode)]
 pub struct GroveDBProofV1 {
     /// The root layer proof for the top-level tree.
     pub root_layer: LayerProof,
-    /// Options that were used when generating this proof.
-    pub prove_options: ProveOptions,
 }
 
 impl fmt::Display for MerkOnlyLayerProof {

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -327,12 +327,18 @@ impl GroveDb {
         ),
         Error,
     > {
+        // V1 proofs do not embed ProveOptions — the verifier uses the default,
+        // which closes the result-truncation attack where a malicious prover
+        // could set decrease_limit_on_empty_sub_query_result to manipulate
+        // how many results the verifier returns.
+        let prove_options = ProveOptions::default();
+
         let mut result = Vec::new();
         let mut limit = query.query.limit;
         let mut last_tree_feature_type = None;
         let root_hash = Self::verify_layer_proof_v1(
             &proof.root_layer,
-            &proof.prove_options,
+            &prove_options,
             query,
             &mut limit,
             &[],
@@ -373,12 +379,14 @@ impl GroveDb {
         options: VerifyOptions,
         grove_version: &GroveVersion,
     ) -> Result<(CryptoHash, Option<TreeFeatureType>, ProvedPathKeyValues), Error> {
+        let prove_options = ProveOptions::default();
+
         let mut result = Vec::new();
         let mut limit = query.query.limit;
         let mut last_tree_feature_type = None;
         let root_hash = Self::verify_layer_proof_v1(
             &proof.root_layer,
-            &proof.prove_options,
+            &prove_options,
             query,
             &mut limit,
             &[],

--- a/grovedb/src/tests/proof_depth_limit_tests.rs
+++ b/grovedb/src/tests/proof_depth_limit_tests.rs
@@ -392,10 +392,7 @@ mod tests {
                 lower_layers,
             };
         }
-        let proof = crate::operations::proof::GroveDBProofV1 {
-            root_layer: layer,
-            prove_options: ProveOptions::default(),
-        };
+        let proof = crate::operations::proof::GroveDBProofV1 { root_layer: layer };
         let full_proof = crate::operations::proof::GroveDBProof::V1(proof);
         let config = bincode::config::standard().with_big_endian();
         bincode::encode_to_vec(&full_proof, config).expect("encoding should succeed")
@@ -529,10 +526,7 @@ mod tests {
             merk_proof: ProofBytes::Merk(vec![]),
             lower_layers,
         };
-        let proof = crate::operations::proof::GroveDBProofV1 {
-            root_layer,
-            prove_options: ProveOptions::default(),
-        };
+        let proof = crate::operations::proof::GroveDBProofV1 { root_layer };
         let full_proof = crate::operations::proof::GroveDBProof::V1(proof);
         let config = bincode::config::standard().with_big_endian();
         bincode::encode_to_vec(&full_proof, config).expect("encoding should succeed")


### PR DESCRIPTION
## Summary

- Removes `prove_options` field from `GroveDBProofV1` struct — V1 proofs no longer embed prover-controlled options
- V1 verification now uses `ProveOptions::default()` instead of deserializing options from the untrusted proof
- V0 proofs are unchanged (backwards compatible)
- Updates debugger, depth-limit tests, and doc comments

## Background

`ProveOptions` (specifically `decrease_limit_on_empty_sub_query_result`) was embedded in the serialized proof and trusted by the verifier. A malicious prover could set this flag to `true` to make empty subquery results consume the query limit, causing the verifier to return fewer results than actually exist. Both honest and malicious proofs verified correctly — the verifier couldn't distinguish them.

Since all Platform queries use `decrease_limit_on_empty_sub_query_result = true` (the default), removing it from V1 proofs has no practical impact while closing the attack vector.

## Test plan

- [x] All 22 proof depth limit tests pass
- [x] All 133 proof coverage tests pass
- [x] All 5 trunk proof tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build --no-default-features --features verify` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified V1 proof structure by removing embedded configuration options.
  * V1 proof verification now uses standardized default configuration settings instead of proof-embedded options.
  * Updated documentation to clarify V1 proof behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->