### PR TITLE
fix: include known_versions in GroveVersionError messages

### DIFF
--- a/grovedb-version/src/error.rs
+++ b/grovedb-version/src/error.rs
@@ -4,7 +4,9 @@ use versioned_feature_core::FeatureVersion;
 #[derive(Error, Debug)]
 pub enum GroveVersionError {
     /// Expected some specific versions
-    #[error("grove unknown version on {method}, received: {received}")]
+    #[error(
+        "grove unknown version on {method}, received: {received}, expected one of: {known_versions:?}"
+    )]
     UnknownVersionMismatch {
         /// method
         method: String,
@@ -15,7 +17,9 @@ pub enum GroveVersionError {
     },
 
     /// Expected some specific versions
-    #[error("{method} not active for grove version")]
+    #[error(
+        "{method} not active for grove version, expected one of: {known_versions:?}"
+    )]
     VersionNotActive {
         /// method
         method: String,


### PR DESCRIPTION
Include known_versions in error messages to improve debugging clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced version mismatch error messages to display the set of allowed versions, providing clearer guidance when version conflicts are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->