### PR TITLE
feat: add Element::NonCounted wrapper to opt-out of count propagation

### DIFF
--- a/grovedb-commitment-tree/Cargo.toml
+++ b/grovedb-commitment-tree/Cargo.toml
@@ -17,7 +17,7 @@ client = ["shardtree"]
 sqlite = ["client", "rusqlite"]
 
 [dependencies]
-orchard = { git = "https://github.com/dashpay/orchard.git", rev = "41c8f7169f2683c99cf0e0c63e8d25ec12c47a79", features = ["circuit"] }
+orchard = { git = "https://github.com/dashpay/orchard.git", rev = "898258d76aab2822249492aede59a02d49278fff", features = ["circuit"] }
 incrementalmerkletree = "0.8"
 shardtree = { version = "0.6", optional = true }
 rusqlite = { version = "0.38", features = ["bundled"], optional = true }

--- a/grovedb-element/src/element/constructor.rs
+++ b/grovedb-element/src/element/constructor.rs
@@ -383,4 +383,28 @@ impl Element {
     pub fn new_dense_tree(count: u16, height: u8, flags: Option<ElementFlags>) -> Self {
         Element::DenseAppendOnlyFixedSizeTree(count, height, flags)
     }
+
+    /// Wrap an element in `NonCounted` so it contributes 0 to its parent count
+    /// tree's aggregate count when inserted. Sums (if any) still propagate.
+    ///
+    /// Returns `InvalidInput` if `inner` is itself a `NonCounted`. Wrapping
+    /// is not idempotent at the type level — use `into_non_counted` to wrap
+    /// without that risk.
+    pub fn new_non_counted(inner: Element) -> Result<Self, ElementError> {
+        if matches!(inner, Element::NonCounted(_)) {
+            return Err(ElementError::InvalidInput(
+                "NonCounted cannot wrap another NonCounted",
+            ));
+        }
+        Ok(Element::NonCounted(Box::new(inner)))
+    }
+
+    /// Wrap `self` in `NonCounted`. If `self` is already `NonCounted`, returns
+    /// `self` unchanged (idempotent).
+    pub fn into_non_counted(self) -> Self {
+        match self {
+            Element::NonCounted(_) => self,
+            other => Element::NonCounted(Box::new(other)),
+        }
+    }
 }

--- a/grovedb-element/src/element/helpers.rs
+++ b/grovedb-element/src/element/helpers.rs
@@ -11,10 +11,48 @@ use crate::{
 };
 
 impl Element {
+    /// Returns `true` if this element is wrapped in `Element::NonCounted`.
+    /// The wrapper suppresses count propagation to the parent count tree but
+    /// leaves all other behavior (storage, hashing, sum propagation, internal
+    /// aggregation) unchanged.
+    pub fn is_non_counted(&self) -> bool {
+        matches!(self, Element::NonCounted(_))
+    }
+
+    /// Returns the wrapped element if `self` is `NonCounted`, else `self`.
+    /// Use this when you need to inspect the actual element type and don't
+    /// care whether it is wrapped.
+    pub fn underlying(&self) -> &Element {
+        match self {
+            Element::NonCounted(inner) => inner,
+            other => other,
+        }
+    }
+
+    /// Mutable variant of [`underlying`].
+    pub fn underlying_mut(&mut self) -> &mut Element {
+        match self {
+            Element::NonCounted(inner) => inner,
+            other => other,
+        }
+    }
+
+    /// Owned variant of [`underlying`].
+    pub fn into_underlying(self) -> Element {
+        match self {
+            Element::NonCounted(inner) => *inner,
+            other => other,
+        }
+    }
+
     /// Decoded the integer value in the SumItem element type, returns 0 for
-    /// everything else
+    /// everything else.
+    ///
+    /// `NonCounted` delegates to its inner element — sums still propagate
+    /// when the wrapper is inserted into a sum-bearing parent.
     pub fn sum_value_or_default(&self) -> i64 {
         match self {
+            Element::NonCounted(inner) => inner.sum_value_or_default(),
             Element::SumItem(sum_value, _)
             | Element::ItemWithSumItem(_, sum_value, _)
             | Element::SumTree(_, sum_value, _)
@@ -25,9 +63,13 @@ impl Element {
     }
 
     /// Decoded the integer value in the CountTree element type, returns 1 for
-    /// everything else
+    /// everything else.
+    ///
+    /// `NonCounted` returns 0 — the wrapper's whole purpose is to contribute
+    /// nothing to the parent count tree.
     pub fn count_value_or_default(&self) -> u64 {
         match self {
+            Element::NonCounted(_) => 0,
             Element::CountTree(_, count_value, _)
             | Element::CountSumTree(_, count_value, ..)
             | Element::ProvableCountTree(_, count_value, _)
@@ -37,9 +79,13 @@ impl Element {
     }
 
     /// Decoded the count and sum values from the element type, returns (1, 0)
-    /// for elements without count/sum semantics
+    /// for elements without count/sum semantics.
+    ///
+    /// `NonCounted` returns `(0, inner_sum)` — count is suppressed, sum still
+    /// propagates.
     pub fn count_sum_value_or_default(&self) -> (u64, i64) {
         match self {
+            Element::NonCounted(inner) => (0, inner.sum_value_or_default()),
             Element::SumItem(sum_value, _)
             | Element::ItemWithSumItem(_, sum_value, _)
             | Element::SumTree(_, sum_value, _) => (1, *sum_value),
@@ -54,9 +100,10 @@ impl Element {
     }
 
     /// Decoded the integer value in the SumItem element type, returns 0 for
-    /// everything else
+    /// everything else. `NonCounted` delegates to its inner.
     pub fn big_sum_value_or_default(&self) -> i128 {
         match self {
+            Element::NonCounted(inner) => inner.big_sum_value_or_default(),
             Element::SumItem(sum_value, _)
             | Element::ItemWithSumItem(_, sum_value, _)
             | Element::SumTree(_, sum_value, _)
@@ -67,85 +114,93 @@ impl Element {
         }
     }
 
-    /// Decoded the integer value in the SumItem element type
+    /// Decoded the integer value in the SumItem element type. Looks through
+    /// a `NonCounted` wrapper.
     pub fn as_sum_item_value(&self) -> Result<i64, ElementError> {
-        match self {
+        match self.underlying() {
             Element::SumItem(value, _) => Ok(*value),
             Element::ItemWithSumItem(_, value, _) => Ok(*value),
             _ => Err(ElementError::WrongElementType("expected a sum item")),
         }
     }
 
-    /// Decoded the integer value in the SumItem element type
+    /// Decoded the integer value in the SumItem element type. Looks through
+    /// a `NonCounted` wrapper.
     pub fn into_sum_item_value(self) -> Result<i64, ElementError> {
-        match self {
+        match self.into_underlying() {
             Element::SumItem(value, _) => Ok(value),
             Element::ItemWithSumItem(_, value, _) => Ok(value),
             _ => Err(ElementError::WrongElementType("expected a sum item")),
         }
     }
 
-    /// Decoded the integer value in the SumTree element type
+    /// Decoded the integer value in the SumTree element type. Looks through
+    /// a `NonCounted` wrapper.
     pub fn as_sum_tree_value(&self) -> Result<i64, ElementError> {
-        match self {
+        match self.underlying() {
             Element::SumTree(_, value, _) => Ok(*value),
             _ => Err(ElementError::WrongElementType("expected a sum tree")),
         }
     }
 
-    /// Decoded the integer value in the SumTree element type
+    /// Decoded the integer value in the SumTree element type. Looks through
+    /// a `NonCounted` wrapper.
     pub fn into_sum_tree_value(self) -> Result<i64, ElementError> {
-        match self {
+        match self.into_underlying() {
             Element::SumTree(_, value, _) => Ok(value),
             _ => Err(ElementError::WrongElementType("expected a sum tree")),
         }
     }
 
-    /// Gives the item value in the Item element type
+    /// Gives the item value in the Item element type. Looks through a
+    /// `NonCounted` wrapper.
     pub fn as_item_bytes(&self) -> Result<&[u8], ElementError> {
-        match self {
+        match self.underlying() {
             Element::Item(value, _) => Ok(value),
             Element::ItemWithSumItem(value, ..) => Ok(value),
             _ => Err(ElementError::WrongElementType("expected an item")),
         }
     }
 
-    /// Gives the item value in the Item element type
+    /// Gives the item value in the Item element type. Looks through a
+    /// `NonCounted` wrapper.
     pub fn into_item_bytes(self) -> Result<Vec<u8>, ElementError> {
-        match self {
+        match self.into_underlying() {
             Element::Item(value, _) => Ok(value),
             Element::ItemWithSumItem(value, ..) => Ok(value),
             _ => Err(ElementError::WrongElementType("expected an item")),
         }
     }
 
-    /// Gives the reference path type in the Reference element type
+    /// Gives the reference path type in the Reference element type. Looks
+    /// through a `NonCounted` wrapper.
     pub fn into_reference_path_type(self) -> Result<ReferencePathType, ElementError> {
-        match self {
+        match self.into_underlying() {
             Element::Reference(value, ..) => Ok(value),
             _ => Err(ElementError::WrongElementType("expected a reference")),
         }
     }
 
-    /// Check if the element is a sum tree
+    /// Check if the element is a sum tree. Looks through `NonCounted`.
     pub fn is_sum_tree(&self) -> bool {
-        matches!(self, Element::SumTree(..))
+        matches!(self.underlying(), Element::SumTree(..))
     }
 
-    /// Check if the element is a big sum tree
+    /// Check if the element is a big sum tree. Looks through `NonCounted`.
     pub fn is_big_sum_tree(&self) -> bool {
-        matches!(self, Element::BigSumTree(..))
+        matches!(self.underlying(), Element::BigSumTree(..))
     }
 
-    /// Check if the element is a tree but not a sum tree
+    /// Check if the element is a tree but not a sum tree. Looks through
+    /// `NonCounted`.
     pub fn is_basic_tree(&self) -> bool {
-        matches!(self, Element::Tree(..))
+        matches!(self.underlying(), Element::Tree(..))
     }
 
-    /// Check if the element is a tree
+    /// Check if the element is a tree. Looks through `NonCounted`.
     pub fn is_any_tree(&self) -> bool {
         matches!(
-            self,
+            self.underlying(),
             Element::SumTree(..)
                 | Element::Tree(..)
                 | Element::BigSumTree(..)
@@ -160,24 +215,25 @@ impl Element {
         )
     }
 
-    /// Check if the element is a commitment tree
+    /// Check if the element is a commitment tree. Looks through `NonCounted`.
     pub fn is_commitment_tree(&self) -> bool {
-        matches!(self, Element::CommitmentTree(..))
+        matches!(self.underlying(), Element::CommitmentTree(..))
     }
 
-    /// Check if the element is an MMR tree
+    /// Check if the element is an MMR tree. Looks through `NonCounted`.
     pub fn is_mmr_tree(&self) -> bool {
-        matches!(self, Element::MmrTree(..))
+        matches!(self.underlying(), Element::MmrTree(..))
     }
 
-    /// Check if the element is a bulk append tree
+    /// Check if the element is a bulk append tree. Looks through `NonCounted`.
     pub fn is_bulk_append_tree(&self) -> bool {
-        matches!(self, Element::BulkAppendTree(..))
+        matches!(self.underlying(), Element::BulkAppendTree(..))
     }
 
-    /// Check if the element is a dense append-only fixed-size tree
+    /// Check if the element is a dense append-only fixed-size tree. Looks
+    /// through `NonCounted`.
     pub fn is_dense_tree(&self) -> bool {
-        matches!(self, Element::DenseAppendOnlyFixedSizeTree(..))
+        matches!(self.underlying(), Element::DenseAppendOnlyFixedSizeTree(..))
     }
 
     /// Check if the element is a tree type that stores data in the data
@@ -188,9 +244,10 @@ impl Element {
     ///
     /// Note: This must be kept in sync with
     /// `TreeType::uses_non_merk_data_storage()` in the merk crate.
+    /// Looks through `NonCounted`.
     pub fn uses_non_merk_data_storage(&self) -> bool {
         matches!(
-            self,
+            self.underlying(),
             Element::CommitmentTree(..)
                 | Element::MmrTree(..)
                 | Element::BulkAppendTree(..)
@@ -201,9 +258,9 @@ impl Element {
     /// Returns the entry count for non-Merk data tree types, or `None` for
     /// regular Merk trees and non-tree elements.  This is used by delete
     /// and is_empty_tree operations to determine emptiness without
-    /// iterating the data namespace.
+    /// iterating the data namespace. Looks through `NonCounted`.
     pub fn non_merk_entry_count(&self) -> Option<u64> {
-        match self {
+        match self.underlying() {
             Element::CommitmentTree(count, ..) => Some(*count),
             Element::MmrTree(mmr_size, _) => Some(*mmr_size),
             Element::BulkAppendTree(count, ..) => Some(*count),
@@ -218,9 +275,10 @@ impl Element {
     /// node). Non-merk tree types (MmrTree, BulkAppendTree, CommitmentTree,
     /// DenseAppendOnlyFixedSizeTree) always carry their own data and are
     /// considered non-empty regardless of their count field.
+    /// Looks through `NonCounted`.
     pub fn is_non_empty_tree(&self) -> bool {
         matches!(
-            self,
+            self.underlying(),
             Element::Tree(Some(_), _)
                 | Element::SumTree(Some(_), ..)
                 | Element::BigSumTree(Some(_), ..)
@@ -241,9 +299,10 @@ impl Element {
     /// CountTree, CountSumTree, ProvableCountTree, ProvableCountSumTree)
     /// with a `Some(_)` root key. Excludes non-Merk tree types (MmrTree,
     /// BulkAppendTree, CommitmentTree, DenseAppendOnlyFixedSizeTree).
+    /// Looks through `NonCounted`.
     pub fn is_non_empty_merk_tree(&self) -> bool {
         matches!(
-            self,
+            self.underlying(),
             Element::Tree(Some(_), _)
                 | Element::SumTree(Some(_), ..)
                 | Element::BigSumTree(Some(_), ..)
@@ -254,40 +313,49 @@ impl Element {
         )
     }
 
-    /// Check if the element is a reference
+    /// Check if the element is a reference. Looks through `NonCounted`.
     pub fn is_reference(&self) -> bool {
-        matches!(self, Element::Reference(..))
+        matches!(self.underlying(), Element::Reference(..))
     }
 
-    /// Check if the element is an item
+    /// Check if the element is an item. Looks through `NonCounted`.
     pub fn is_any_item(&self) -> bool {
         matches!(
-            self,
+            self.underlying(),
             Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..)
         )
     }
 
-    /// Check if the element is an item
+    /// Check if the element is a basic item. Looks through `NonCounted`.
     pub fn is_basic_item(&self) -> bool {
-        matches!(self, Element::Item(..))
+        matches!(self.underlying(), Element::Item(..))
     }
 
-    /// Check if the element is an item
+    /// Check if the element has a basic item value (Item or ItemWithSumItem).
+    /// Looks through `NonCounted`.
     pub fn has_basic_item(&self) -> bool {
-        matches!(self, Element::Item(..) | Element::ItemWithSumItem(..))
+        matches!(
+            self.underlying(),
+            Element::Item(..) | Element::ItemWithSumItem(..)
+        )
     }
 
-    /// Check if the element is a sum item
+    /// Check if the element is a sum item. Looks through `NonCounted`.
     pub fn is_sum_item(&self) -> bool {
-        matches!(self, Element::SumItem(..) | Element::ItemWithSumItem(..))
+        matches!(
+            self.underlying(),
+            Element::SumItem(..) | Element::ItemWithSumItem(..)
+        )
     }
 
-    /// Check if the element is a sum item
+    /// Check if the element is an item-with-sum-item. Looks through
+    /// `NonCounted`.
     pub fn is_item_with_sum_item(&self) -> bool {
-        matches!(self, Element::ItemWithSumItem(..))
+        matches!(self.underlying(), Element::ItemWithSumItem(..))
     }
 
-    /// Grab the optional flag stored in an element
+    /// Grab the optional flag stored in an element. For `NonCounted`, returns
+    /// the inner element's flags.
     pub fn get_flags(&self) -> &Option<ElementFlags> {
         match self {
             Element::Tree(_, flags)
@@ -305,10 +373,12 @@ impl Element {
             | Element::MmrTree(.., flags)
             | Element::BulkAppendTree(.., flags)
             | Element::DenseAppendOnlyFixedSizeTree(.., flags) => flags,
+            Element::NonCounted(inner) => inner.get_flags(),
         }
     }
 
-    /// Grab the optional flag stored in an element
+    /// Grab the optional flag stored in an element. For `NonCounted`, returns
+    /// the inner element's flags.
     pub fn get_flags_owned(self) -> Option<ElementFlags> {
         match self {
             Element::Tree(_, flags)
@@ -326,10 +396,12 @@ impl Element {
             | Element::MmrTree(.., flags)
             | Element::BulkAppendTree(.., flags)
             | Element::DenseAppendOnlyFixedSizeTree(.., flags) => flags,
+            Element::NonCounted(inner) => inner.get_flags_owned(),
         }
     }
 
-    /// Grab the optional flag stored in an element as mutable
+    /// Grab the optional flag stored in an element as mutable. For
+    /// `NonCounted`, returns a mutable reference to the inner element's flags.
     pub fn get_flags_mut(&mut self) -> &mut Option<ElementFlags> {
         match self {
             Element::Tree(_, flags)
@@ -347,10 +419,12 @@ impl Element {
             | Element::MmrTree(.., flags)
             | Element::BulkAppendTree(.., flags)
             | Element::DenseAppendOnlyFixedSizeTree(.., flags) => flags,
+            Element::NonCounted(inner) => inner.get_flags_mut(),
         }
     }
 
-    /// Sets the optional flag stored in an element
+    /// Sets the optional flag stored in an element. For `NonCounted`, sets
+    /// the inner element's flags.
     pub fn set_flags(&mut self, new_flags: Option<ElementFlags>) {
         match self {
             Element::Tree(_, flags)
@@ -368,6 +442,7 @@ impl Element {
             | Element::MmrTree(.., flags)
             | Element::BulkAppendTree(.., flags)
             | Element::DenseAppendOnlyFixedSizeTree(.., flags) => *flags = new_flags,
+            Element::NonCounted(inner) => inner.set_flags(new_flags),
         }
     }
 
@@ -384,7 +459,8 @@ impl Element {
         Ok(len + len.required_space() as u32 + flag_len + flag_len.required_space() as u32 + 1)
     }
 
-    /// Convert the reference to an absolute reference
+    /// Convert the reference to an absolute reference. Looks through a
+    /// `NonCounted` wrapper, converting the inner reference and re-wrapping.
     pub fn convert_if_reference_to_absolute_reference(
         self,
         path: &[&[u8]],
@@ -394,23 +470,142 @@ impl Element {
         // we do this here because references are aggregated first then followed later
         // to follow non-absolute references, we need the path they are stored at
         // this information is lost during the aggregation phase.
-        Ok(match &self {
-            Element::Reference(reference_path_type, max_hop, flags) => match reference_path_type {
-                ReferencePathType::AbsolutePathReference(..) => self,
-                _ => {
-                    // Element is a reference and is not absolute.
-                    // build the stored path for this reference
-                    let absolute_path =
-                        path_from_reference_path_type(reference_path_type.clone(), path, key)?;
-                    // return an absolute reference that contains this info
-                    Element::Reference(
-                        ReferencePathType::AbsolutePathReference(absolute_path),
-                        *max_hop,
-                        flags.clone(),
-                    )
+        Ok(match self {
+            Element::Reference(ref reference_path_type, max_hop, ref flags) => {
+                match reference_path_type {
+                    ReferencePathType::AbsolutePathReference(..) => self,
+                    _ => {
+                        // Element is a reference and is not absolute.
+                        // build the stored path for this reference
+                        let absolute_path =
+                            path_from_reference_path_type(reference_path_type.clone(), path, key)?;
+                        // return an absolute reference that contains this info
+                        Element::Reference(
+                            ReferencePathType::AbsolutePathReference(absolute_path),
+                            max_hop,
+                            flags.clone(),
+                        )
+                    }
                 }
-            },
-            _ => self,
+            }
+            Element::NonCounted(inner) => Element::NonCounted(Box::new(
+                inner.convert_if_reference_to_absolute_reference(path, key)?,
+            )),
+            other => other,
         })
+    }
+}
+
+#[cfg(test)]
+mod non_counted_tests {
+    use grovedb_version::version::GroveVersion;
+
+    use crate::element::Element;
+
+    #[test]
+    fn new_non_counted_wraps_basic_item() {
+        let inner = Element::Item(b"x".to_vec(), None);
+        let wrapped = Element::new_non_counted(inner.clone()).expect("wrap ok");
+        assert!(wrapped.is_non_counted());
+        assert_eq!(wrapped.underlying(), &inner);
+    }
+
+    #[test]
+    fn new_non_counted_rejects_nested_wrapper() {
+        let inner = Element::Item(b"x".to_vec(), None);
+        let once = Element::new_non_counted(inner).expect("first wrap ok");
+        assert!(Element::new_non_counted(once).is_err());
+    }
+
+    #[test]
+    fn into_non_counted_is_idempotent() {
+        let inner = Element::Item(b"x".to_vec(), None);
+        let once = inner.clone().into_non_counted();
+        let twice = once.clone().into_non_counted();
+        assert_eq!(once, twice);
+        assert!(twice.is_non_counted());
+    }
+
+    #[test]
+    fn predicates_look_through_wrapper() {
+        let tree = Element::new_tree(None);
+        let nc_tree = Element::new_non_counted(tree).expect("wrap ok");
+        assert!(nc_tree.is_any_tree());
+        assert!(nc_tree.is_basic_tree());
+
+        let sum_item = Element::new_sum_item(7);
+        let nc_sum = Element::new_non_counted(sum_item).expect("wrap ok");
+        assert!(nc_sum.is_sum_item());
+        assert!(nc_sum.is_any_item());
+        assert!(!nc_sum.is_any_tree());
+        // sum still propagates
+        assert_eq!(nc_sum.sum_value_or_default(), 7);
+    }
+
+    #[test]
+    fn count_value_or_default_is_zero_for_non_counted() {
+        // Bare ProvableCountTree with internal count 5 contributes 5.
+        let pct = Element::new_provable_count_tree_with_flags_and_count_value(None, 5, None);
+        assert_eq!(pct.count_value_or_default(), 5);
+
+        // NonCounted wrapper suppresses that to 0.
+        let nc_pct = Element::new_non_counted(pct).expect("wrap ok");
+        assert_eq!(nc_pct.count_value_or_default(), 0);
+
+        // Non-tree elements normally count as 1; wrapped they count as 0.
+        let item = Element::new_item(b"x".to_vec());
+        assert_eq!(item.count_value_or_default(), 1);
+        let nc_item = Element::new_non_counted(item).expect("wrap ok");
+        assert_eq!(nc_item.count_value_or_default(), 0);
+    }
+
+    #[test]
+    fn count_sum_value_or_default_zeros_count_keeps_sum() {
+        let sum_item = Element::new_sum_item(42);
+        assert_eq!(sum_item.count_sum_value_or_default(), (1, 42));
+
+        let nc_sum = Element::new_non_counted(sum_item).expect("wrap ok");
+        assert_eq!(nc_sum.count_sum_value_or_default(), (0, 42));
+    }
+
+    #[test]
+    fn flags_delegate_through_wrapper() {
+        let flags = Some(vec![1, 2, 3]);
+        let item = Element::new_item_with_flags(b"x".to_vec(), flags.clone());
+        let nc_item = Element::new_non_counted(item).expect("wrap ok");
+        assert_eq!(nc_item.get_flags(), &flags);
+    }
+
+    #[test]
+    fn bincode_round_trip_through_wrapper() {
+        let grove_version = GroveVersion::latest();
+        let inner = Element::SumItem(7, Some(vec![9, 8]));
+        let wrapped = Element::new_non_counted(inner).expect("wrap ok");
+        let bytes = wrapped.serialize(grove_version).expect("serialize ok");
+        let back = Element::deserialize(&bytes, grove_version).expect("deserialize ok");
+        assert_eq!(back, wrapped);
+    }
+
+    #[test]
+    fn deserialize_rejects_nested_non_counted() {
+        // Construct nested NonCounted manually, bypassing the constructor's check.
+        let inner = Element::NonCounted(Box::new(Element::Item(b"x".to_vec(), None)));
+        let bad = Element::NonCounted(Box::new(inner));
+        // serialize() also rejects, but for the test we want to verify the
+        // *deserialize* path. Use bincode directly to bypass our serialize()
+        // safety check.
+        use bincode::config;
+        let cfg = config::standard().with_big_endian().with_no_limit();
+        let bytes = bincode::encode_to_vec(&bad, cfg).expect("bincode encode ok");
+        let grove_version = GroveVersion::latest();
+        assert!(Element::deserialize(&bytes, grove_version).is_err());
+    }
+
+    #[test]
+    fn serialize_rejects_nested_non_counted() {
+        let inner = Element::NonCounted(Box::new(Element::Item(b"x".to_vec(), None)));
+        let bad = Element::NonCounted(Box::new(inner));
+        let grove_version = GroveVersion::latest();
+        assert!(bad.serialize(grove_version).is_err());
     }
 }

--- a/grovedb-element/src/element/helpers.rs
+++ b/grovedb-element/src/element/helpers.rs
@@ -601,6 +601,28 @@ mod non_counted_tests {
         assert!(Element::deserialize(&bytes, grove_version).is_err());
     }
 
+    /// The pre-check before bincode decode is the actual stack-overflow
+    /// guard: a long chain of wrapper bytes is rejected without bincode
+    /// recursing through them. This synthesizes the malicious payload
+    /// directly (no construction goes through `serialize`).
+    #[test]
+    fn deserialize_rejects_long_nested_wrapper_chain_without_recursion() {
+        let grove_version = GroveVersion::latest();
+        // 1024 wrapper bytes followed by a base item. With the post-check
+        // alone, bincode would recurse through all 1024 Box<Element>
+        // wrappers before our check fires — pre-check stops it on byte 1.
+        let mut bytes = vec![15u8; 1024];
+        bytes.extend_from_slice(&[0, 0, 0]); // Item with empty value, no flags
+        let err = Element::deserialize(&bytes, grove_version)
+            .expect_err("nested wrapper bytes must be rejected");
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("NonCounted") || msg.contains("non_counted"),
+            "error should mention nested NonCounted: {}",
+            msg
+        );
+    }
+
     #[test]
     fn serialize_rejects_nested_non_counted() {
         let inner = Element::NonCounted(Box::new(Element::Item(b"x".to_vec(), None)));

--- a/grovedb-element/src/element/mod.rs
+++ b/grovedb-element/src/element/mod.rs
@@ -327,6 +327,11 @@ impl fmt::Display for Element {
 
 impl Element {
     /// Returns the ElementType for this element.
+    ///
+    /// For `Element::NonCounted(inner)`, returns the matching `NonCountedXxx`
+    /// twin of the inner element's type (high bit set). Nested wrappers are
+    /// disallowed at construction and serialization, so the inner is always
+    /// a base element.
     pub fn element_type(&self) -> ElementType {
         match self {
             Element::Item(..) => ElementType::Item,
@@ -344,7 +349,28 @@ impl Element {
             Element::MmrTree(..) => ElementType::MmrTree,
             Element::BulkAppendTree(..) => ElementType::BulkAppendTree,
             Element::DenseAppendOnlyFixedSizeTree(..) => ElementType::DenseAppendOnlyFixedSizeTree,
-            Element::NonCounted(..) => ElementType::NonCounted,
+            Element::NonCounted(inner) => match inner.element_type() {
+                ElementType::Item => ElementType::NonCountedItem,
+                ElementType::Reference => ElementType::NonCountedReference,
+                ElementType::Tree => ElementType::NonCountedTree,
+                ElementType::SumItem => ElementType::NonCountedSumItem,
+                ElementType::SumTree => ElementType::NonCountedSumTree,
+                ElementType::BigSumTree => ElementType::NonCountedBigSumTree,
+                ElementType::CountTree => ElementType::NonCountedCountTree,
+                ElementType::CountSumTree => ElementType::NonCountedCountSumTree,
+                ElementType::ProvableCountTree => ElementType::NonCountedProvableCountTree,
+                ElementType::ItemWithSumItem => ElementType::NonCountedItemWithSumItem,
+                ElementType::ProvableCountSumTree => ElementType::NonCountedProvableCountSumTree,
+                ElementType::CommitmentTree => ElementType::NonCountedCommitmentTree,
+                ElementType::MmrTree => ElementType::NonCountedMmrTree,
+                ElementType::BulkAppendTree => ElementType::NonCountedBulkAppendTree,
+                ElementType::DenseAppendOnlyFixedSizeTree => {
+                    ElementType::NonCountedDenseAppendOnlyFixedSizeTree
+                }
+                // Inner is always a base type — nested wrappers are
+                // forbidden at construction and (de)serialization.
+                already_non_counted => already_non_counted,
+            },
         }
     }
 

--- a/grovedb-element/src/element/mod.rs
+++ b/grovedb-element/src/element/mod.rs
@@ -122,6 +122,17 @@ pub enum Element {
     /// - `height`: Tree height h; the tree has 2^h - 1 positions.
     /// - `flags`: Optional per-element metadata.
     DenseAppendOnlyFixedSizeTree(u16, u8, Option<ElementFlags>),
+    /// Non-counted wrapper: contains any other Element type and behaves
+    /// identically to it for storage, hashing, and internal aggregation, but
+    /// contributes 0 to its parent count tree's aggregate count when inserted.
+    /// Sums still propagate to parent sum trees.
+    ///
+    /// May only be inserted into count-bearing trees (`CountTree`,
+    /// `ProvableCountTree`, `CountSumTree`, `ProvableCountSumTree`).
+    ///
+    /// Invariant: a `NonCounted` may not wrap another `NonCounted`. Enforced
+    /// at construction and at deserialization.
+    NonCounted(Box<Element>),
 }
 
 pub fn hex_to_ascii(hex_value: &[u8]) -> String {
@@ -307,6 +318,9 @@ impl fmt::Display for Element {
                         .map_or(String::new(), |f| format!(", flags: {:?}", f))
                 )
             }
+            Element::NonCounted(inner) => {
+                write!(f, "NonCounted({})", inner)
+            }
         }
     }
 }
@@ -330,6 +344,7 @@ impl Element {
             Element::MmrTree(..) => ElementType::MmrTree,
             Element::BulkAppendTree(..) => ElementType::BulkAppendTree,
             Element::DenseAppendOnlyFixedSizeTree(..) => ElementType::DenseAppendOnlyFixedSizeTree,
+            Element::NonCounted(..) => ElementType::NonCounted,
         }
     }
 

--- a/grovedb-element/src/element/serialize.rs
+++ b/grovedb-element/src/element/serialize.rs
@@ -8,11 +8,22 @@ use crate::{element::Element, error::ElementError};
 
 impl Element {
     /// Serializes self. Returns vector of u8s.
+    ///
+    /// Rejects `NonCounted(NonCounted(_))` — the wrapper is not allowed to
+    /// nest. Constructed via `Element::new_non_counted` this is impossible,
+    /// but a caller could build it directly.
     pub fn serialize(&self, grove_version: &GroveVersion) -> Result<Vec<u8>, ElementError> {
         check_grovedb_v0!(
             "Element::serialize",
             grove_version.grovedb_versions.element.serialize
         );
+        if let Element::NonCounted(inner) = self
+            && matches!(**inner, Element::NonCounted(_))
+        {
+            return Err(ElementError::CorruptedData(
+                "NonCounted cannot wrap another NonCounted".to_string(),
+            ));
+        }
         let config = config::standard().with_big_endian().with_no_limit();
         bincode::encode_to_vec(self, config)
             .map_err(|e| ElementError::CorruptedData(format!("unable to serialize element {}", e)))
@@ -28,18 +39,30 @@ impl Element {
             .map(|serialized| serialized.len())
     }
 
-    /// Deserializes given bytes and sets as self
+    /// Deserializes given bytes and sets as self.
+    ///
+    /// Rejects `NonCounted(NonCounted(_))` to close a recursion / stack
+    /// overflow vector — bincode itself imposes some recursion limits, but
+    /// explicit rejection here is cheaper and more obvious.
     pub fn deserialize(bytes: &[u8], grove_version: &GroveVersion) -> Result<Self, ElementError> {
         check_grovedb_v0!(
             "Element::deserialize",
             grove_version.grovedb_versions.element.deserialize
         );
         let config = config::standard().with_big_endian().with_no_limit();
-        Ok(bincode::decode_from_slice(bytes, config)
+        let elem: Element = bincode::decode_from_slice(bytes, config)
             .map_err(|e| {
                 ElementError::CorruptedData(format!("unable to deserialize element {}", e))
             })?
-            .0)
+            .0;
+        if let Element::NonCounted(inner) = &elem
+            && matches!(**inner, Element::NonCounted(_))
+        {
+            return Err(ElementError::CorruptedData(
+                "deserialized NonCounted wrapping another NonCounted".to_string(),
+            ));
+        }
+        Ok(elem)
     }
 }
 

--- a/grovedb-element/src/element/serialize.rs
+++ b/grovedb-element/src/element/serialize.rs
@@ -4,7 +4,9 @@
 use bincode::config;
 use grovedb_version::{check_grovedb_v0, version::GroveVersion};
 
-use crate::{element::Element, error::ElementError};
+use crate::{
+    element::Element, element_type::NON_COUNTED_WRAPPER_DISCRIMINANT, error::ElementError,
+};
 
 impl Element {
     /// Serializes self. Returns vector of u8s.
@@ -41,20 +43,42 @@ impl Element {
 
     /// Deserializes given bytes and sets as self.
     ///
-    /// Rejects `NonCounted(NonCounted(_))` to close a recursion / stack
-    /// overflow vector — bincode itself imposes some recursion limits, but
-    /// explicit rejection here is cheaper and more obvious.
+    /// Pre-checks the leading bytes for a nested `NonCounted` wrapper and
+    /// rejects before invoking bincode. This closes a stack-exhaustion
+    /// vector: a hostile payload of repeated `NON_COUNTED_WRAPPER_DISCRIMINANT`
+    /// bytes would otherwise cause bincode to recursively decode the
+    /// `Box<Element>` chain (and overflow the stack) before any post-decode
+    /// check could fire. The pre-check is O(1) — only the first two bytes
+    /// matter.
     pub fn deserialize(bytes: &[u8], grove_version: &GroveVersion) -> Result<Self, ElementError> {
         check_grovedb_v0!(
             "Element::deserialize",
             grove_version.grovedb_versions.element.deserialize
         );
+        // Pre-check: if the wire starts with the wrapper discriminant, the
+        // very next byte must NOT be the wrapper discriminant again. This
+        // bounds the recursion bincode will attempt.
+        if matches!(
+            bytes,
+            [
+                NON_COUNTED_WRAPPER_DISCRIMINANT,
+                NON_COUNTED_WRAPPER_DISCRIMINANT,
+                ..
+            ]
+        ) {
+            return Err(ElementError::CorruptedData(
+                "deserialized NonCounted wrapping another NonCounted".to_string(),
+            ));
+        }
         let config = config::standard().with_big_endian().with_no_limit();
         let elem: Element = bincode::decode_from_slice(bytes, config)
             .map_err(|e| {
                 ElementError::CorruptedData(format!("unable to deserialize element {}", e))
             })?
             .0;
+        // Defensive belt-and-braces post-check (guards against future
+        // bincode/discriminant changes that could let a nested wrapper
+        // sneak past the pre-check).
         if let Element::NonCounted(inner) = &elem
             && matches!(**inner, Element::NonCounted(_))
         {

--- a/grovedb-element/src/element/visualize.rs
+++ b/grovedb-element/src/element/visualize.rs
@@ -176,6 +176,11 @@ impl Visualize for Element {
                     drawer = f.visualize(drawer)?;
                 }
             }
+            Element::NonCounted(inner) => {
+                drawer.write(b"non_counted(")?;
+                drawer = inner.visualize(drawer)?;
+                drawer.write(b")")?;
+            }
         }
         Ok(drawer)
     }

--- a/grovedb-element/src/element_type.rs
+++ b/grovedb-element/src/element_type.rs
@@ -203,11 +203,22 @@ impl ElementType {
                     "NonCounted wrapper has no inner element discriminant byte".to_string(),
                 )
             })?;
-            // Reject nested wrappers up front.
-            if inner_byte == NON_COUNTED_WRAPPER_DISCRIMINANT {
-                return Err(ElementError::CorruptedData(
-                    "NonCounted cannot wrap another NonCounted".to_string(),
-                ));
+            // The inner discriminant must be a base type — i.e. strictly less
+            // than NON_COUNTED_WRAPPER_DISCRIMINANT (15). Bytes 15+ are not
+            // valid on-disk inner discriminants:
+            //   - 15 itself is the wrapper byte (nested wrappers forbidden),
+            //   - 16..=127 are unallocated,
+            //   - 128..=142 are the synthetic NonCountedXxx twins which
+            //     never appear on disk; without this check, the bitwise OR
+            //     below would collapse `0x80 | inner_byte` into `inner_byte`
+            //     and a payload like `[15, 128, ...]` would silently parse
+            //     as `NonCountedItem`.
+            if inner_byte >= NON_COUNTED_WRAPPER_DISCRIMINANT {
+                return Err(ElementError::CorruptedData(format!(
+                    "NonCounted inner discriminant must be a base type 0..={}, got {}",
+                    NON_COUNTED_WRAPPER_DISCRIMINANT - 1,
+                    inner_byte
+                )));
             }
             Self::try_from(NON_COUNTED_FLAG | inner_byte)
         } else {
@@ -780,6 +791,16 @@ mod tests {
         assert!(ElementType::from_serialized_value(&[15, 15]).is_err());
         // Wrapper with unknown inner discriminant is rejected.
         assert!(ElementType::from_serialized_value(&[15, 200]).is_err());
+        // Wrapper whose inner byte is itself a synthetic twin discriminant
+        // (high bit set) is rejected — only base discriminants 0..=14 are
+        // legal on-disk inner bytes. Without this guard, `0x80 | 128 == 128`
+        // would silently parse as `NonCountedItem`.
+        assert!(ElementType::from_serialized_value(&[15, 128]).is_err());
+        assert!(ElementType::from_serialized_value(&[15, 142]).is_err());
+        // Wrapper with an unallocated mid-range inner byte (16..=127) is
+        // also rejected, even though it has no high bit set.
+        assert!(ElementType::from_serialized_value(&[15, 16]).is_err());
+        assert!(ElementType::from_serialized_value(&[15, 100]).is_err());
     }
 
     #[test]

--- a/grovedb-element/src/element_type.rs
+++ b/grovedb-element/src/element_type.rs
@@ -116,6 +116,8 @@ pub enum ElementType {
     BulkAppendTree = 13,
     /// Dense fixed-sized Merkle tree - discriminant 14
     DenseAppendOnlyFixedSizeTree = 14,
+    /// Non-counted wrapper around any other Element - discriminant 15
+    NonCounted = 15,
 }
 
 impl ElementType {
@@ -237,6 +239,11 @@ impl ElementType {
     }
 
     /// Returns true if this element type is any kind of tree (subtree).
+    ///
+    /// Note: this returns false for `NonCounted` because the wrapper itself is
+    /// not a tree (its inner element may or may not be). Callers that want to
+    /// look through a `NonCounted` wrapper should call
+    /// `Element::is_any_tree()` instead, which inspects the underlying element.
     #[inline]
     pub fn is_tree(&self) -> bool {
         matches!(
@@ -289,6 +296,7 @@ impl ElementType {
             ElementType::MmrTree => "mmr tree",
             ElementType::BulkAppendTree => "bulk_append_tree",
             ElementType::DenseAppendOnlyFixedSizeTree => "dense_tree",
+            ElementType::NonCounted => "non_counted",
         }
     }
 }
@@ -313,6 +321,7 @@ impl TryFrom<u8> for ElementType {
             12 => Ok(ElementType::MmrTree),
             13 => Ok(ElementType::BulkAppendTree),
             14 => Ok(ElementType::DenseAppendOnlyFixedSizeTree),
+            15 => Ok(ElementType::NonCounted),
             _ => Err(ElementError::CorruptedData(format!(
                 "Unknown element type discriminant: {}",
                 value
@@ -366,7 +375,8 @@ mod tests {
             ElementType::try_from(14).unwrap(),
             ElementType::DenseAppendOnlyFixedSizeTree
         );
-        assert!(ElementType::try_from(15).is_err());
+        assert_eq!(ElementType::try_from(15).unwrap(), ElementType::NonCounted);
+        assert!(ElementType::try_from(16).is_err());
     }
 
     #[test]
@@ -549,6 +559,8 @@ mod tests {
         assert!(ElementType::MmrTree.is_tree());
         assert!(ElementType::BulkAppendTree.is_tree());
         assert!(ElementType::DenseAppendOnlyFixedSizeTree.is_tree());
+        // NonCounted is a wrapper, not a tree itself.
+        assert!(!ElementType::NonCounted.is_tree());
     }
 
     /// Verifies that serialized Element discriminants match ElementType
@@ -649,13 +661,19 @@ mod tests {
                 ElementType::DenseAppendOnlyFixedSizeTree,
                 "DenseAppendOnlyFixedSizeTree",
             ),
+            // discriminant 15
+            (
+                Element::NonCounted(Box::new(Element::Item(vec![1, 2, 3], None))),
+                ElementType::NonCounted,
+                "NonCounted",
+            ),
         ];
 
-        // Verify we're testing all 15 discriminants (0-14)
+        // Verify we're testing all 16 discriminants (0-15)
         assert_eq!(
             test_cases.len(),
-            15,
-            "Expected 15 Element variants in test, got {}",
+            16,
+            "Expected 16 Element variants in test, got {}",
             test_cases.len()
         );
 

--- a/grovedb-element/src/element_type.rs
+++ b/grovedb-element/src/element_type.rs
@@ -2,6 +2,25 @@
 
 use crate::error::ElementError;
 
+/// Bincode discriminant byte for `Element::NonCounted`. Tied to the
+/// declaration order of the `Element` enum (0-indexed, 16th variant).
+///
+/// `ElementType` does NOT have a direct variant at this byte — when
+/// `from_serialized_value` sees this discriminant, it reads the next byte to
+/// resolve the inner type and returns a synthetic `NonCountedXxx` variant
+/// (high bit set). The `test_element_serialization_discriminants_match_element_type`
+/// test pins this constant to the actual bincode encoding.
+pub const NON_COUNTED_WRAPPER_DISCRIMINANT: u8 = 15;
+
+/// High bit set on every `NonCountedXxx` discriminant. The base type can be
+/// recovered with `disc & NON_COUNTED_BASE_MASK`, and "is non-counted" is
+/// `disc & NON_COUNTED_FLAG != 0`.
+pub const NON_COUNTED_FLAG: u8 = 0x80;
+
+/// Mask to recover the base type discriminant from a `NonCountedXxx`
+/// discriminant.
+pub const NON_COUNTED_BASE_MASK: u8 = 0x7F;
+
 /// Indicates which type of proof node should be used when generating proofs.
 ///
 /// This determines whether the verifier will recompute the value hash (secure)
@@ -78,11 +97,19 @@ pub enum ProofNodeType {
     KvRefValueHashCount,
 }
 
-/// Element type discriminants matching the Element enum serialization order.
-/// These correspond to the bincode serialization of the Element enum.
+/// Element type discriminants.
 ///
-/// IMPORTANT: These values must match the order of variants in the Element
-/// enum. If Element enum order changes, these must be updated accordingly.
+/// Base types (0..=14) match the bincode serialization order of the `Element`
+/// enum. Non-counted twins (128..=142) are synthetic — they encode "this is a
+/// `NonCounted` wrapper around an inner element of base type
+/// `disc & 0x7F`". The on-disk representation of `Element::NonCounted` still
+/// uses the wrapper byte `NON_COUNTED_WRAPPER_DISCRIMINANT` (15) followed by
+/// the inner element's bytes; `from_serialized_value` synthesizes the
+/// `NonCountedXxx` variant by peeking at the second byte.
+///
+/// IMPORTANT: Base values (0..=14) must match the order of variants in the
+/// `Element` enum. The `test_element_serialization_discriminants_match_element_type`
+/// test catches drift.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum ElementType {
@@ -116,28 +143,97 @@ pub enum ElementType {
     BulkAppendTree = 13,
     /// Dense fixed-sized Merkle tree - discriminant 14
     DenseAppendOnlyFixedSizeTree = 14,
-    /// Non-counted wrapper around any other Element - discriminant 15
-    NonCounted = 15,
+    // 15 is reserved as the on-disk wrapper byte and has no direct
+    // ElementType variant.
+    /// Non-counted wrapper around `Item` - discriminant 128
+    NonCountedItem = 128,
+    /// Non-counted wrapper around `Reference` - discriminant 129
+    NonCountedReference = 129,
+    /// Non-counted wrapper around `Tree` - discriminant 130
+    NonCountedTree = 130,
+    /// Non-counted wrapper around `SumItem` - discriminant 131
+    NonCountedSumItem = 131,
+    /// Non-counted wrapper around `SumTree` - discriminant 132
+    NonCountedSumTree = 132,
+    /// Non-counted wrapper around `BigSumTree` - discriminant 133
+    NonCountedBigSumTree = 133,
+    /// Non-counted wrapper around `CountTree` - discriminant 134
+    NonCountedCountTree = 134,
+    /// Non-counted wrapper around `CountSumTree` - discriminant 135
+    NonCountedCountSumTree = 135,
+    /// Non-counted wrapper around `ProvableCountTree` - discriminant 136
+    NonCountedProvableCountTree = 136,
+    /// Non-counted wrapper around `ItemWithSumItem` - discriminant 137
+    NonCountedItemWithSumItem = 137,
+    /// Non-counted wrapper around `ProvableCountSumTree` - discriminant 138
+    NonCountedProvableCountSumTree = 138,
+    /// Non-counted wrapper around `CommitmentTree` - discriminant 139
+    NonCountedCommitmentTree = 139,
+    /// Non-counted wrapper around `MmrTree` - discriminant 140
+    NonCountedMmrTree = 140,
+    /// Non-counted wrapper around `BulkAppendTree` - discriminant 141
+    NonCountedBulkAppendTree = 141,
+    /// Non-counted wrapper around `DenseAppendOnlyFixedSizeTree` - discriminant 142
+    NonCountedDenseAppendOnlyFixedSizeTree = 142,
 }
 
 impl ElementType {
-    /// Get the ElementType from a serialized Element's first byte.
+    /// Get the ElementType from a serialized Element's leading bytes.
     ///
-    /// This is an O(1) operation that avoids full deserialization.
+    /// Reads byte 0 in the common case. When byte 0 is the
+    /// `NON_COUNTED_WRAPPER_DISCRIMINANT`, also reads byte 1 to resolve the
+    /// inner type and returns the corresponding `NonCountedXxx` variant
+    /// (with bit 7 set).
     ///
     /// # Arguments
     /// * `serialized_value` - The serialized Element bytes
     ///
     /// # Returns
     /// * `Ok(ElementType)` - The element type
-    /// * `Err(ElementError)` - If the value is empty or has an unknown
-    ///   discriminant
+    /// * `Err(ElementError)` - If the value is empty, truncated (wrapper
+    ///   without inner byte), or has an unknown discriminant
     pub fn from_serialized_value(serialized_value: &[u8]) -> Result<Self, ElementError> {
-        let first_byte = serialized_value.first().ok_or_else(|| {
+        let first_byte = *serialized_value.first().ok_or_else(|| {
             ElementError::CorruptedData("Cannot get element type from empty value".to_string())
         })?;
 
-        Self::try_from(*first_byte)
+        if first_byte == NON_COUNTED_WRAPPER_DISCRIMINANT {
+            let inner_byte = *serialized_value.get(1).ok_or_else(|| {
+                ElementError::CorruptedData(
+                    "NonCounted wrapper has no inner element discriminant byte".to_string(),
+                )
+            })?;
+            // Reject nested wrappers up front.
+            if inner_byte == NON_COUNTED_WRAPPER_DISCRIMINANT {
+                return Err(ElementError::CorruptedData(
+                    "NonCounted cannot wrap another NonCounted".to_string(),
+                ));
+            }
+            Self::try_from(NON_COUNTED_FLAG | inner_byte)
+        } else {
+            Self::try_from(first_byte)
+        }
+    }
+
+    /// Returns true if this is a `NonCountedXxx` discriminant (bit 7 set).
+    #[inline]
+    pub const fn is_non_counted(self) -> bool {
+        (self as u8) & NON_COUNTED_FLAG != 0
+    }
+
+    /// Returns the underlying base ElementType, stripping the NonCounted bit.
+    /// For base types, returns `self` unchanged.
+    #[inline]
+    pub fn base(self) -> ElementType {
+        if self.is_non_counted() {
+            // Safe: every NonCountedXxx is constructed from a valid base
+            // discriminant 0..=14, so masking the high bit yields a valid
+            // base discriminant.
+            ElementType::try_from((self as u8) & NON_COUNTED_BASE_MASK)
+                .expect("NonCounted twin always has a valid base")
+        } else {
+            self
+        }
     }
 
     /// Returns the type of proof node that should be used for this element
@@ -177,21 +273,28 @@ impl ElementType {
     /// # Arguments
     /// * `parent_tree_type` - The type of tree containing this element, or
     ///   `None` for root-level elements
+    ///
+    /// The `NonCounted` wrapper is transparent for proof-node-type
+    /// selection: both `self` and `parent_tree_type` are normalized via
+    /// `base()` before dispatch. The proof shape is determined by the inner
+    /// element type, not by the wrapper.
     #[inline]
     pub fn proof_node_type(&self, parent_tree_type: Option<ElementType>) -> ProofNodeType {
+        let parent_base = parent_tree_type.map(|t| t.base());
         let is_provable_count_tree = matches!(
-            parent_tree_type,
+            parent_base,
             Some(ElementType::ProvableCountTree) | Some(ElementType::ProvableCountSumTree)
         );
 
-        if self.has_simple_value_hash() {
+        let base = self.base();
+        if base.has_simple_value_hash() {
             // Items (Item, SumItem, ItemWithSumItem)
             if is_provable_count_tree {
                 ProofNodeType::KvCount
             } else {
                 ProofNodeType::Kv
             }
-        } else if self.is_reference() {
+        } else if base.is_reference() {
             // References need combined hash (for reference resolution).
             // In ProvableCountTree, they also need the count in node_hash.
             // GroveDB post-processes these to KVRefValueHash/KVRefValueHashCount.
@@ -215,11 +318,12 @@ impl ElementType {
     ///
     /// Item types have `value_hash = H(serialized_element)`.
     /// These can safely use `Node::KV` in proofs because the verifier
-    /// can recompute the hash from the value.
+    /// can recompute the hash from the value. Looks through the
+    /// `NonCounted` wrapper.
     #[inline]
     pub fn has_simple_value_hash(&self) -> bool {
         matches!(
-            self,
+            self.base(),
             ElementType::Item | ElementType::SumItem | ElementType::ItemWithSumItem
         )
     }
@@ -239,15 +343,11 @@ impl ElementType {
     }
 
     /// Returns true if this element type is any kind of tree (subtree).
-    ///
-    /// Note: this returns false for `NonCounted` because the wrapper itself is
-    /// not a tree (its inner element may or may not be). Callers that want to
-    /// look through a `NonCounted` wrapper should call
-    /// `Element::is_any_tree()` instead, which inspects the underlying element.
+    /// Looks through the `NonCounted` wrapper.
     #[inline]
     pub fn is_tree(&self) -> bool {
         matches!(
-            self,
+            self.base(),
             ElementType::Tree
                 | ElementType::SumTree
                 | ElementType::BigSumTree
@@ -262,18 +362,19 @@ impl ElementType {
         )
     }
 
-    /// Returns true if this element type is a reference.
+    /// Returns true if this element type is a reference. Looks through the
+    /// `NonCounted` wrapper.
     #[inline]
     pub fn is_reference(&self) -> bool {
-        matches!(self, ElementType::Reference)
+        matches!(self.base(), ElementType::Reference)
     }
 
     /// Returns true if this element type is any kind of item (not a tree or
-    /// reference).
+    /// reference). Looks through the `NonCounted` wrapper.
     #[inline]
     pub fn is_item(&self) -> bool {
         matches!(
-            self,
+            self.base(),
             ElementType::Item | ElementType::SumItem | ElementType::ItemWithSumItem
         )
     }
@@ -296,7 +397,21 @@ impl ElementType {
             ElementType::MmrTree => "mmr tree",
             ElementType::BulkAppendTree => "bulk_append_tree",
             ElementType::DenseAppendOnlyFixedSizeTree => "dense_tree",
-            ElementType::NonCounted => "non_counted",
+            ElementType::NonCountedItem => "non_counted item",
+            ElementType::NonCountedReference => "non_counted reference",
+            ElementType::NonCountedTree => "non_counted tree",
+            ElementType::NonCountedSumItem => "non_counted sum item",
+            ElementType::NonCountedSumTree => "non_counted sum tree",
+            ElementType::NonCountedBigSumTree => "non_counted big sum tree",
+            ElementType::NonCountedCountTree => "non_counted count tree",
+            ElementType::NonCountedCountSumTree => "non_counted count sum tree",
+            ElementType::NonCountedProvableCountTree => "non_counted provable count tree",
+            ElementType::NonCountedItemWithSumItem => "non_counted item with sum item",
+            ElementType::NonCountedProvableCountSumTree => "non_counted provable count sum tree",
+            ElementType::NonCountedCommitmentTree => "non_counted commitment tree",
+            ElementType::NonCountedMmrTree => "non_counted mmr tree",
+            ElementType::NonCountedBulkAppendTree => "non_counted bulk_append_tree",
+            ElementType::NonCountedDenseAppendOnlyFixedSizeTree => "non_counted dense_tree",
         }
     }
 }
@@ -304,6 +419,11 @@ impl ElementType {
 impl TryFrom<u8> for ElementType {
     type Error = ElementError;
 
+    /// Maps a discriminant byte to an `ElementType`.
+    ///
+    /// `NON_COUNTED_WRAPPER_DISCRIMINANT` (15) on its own is rejected: it is
+    /// the on-disk wrapper byte and must be paired with the inner element's
+    /// discriminant byte. Use `from_serialized_value` for that.
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(ElementType::Item),
@@ -321,7 +441,23 @@ impl TryFrom<u8> for ElementType {
             12 => Ok(ElementType::MmrTree),
             13 => Ok(ElementType::BulkAppendTree),
             14 => Ok(ElementType::DenseAppendOnlyFixedSizeTree),
-            15 => Ok(ElementType::NonCounted),
+            // 15 is the raw NonCounted wrapper byte; from_serialized_value
+            // resolves it by reading the inner discriminant.
+            128 => Ok(ElementType::NonCountedItem),
+            129 => Ok(ElementType::NonCountedReference),
+            130 => Ok(ElementType::NonCountedTree),
+            131 => Ok(ElementType::NonCountedSumItem),
+            132 => Ok(ElementType::NonCountedSumTree),
+            133 => Ok(ElementType::NonCountedBigSumTree),
+            134 => Ok(ElementType::NonCountedCountTree),
+            135 => Ok(ElementType::NonCountedCountSumTree),
+            136 => Ok(ElementType::NonCountedProvableCountTree),
+            137 => Ok(ElementType::NonCountedItemWithSumItem),
+            138 => Ok(ElementType::NonCountedProvableCountSumTree),
+            139 => Ok(ElementType::NonCountedCommitmentTree),
+            140 => Ok(ElementType::NonCountedMmrTree),
+            141 => Ok(ElementType::NonCountedBulkAppendTree),
+            142 => Ok(ElementType::NonCountedDenseAppendOnlyFixedSizeTree),
             _ => Err(ElementError::CorruptedData(format!(
                 "Unknown element type discriminant: {}",
                 value
@@ -375,8 +511,57 @@ mod tests {
             ElementType::try_from(14).unwrap(),
             ElementType::DenseAppendOnlyFixedSizeTree
         );
-        assert_eq!(ElementType::try_from(15).unwrap(), ElementType::NonCounted);
+        // 15 is the raw NonCounted wrapper byte and is rejected by TryFrom;
+        // it has no direct ElementType variant (use from_serialized_value).
+        assert!(ElementType::try_from(15).is_err());
         assert!(ElementType::try_from(16).is_err());
+
+        // High-bit twins
+        assert_eq!(
+            ElementType::try_from(128).unwrap(),
+            ElementType::NonCountedItem
+        );
+        assert_eq!(
+            ElementType::try_from(129).unwrap(),
+            ElementType::NonCountedReference
+        );
+        assert_eq!(
+            ElementType::try_from(142).unwrap(),
+            ElementType::NonCountedDenseAppendOnlyFixedSizeTree
+        );
+        // Bytes between the base and twin ranges are invalid.
+        assert!(ElementType::try_from(127).is_err());
+        // Bytes past the highest twin are invalid.
+        assert!(ElementType::try_from(143).is_err());
+    }
+
+    #[test]
+    fn test_non_counted_helpers() {
+        // is_non_counted: high bit means non-counted
+        assert!(!ElementType::Item.is_non_counted());
+        assert!(!ElementType::Tree.is_non_counted());
+        assert!(ElementType::NonCountedItem.is_non_counted());
+        assert!(ElementType::NonCountedTree.is_non_counted());
+        assert!(ElementType::NonCountedDenseAppendOnlyFixedSizeTree.is_non_counted());
+
+        // base() strips the wrapper and returns the underlying type.
+        assert_eq!(ElementType::Item.base(), ElementType::Item);
+        assert_eq!(ElementType::NonCountedItem.base(), ElementType::Item);
+        assert_eq!(ElementType::NonCountedTree.base(), ElementType::Tree);
+        assert_eq!(
+            ElementType::NonCountedProvableCountTree.base(),
+            ElementType::ProvableCountTree
+        );
+
+        // The discriminant relationship: twin = base | 0x80
+        assert_eq!(
+            ElementType::NonCountedItem as u8,
+            ElementType::Item as u8 | NON_COUNTED_FLAG
+        );
+        assert_eq!(
+            ElementType::NonCountedDenseAppendOnlyFixedSizeTree as u8,
+            ElementType::DenseAppendOnlyFixedSizeTree as u8 | NON_COUNTED_FLAG
+        );
     }
 
     #[test]
@@ -394,6 +579,12 @@ mod tests {
         assert!(ElementType::CountTree.has_combined_value_hash());
         assert!(ElementType::CountSumTree.has_combined_value_hash());
         assert!(ElementType::ProvableCountTree.has_combined_value_hash());
+
+        // The wrapper is transparent: NonCountedItem still hashes simply.
+        assert!(ElementType::NonCountedItem.has_simple_value_hash());
+        assert!(ElementType::NonCountedSumItem.has_simple_value_hash());
+        assert!(ElementType::NonCountedTree.has_combined_value_hash());
+        assert!(ElementType::NonCountedReference.has_combined_value_hash());
     }
 
     #[test]
@@ -525,6 +716,32 @@ mod tests {
     }
 
     #[test]
+    fn test_proof_node_type_through_non_counted_wrapper() {
+        use super::ProofNodeType;
+
+        // Wrapping doesn't change proof shape — both self and parent fall
+        // back to base() before dispatch.
+        assert_eq!(
+            ElementType::NonCountedItem.proof_node_type(None),
+            ProofNodeType::Kv,
+        );
+        assert_eq!(
+            ElementType::NonCountedItem
+                .proof_node_type(Some(ElementType::NonCountedProvableCountTree)),
+            ProofNodeType::KvCount,
+        );
+        assert_eq!(
+            ElementType::NonCountedReference
+                .proof_node_type(Some(ElementType::ProvableCountSumTree)),
+            ProofNodeType::KvRefValueHashCount,
+        );
+        assert_eq!(
+            ElementType::NonCountedTree.proof_node_type(Some(ElementType::ProvableCountTree)),
+            ProofNodeType::KvValueHashFeatureType,
+        );
+    }
+
+    #[test]
     fn test_from_serialized_value() {
         // Test with valid first bytes
         assert_eq!(
@@ -541,10 +758,33 @@ mod tests {
 
         // Test with unknown discriminant
         assert!(ElementType::from_serialized_value(&[255]).is_err());
+
+        // NonCounted wrapper: the leading byte is the wrapper discriminant
+        // (15) and the next byte is the inner type's discriminant. The
+        // returned type is the synthetic NonCountedXxx with bit 7 set.
+        assert_eq!(
+            ElementType::from_serialized_value(&[15, 0, 1, 2, 3]).unwrap(),
+            ElementType::NonCountedItem
+        );
+        assert_eq!(
+            ElementType::from_serialized_value(&[15, 6]).unwrap(),
+            ElementType::NonCountedCountTree
+        );
+        assert_eq!(
+            ElementType::from_serialized_value(&[15, 14]).unwrap(),
+            ElementType::NonCountedDenseAppendOnlyFixedSizeTree
+        );
+        // Truncated wrapper (no inner byte) is rejected.
+        assert!(ElementType::from_serialized_value(&[15]).is_err());
+        // Nested NonCounted is rejected.
+        assert!(ElementType::from_serialized_value(&[15, 15]).is_err());
+        // Wrapper with unknown inner discriminant is rejected.
+        assert!(ElementType::from_serialized_value(&[15, 200]).is_err());
     }
 
     #[test]
     fn test_is_tree() {
+        // Base types
         assert!(!ElementType::Item.is_tree());
         assert!(!ElementType::Reference.is_tree());
         assert!(ElementType::Tree.is_tree());
@@ -559,8 +799,19 @@ mod tests {
         assert!(ElementType::MmrTree.is_tree());
         assert!(ElementType::BulkAppendTree.is_tree());
         assert!(ElementType::DenseAppendOnlyFixedSizeTree.is_tree());
-        // NonCounted is a wrapper, not a tree itself.
-        assert!(!ElementType::NonCounted.is_tree());
+
+        // The wrapper is transparent: NonCountedTree is a tree, NonCountedItem is not.
+        assert!(!ElementType::NonCountedItem.is_tree());
+        assert!(!ElementType::NonCountedReference.is_tree());
+        assert!(ElementType::NonCountedTree.is_tree());
+        assert!(ElementType::NonCountedSumTree.is_tree());
+        assert!(ElementType::NonCountedProvableCountTree.is_tree());
+        assert!(ElementType::NonCountedDenseAppendOnlyFixedSizeTree.is_tree());
+
+        // is_item / is_reference also see through the wrapper.
+        assert!(ElementType::NonCountedItem.is_item());
+        assert!(ElementType::NonCountedSumItem.is_item());
+        assert!(ElementType::NonCountedReference.is_reference());
     }
 
     /// Verifies that serialized Element discriminants match ElementType
@@ -661,19 +912,13 @@ mod tests {
                 ElementType::DenseAppendOnlyFixedSizeTree,
                 "DenseAppendOnlyFixedSizeTree",
             ),
-            // discriminant 15
-            (
-                Element::NonCounted(Box::new(Element::Item(vec![1, 2, 3], None))),
-                ElementType::NonCounted,
-                "NonCounted",
-            ),
         ];
 
-        // Verify we're testing all 16 discriminants (0-15)
+        // Verify we're testing all 15 base discriminants (0-14)
         assert_eq!(
             test_cases.len(),
-            16,
-            "Expected 16 Element variants in test, got {}",
+            15,
+            "Expected 15 base Element variants in test, got {}",
             test_cases.len()
         );
 
@@ -712,6 +957,86 @@ mod tests {
                 parsed_type, expected_type,
                 "ElementType::from_serialized_value for {} returned {:?}, expected {:?}",
                 variant_name, parsed_type, expected_type
+            );
+        }
+    }
+
+    /// Pins the bincode discriminant for `Element::NonCounted` to
+    /// `NON_COUNTED_WRAPPER_DISCRIMINANT`. If someone reorders the `Element`
+    /// enum and pushes `NonCounted` to a different position, this catches it
+    /// — `from_serialized_value` reads byte 1 specifically when byte 0 is
+    /// this constant.
+    #[test]
+    fn test_non_counted_wrapper_discriminant_pinned() {
+        use grovedb_version::version::GroveVersion;
+
+        use crate::element::Element;
+
+        let grove_version = GroveVersion::latest();
+
+        // Pick one inner element per category to verify the wrapper byte +
+        // inner byte resolve to the right NonCountedXxx.
+        let cases: Vec<(Element, ElementType, u8, &str)> = vec![
+            (
+                Element::NonCounted(Box::new(Element::Item(vec![1, 2, 3], None))),
+                ElementType::NonCountedItem,
+                0,
+                "NonCounted(Item)",
+            ),
+            (
+                Element::NonCounted(Box::new(Element::SumItem(7, None))),
+                ElementType::NonCountedSumItem,
+                3,
+                "NonCounted(SumItem)",
+            ),
+            (
+                Element::NonCounted(Box::new(Element::CountTree(None, 5, None))),
+                ElementType::NonCountedCountTree,
+                6,
+                "NonCounted(CountTree)",
+            ),
+            (
+                Element::NonCounted(Box::new(Element::ProvableCountTree(None, 5, None))),
+                ElementType::NonCountedProvableCountTree,
+                8,
+                "NonCounted(ProvableCountTree)",
+            ),
+        ];
+
+        for (element, expected_type, expected_inner_disc, name) in cases {
+            let serialized = element
+                .serialize(grove_version)
+                .unwrap_or_else(|e| panic!("Failed to serialize {}: {:?}", name, e));
+
+            assert!(
+                serialized.len() >= 2,
+                "Serialized {} should have at least 2 bytes",
+                name
+            );
+            assert_eq!(
+                serialized[0], NON_COUNTED_WRAPPER_DISCRIMINANT,
+                "{}: first byte should be the wrapper discriminant (15)",
+                name
+            );
+            assert_eq!(
+                serialized[1], expected_inner_disc,
+                "{}: second byte should match the inner element's discriminant",
+                name
+            );
+
+            let parsed = ElementType::from_serialized_value(&serialized)
+                .unwrap_or_else(|e| panic!("Failed to parse {}: {:?}", name, e));
+            assert_eq!(
+                parsed, expected_type,
+                "{}: from_serialized_value returned {:?}, expected {:?}",
+                name, parsed, expected_type
+            );
+            // And the synthetic discriminant follows the 0x80|base rule.
+            assert_eq!(
+                parsed as u8,
+                expected_inner_disc | NON_COUNTED_FLAG,
+                "{}: NonCountedXxx = inner_disc | 0x80",
+                name
             );
         }
     }

--- a/grovedb-query/src/proofs/tree_feature_type.rs
+++ b/grovedb-query/src/proofs/tree_feature_type.rs
@@ -96,6 +96,21 @@ impl TreeFeatureType {
         }
     }
 
+    /// Force the count component of this feature type to 0, leaving sum
+    /// components untouched. No-op for variants that don't carry a count.
+    ///
+    /// Used by the `Element::NonCounted` wrapper: when computing the parent
+    /// tree's feature type for a non-counted child, we use the inner element's
+    /// feature type but zero out its count so the parent's aggregate
+    /// excludes it.
+    pub fn zero_count(&mut self) {
+        match self {
+            CountedMerkNode(count) | ProvableCountedMerkNode(count) => *count = 0,
+            CountedSummedMerkNode(count, _) | ProvableCountedSummedMerkNode(count, _) => *count = 0,
+            BasicMerkNode | SummedMerkNode(_) | BigSummedMerkNode(_) => {}
+        }
+    }
+
     /// Get the NodeType for this feature type
     pub fn node_type(&self) -> NodeType {
         match self {

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -1483,6 +1483,8 @@ mod tests {
             flags: None,
             aggregate_data: AggregateData::NoAggregateData,
             meta: NonMerkTreeMeta::MmrTree { mmr_size: 50 },
+
+            non_counted: false,
         };
         let key = KeyInfo::KnownKey(b"inmerk_key".to_vec());
         let layer_info = EstimatedLayerInformation {

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -1118,6 +1118,8 @@ mod tests {
                 count: 0,
                 height: 8,
             },
+
+            non_counted: false,
         };
         let key = KeyInfo::KnownKey(b"new_dense".to_vec());
         let cost = op
@@ -1146,6 +1148,8 @@ mod tests {
                 total_count: 0,
                 chunk_power: 3,
             },
+
+            non_counted: false,
         };
         let key = KeyInfo::KnownKey(b"new_bulk".to_vec());
         let cost = op

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -278,6 +278,11 @@ pub enum GroveOp {
         flags: Option<ElementFlags>,
         /// Aggregate Data such as sum
         aggregate_data: AggregateData,
+        /// True if the original element was wrapped in `Element::NonCounted`.
+        /// Set during propagation; on execution the reconstructed tree
+        /// element is re-wrapped so the on-disk bytes preserve the wrapper
+        /// and the parent count tree's aggregate excludes the subtree.
+        non_counted: bool,
     },
     /// **Internal only — do not construct directly.**
     /// Replace root hash for a non-Merk tree (CommitmentTree, MmrTree,
@@ -313,6 +318,10 @@ pub enum GroveOp {
         aggregate_data: AggregateData,
         /// Tree-type-specific metadata.
         meta: NonMerkTreeMeta,
+        /// True if the original element was wrapped in `Element::NonCounted`.
+        /// On execution the reconstructed element is re-wrapped to preserve
+        /// the wrapper byte on disk.
+        non_counted: bool,
     },
     /// Refresh the reference with information provided
     /// Providing this information is necessary to be able to calculate
@@ -1864,6 +1873,17 @@ where
                         }
                     }
 
+                    // Mirror the per-merk insert guard: NonCounted children
+                    // are only valid inside count-bearing parents. Without
+                    // this check, batch users could persist NonCounted
+                    // elements into Normal/Sum/Big-Sum trees and silently
+                    // violate the wrapper invariant.
+                    if element.is_non_counted() && !in_tree_type.is_count_bearing() {
+                        return Err(Error::InvalidBatchOperation(
+                            "non-counted elements may only be inserted into count-bearing trees",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
                     // Look through NonCounted; methods called on `element`
                     // (serialize, get_feature_type, insert_*_into_batch_operations,
                     // element_at_key_already_exists) are wrapper-aware via the
@@ -2224,6 +2244,7 @@ where
                     root_key,
                     flags,
                     aggregate_data,
+                    non_counted,
                 } => {
                     // Standard Merk trees — infer element from aggregate_data
                     let element = match aggregate_data {
@@ -2266,6 +2287,14 @@ where
                             Element::ProvableCountSumTree(root_key, count_value, sum_value, flags)
                         }
                     };
+                    // Re-wrap if the original element was NonCounted, so the
+                    // on-disk bytes preserve the wrapper and the parent
+                    // count tree's aggregate excludes this subtree.
+                    let element = if non_counted {
+                        element.into_non_counted()
+                    } else {
+                        element
+                    };
                     let merk_feature_type = cost_return_on_error_into_no_add!(
                         cost,
                         element.get_feature_type(in_tree_type)
@@ -2284,9 +2313,19 @@ where
                     );
                 }
                 GroveOp::InsertNonMerkTree {
-                    hash, flags, meta, ..
+                    hash,
+                    flags,
+                    meta,
+                    non_counted,
+                    ..
                 } => {
                     let element = meta.to_element(flags);
+                    // Re-wrap as above for the non-Merk tree path.
+                    let element = if non_counted {
+                        element.into_non_counted()
+                    } else {
+                        element
+                    };
                     let merk_feature_type = cost_return_on_error_into_no_add!(
                         cost,
                         element.get_feature_type(in_tree_type)
@@ -2619,9 +2658,13 @@ impl GroveDb {
                                                     // still needs to be converted into the
                                                     // appropriate InsertTreeWithRootHash /
                                                     // InsertNonMerkTree variant during
-                                                    // upward propagation, otherwise the chain
-                                                    // below would fall into the "non tree"
-                                                    // error path.
+                                                    // upward propagation. Capture the wrapper
+                                                    // status so execution can re-wrap the
+                                                    // reconstructed element — otherwise the
+                                                    // wrapper byte would be silently dropped
+                                                    // from storage and the parent count tree
+                                                    // would aggregate a value it should not.
+                                                    let non_counted = element.is_non_counted();
                                                     let element = element.underlying();
                                                     // Standard Merk trees
                                                     if let Element::Tree(_, flags) = element {
@@ -2632,6 +2675,7 @@ impl GroveDb {
                                                                 flags: flags.clone(),
                                                                 aggregate_data:
                                                                     AggregateData::NoAggregateData,
+                                                                non_counted,
                                                             }
                                                     } else if let Element::SumTree(.., flags) =
                                                         element
@@ -2642,6 +2686,7 @@ impl GroveDb {
                                                                 root_key: calculated_root_key,
                                                                 flags: flags.clone(),
                                                                 aggregate_data,
+                                                                non_counted,
                                                             }
                                                     } else if let Element::BigSumTree(.., flags) =
                                                         element
@@ -2652,6 +2697,7 @@ impl GroveDb {
                                                                 root_key: calculated_root_key,
                                                                 flags: flags.clone(),
                                                                 aggregate_data,
+                                                                non_counted,
                                                             }
                                                     } else if let Element::CountTree(.., flags) =
                                                         element
@@ -2662,6 +2708,7 @@ impl GroveDb {
                                                                 root_key: calculated_root_key,
                                                                 flags: flags.clone(),
                                                                 aggregate_data,
+                                                                non_counted,
                                                             }
                                                     } else if let Element::CountSumTree(.., flags) =
                                                         element
@@ -2672,6 +2719,7 @@ impl GroveDb {
                                                                 root_key: calculated_root_key,
                                                                 flags: flags.clone(),
                                                                 aggregate_data,
+                                                                non_counted,
                                                             }
                                                     } else if let Element::ProvableCountTree(
                                                         ..,
@@ -2684,6 +2732,7 @@ impl GroveDb {
                                                                 root_key: calculated_root_key,
                                                                 flags: flags.clone(),
                                                                 aggregate_data,
+                                                                non_counted,
                                                             }
                                                     } else if let Element::ProvableCountSumTree(
                                                         ..,
@@ -2696,6 +2745,7 @@ impl GroveDb {
                                                                 root_key: calculated_root_key,
                                                                 flags: flags.clone(),
                                                                 aggregate_data,
+                                                                non_counted,
                                                             }
                                                     // Non-Merk trees → InsertNonMerkTree
                                                     } else if let Element::CommitmentTree(
@@ -2715,6 +2765,7 @@ impl GroveDb {
                                                                 flags: flags.clone(),
                                                                 aggregate_data,
                                                                 meta,
+                                                                non_counted,
                                                             }
                                                     } else if let Element::MmrTree(
                                                         mmr_size,
@@ -2731,6 +2782,7 @@ impl GroveDb {
                                                                 flags: flags.clone(),
                                                                 aggregate_data,
                                                                 meta,
+                                                                non_counted,
                                                             }
                                                     } else if let Element::BulkAppendTree(
                                                         total_count,
@@ -2749,6 +2801,7 @@ impl GroveDb {
                                                                 flags: flags.clone(),
                                                                 aggregate_data,
                                                                 meta,
+                                                                non_counted,
                                                             }
                                                     } else if let
                                                         Element::DenseAppendOnlyFixedSizeTree(
@@ -2767,6 +2820,7 @@ impl GroveDb {
                                                                     count: *count,
                                                                     height: *height,
                                                                 },
+                                                                non_counted,
                                                             }
                                                     } else {
                                                         return Err(Error::InvalidBatchOperation(

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1441,6 +1441,11 @@ where
             .wrap_with_cost(cost);
         };
 
+        // Look through `NonCounted` for dispatch — the wrapper does not change
+        // how a referenced value is hashed or how a tree/reference is processed.
+        // The actual `element.serialize()` below preserves the wrapper byte
+        // when present, so the resulting value hash matches what's on disk.
+        let element = element.into_underlying();
         match element {
             Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
                 let serialized =
@@ -1477,6 +1482,8 @@ where
                 "references can not point to trees being updated",
             ))
             .wrap_with_cost(cost),
+            // NonCounted is unwrapped above via into_underlying().
+            Element::NonCounted(_) => unreachable!("unwrapped above"),
         }
     }
 
@@ -1541,7 +1548,9 @@ where
                 GroveOp::InsertOrReplace { element }
                 | GroveOp::Replace { element }
                 | GroveOp::Patch { element, .. } => {
-                    match element {
+                    // Look through NonCounted for dispatch; serialize the outer
+                    // wrapper for hashing so the value hash matches storage.
+                    match element.underlying() {
                         Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
                             let serialized = cost_return_on_error_into_no_add!(
                                 cost,
@@ -1625,10 +1634,12 @@ where
                             ))
                             .wrap_with_cost(cost)
                         }
+                        // NonCounted is unwrapped via underlying() above.
+                        Element::NonCounted(_) => unreachable!("unwrapped above"),
                     }
                 }
                 GroveOp::InsertWithKnownToNotAlreadyExist { element }
-                | GroveOp::InsertIfNotExists { element, .. } => match element {
+                | GroveOp::InsertIfNotExists { element, .. } => match element.underlying() {
                     Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
                         let serialized = cost_return_on_error_into_no_add!(
                             cost,
@@ -1668,6 +1679,8 @@ where
                         ))
                         .wrap_with_cost(cost)
                     }
+                    // NonCounted is unwrapped via underlying() above.
+                    Element::NonCounted(_) => unreachable!("unwrapped above"),
                 },
                 GroveOp::RefreshReference {
                     reference_path_type,
@@ -1851,7 +1864,11 @@ where
                         }
                     }
 
-                    match &element {
+                    // Look through NonCounted; methods called on `element`
+                    // (serialize, get_feature_type, insert_*_into_batch_operations,
+                    // element_at_key_already_exists) are wrapper-aware via the
+                    // helper methods updated in grovedb-element.
+                    match element.underlying() {
                         Element::Reference(path_reference, element_max_reference_hop, _) => {
                             // Check existence for InsertIfNotExists on references
                             if is_insert_if_not_exists
@@ -2041,6 +2058,8 @@ where
                                 );
                             }
                         }
+                        // NonCounted is unwrapped via underlying() above.
+                        Element::NonCounted(_) => unreachable!("unwrapped above"),
                     }
                 }
                 GroveOp::RefreshReference {

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -2119,7 +2119,12 @@ where
                         )
                     };
 
-                    let Element::Reference(path_reference, max_reference_hop, _) = &element else {
+                    // Look through `NonCounted` so a wrapped reference can
+                    // still be refreshed. The wrapper is transparent for
+                    // refresh; only the inner reference's path matters.
+                    let Element::Reference(path_reference, max_reference_hop, _) =
+                        element.underlying()
+                    else {
                         return Err(Error::InvalidInput(
                             "trying to refresh a an element that is not a reference",
                         ))

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -2439,8 +2439,18 @@ where
                                     })?,
                                 );
                                 // we need to give back the value defined cost in the case that the
-                                // new element is a tree
-                                match new_element {
+                                // new element is a tree.
+                                //
+                                // Look through `NonCounted` for the cost path
+                                // (the wrapper byte costs +1 over the bare
+                                // type, mirroring `wrapper_overhead` in
+                                // `merk/src/element/costs.rs`).
+                                let wrapper_overhead = if new_element.is_non_counted() {
+                                    1u32
+                                } else {
+                                    0
+                                };
+                                match new_element.underlying() {
                                     Element::Tree(..)
                                     | Element::SumTree(..)
                                     | Element::BigSumTree(..)
@@ -2458,13 +2468,15 @@ where
                                         let tree_cost_size = tree_type.cost_size();
                                         let tree_value_cost = tree_cost_size
                                             + flags_len
-                                            + flags_len.required_space() as u32;
+                                            + flags_len.required_space() as u32
+                                            + wrapper_overhead;
                                         Ok((true, Some(LayeredValueDefinedCost(tree_value_cost))))
                                     }
                                     Element::SumItem(..) => {
                                         let sum_item_value_cost = SUM_ITEM_COST_SIZE
                                             + flags_len
-                                            + flags_len.required_space() as u32;
+                                            + flags_len.required_space() as u32
+                                            + wrapper_overhead;
                                         Ok((
                                             true,
                                             Some(SpecializedValueDefinedCost(sum_item_value_cost)),
@@ -2476,7 +2488,8 @@ where
                                             + flags_len
                                             + flags_len.required_space() as u32
                                             + item_len
-                                            + item_len.required_space() as u32;
+                                            + item_len.required_space() as u32
+                                            + wrapper_overhead;
                                         Ok((
                                             true,
                                             Some(SpecializedValueDefinedCost(sum_item_value_cost)),

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1441,12 +1441,10 @@ where
             .wrap_with_cost(cost);
         };
 
-        // Look through `NonCounted` for dispatch — the wrapper does not change
-        // how a referenced value is hashed or how a tree/reference is processed.
-        // The actual `element.serialize()` below preserves the wrapper byte
-        // when present, so the resulting value hash matches what's on disk.
-        let element = element.into_underlying();
-        match element {
+        // Dispatch on the underlying element type but compute the value hash
+        // from the OUTER element's serialized bytes. Storage keeps the
+        // wrapper byte; the on-disk value hash must reflect that.
+        match element.underlying() {
             Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
                 let serialized =
                     cost_return_on_error_into_no_add!(cost, element.serialize(grove_version));
@@ -1456,7 +1454,7 @@ where
             Element::Reference(path, ..) => {
                 let path = cost_return_on_error_into_no_add!(
                     cost,
-                    path_from_reference_qualified_path_type(path, qualified_path)
+                    path_from_reference_qualified_path_type(path.clone(), qualified_path)
                 );
                 self.follow_reference_get_value_hash(
                     path.as_slice(),
@@ -1482,8 +1480,10 @@ where
                 "references can not point to trees being updated",
             ))
             .wrap_with_cost(cost),
-            // NonCounted is unwrapped above via into_underlying().
-            Element::NonCounted(_) => unreachable!("unwrapped above"),
+            // underlying() unwraps a single level; the constructor and
+            // (de)serializer reject nested NonCounted, so this is unreachable
+            // by construction.
+            Element::NonCounted(_) => unreachable!("NonCounted may not nest"),
         }
     }
 
@@ -2615,6 +2615,14 @@ impl GroveDb {
                                                 | GroveOp::InsertIfNotExists { element, .. }
                                                 | GroveOp::Replace { element }
                                                 | GroveOp::Patch { element, .. } => {
+                                                    // Look through NonCounted: a wrapped tree
+                                                    // still needs to be converted into the
+                                                    // appropriate InsertTreeWithRootHash /
+                                                    // InsertNonMerkTree variant during
+                                                    // upward propagation, otherwise the chain
+                                                    // below would fall into the "non tree"
+                                                    // error path.
+                                                    let element = element.underlying();
                                                     // Standard Merk trees
                                                     if let Element::Tree(_, flags) = element {
                                                         *mutable_occupied_entry =

--- a/grovedb/src/debugger.rs
+++ b/grovedb/src/debugger.rs
@@ -791,6 +791,9 @@ fn element_to_grovedbg(element: crate::Element) -> grovedbg_types::Element {
                 element_flags,
             }
         }
+        // The visualizer wire format has no NonCounted variant; render the
+        // inner element. The wrapper is invisible at the debug-UI layer.
+        crate::Element::NonCounted(inner) => element_to_grovedbg(*inner),
     }
 }
 

--- a/grovedb/src/element/aggregate_sum_query/mod.rs
+++ b/grovedb/src/element/aggregate_sum_query/mod.rs
@@ -772,7 +772,10 @@ impl ElementAggregateSumQueryExtensions for Element {
 
         let element = element.convert_if_reference_to_absolute_reference(path, key)?;
 
-        let value = match element {
+        // Look through `NonCounted`: a wrapped sum item is exactly the kind
+        // of element this aggregator should accept (suppress the count
+        // contribution while still totaling the sum).
+        let value = match element.into_underlying() {
             Element::SumItem(value, _) => value,
             Element::ItemWithSumItem(_, value, _) => value,
             _ => return Err(Error::InvalidInput("Only sum items are allowed")),

--- a/grovedb/src/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/estimated_costs/average_case_costs.rs
@@ -326,7 +326,11 @@ impl GroveDb {
 
         let mut cost = OperationCost::default();
         let key_len = key.max_length() as u32;
-        match value {
+        // Look through `NonCounted` for cost dispatch (the wrapper byte is
+        // accounted for via `wrapper_overhead` parallel to
+        // `merk/src/element/costs.rs`).
+        let wrapper_overhead = if value.is_non_counted() { 1u32 } else { 0 };
+        match value.underlying() {
             Element::Tree(_, flags)
             | Element::SumTree(_, _, flags)
             | Element::BigSumTree(_, _, flags)
@@ -336,7 +340,7 @@ impl GroveDb {
                     flags_len + flags_len.required_space() as u32
                 });
                 let tree_cost_size = value.tree_type().unwrap().cost_size();
-                let value_len = tree_cost_size + flags_len;
+                let value_len = tree_cost_size + flags_len + wrapper_overhead;
                 add_cost_case_merk_replace_layered(&mut cost, key_len, value_len, in_tree_type)
             }
             Element::Item(_, flags) | Element::SumItem(_, flags) => {
@@ -351,7 +355,7 @@ impl GroveDb {
                     cost_return_on_error_into_no_add!(cost, value.serialized_size(grove_version))
                         as u32
                 };
-                let value_len = sum_item_cost_size + flags_len;
+                let value_len = sum_item_cost_size + flags_len + wrapper_overhead;
                 add_cost_case_merk_replace_same_size(&mut cost, key_len, value_len, in_tree_type)
             }
             _ => add_cost_case_merk_replace_same_size(

--- a/grovedb/src/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/estimated_costs/worst_case_costs.rs
@@ -186,7 +186,9 @@ impl GroveDb {
 
         let mut cost = OperationCost::default();
         let key_len = key.max_length() as u32;
-        match value {
+        // Look through `NonCounted` for cost dispatch.
+        let wrapper_overhead = if value.is_non_counted() { 1u32 } else { 0 };
+        match value.underlying() {
             Element::Tree(_, flags)
             | Element::SumTree(_, _, flags)
             | Element::BigSumTree(_, _, flags)
@@ -196,7 +198,7 @@ impl GroveDb {
                     flags_len + flags_len.required_space() as u32
                 });
                 let tree_cost_size = value.tree_type().unwrap().cost_size();
-                let value_len = tree_cost_size + flags_len;
+                let value_len = tree_cost_size + flags_len + wrapper_overhead;
                 add_cost_case_merk_insert_layered(
                     &mut cost,
                     key_len,
@@ -241,7 +243,9 @@ impl GroveDb {
 
         let mut cost = OperationCost::default();
         let key_len = key.max_length() as u32;
-        match value {
+        // Look through `NonCounted` for cost dispatch.
+        let wrapper_overhead = if value.is_non_counted() { 1u32 } else { 0 };
+        match value.underlying() {
             Element::Tree(_, flags) | Element::SumTree(_, _, flags) => {
                 let flags_len = flags.as_ref().map_or(0, |flags| {
                     let flags_len = flags.len() as u32;
@@ -252,7 +256,7 @@ impl GroveDb {
                 } else {
                     TREE_COST_SIZE
                 };
-                let value_len = tree_cost_size + flags_len;
+                let value_len = tree_cost_size + flags_len + wrapper_overhead;
                 add_cost_case_merk_replace_layered(
                     &mut cost,
                     key_len,

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -956,7 +956,10 @@ impl GroveDb {
         let mut element_iterator = KVIterator::new(merk.storage.raw_iter(), &all_query).unwrap();
 
         while let Some((key, element_value)) = element_iterator.next_kv().unwrap() {
-            let element = Element::raw_decode(&element_value, grove_version)?;
+            // Look through NonCounted: verification dispatches on inner type.
+            // The on-disk value bytes are still the wrapper bytes, so the
+            // hash checks below operate on those.
+            let element = Element::raw_decode(&element_value, grove_version)?.into_underlying();
             match element {
                 Element::SumTree(..)
                 | Element::Tree(..)
@@ -1107,6 +1110,7 @@ impl GroveDb {
                         );
                     }
                 }
+                Element::NonCounted(_) => unreachable!("unwrapped above"),
             }
         }
         Ok(issues)

--- a/grovedb/src/operations/bulk_append_tree.rs
+++ b/grovedb/src/operations/bulk_append_tree.rs
@@ -57,7 +57,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let (total_count, chunk_power, existing_flags) = match &element {
+        // Look through NonCounted: a wrapped BulkAppendTree is still one.
+        let (total_count, chunk_power, existing_flags) = match element.underlying() {
             Element::BulkAppendTree(tc, cp, flags) => (*tc, *cp, flags.clone()),
             _ => {
                 return Err(Error::InvalidInput("element is not a BulkAppendTree"))
@@ -189,7 +190,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let (total_count, chunk_power) = match &element {
+        // Look through NonCounted: a wrapped BulkAppendTree is still one.
+        let (total_count, chunk_power) = match element.underlying() {
             Element::BulkAppendTree(tc, cp, _) => (*tc, *cp),
             _ => {
                 return Err(Error::InvalidInput("element is not a BulkAppendTree"))
@@ -273,7 +275,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let (total_count, chunk_power) = match &element {
+        // Look through NonCounted: a wrapped BulkAppendTree is still one.
+        let (total_count, chunk_power) = match element.underlying() {
             Element::BulkAppendTree(tc, cp, _) => (*tc, *cp),
             _ => {
                 return Err(Error::InvalidInput("element is not a BulkAppendTree"))
@@ -326,7 +329,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let (total_count, chunk_power) = match &element {
+        // Look through NonCounted: a wrapped BulkAppendTree is still one.
+        let (total_count, chunk_power) = match element.underlying() {
             Element::BulkAppendTree(tc, cp, _) => (*tc, *cp),
             _ => {
                 return Err(Error::InvalidInput("element is not a BulkAppendTree"))
@@ -386,7 +390,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path, key, true, transaction, grove_version)
         );
 
-        match element {
+        // Look through NonCounted: a wrapped BulkAppendTree is still one.
+        match element.into_underlying() {
             Element::BulkAppendTree(total_count, ..) => Ok(total_count).wrap_with_cost(cost),
             _ => Err(Error::InvalidInput("element is not a BulkAppendTree")).wrap_with_cost(cost),
         }
@@ -412,7 +417,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path, key, true, transaction, grove_version)
         );
 
-        match element {
+        // Look through NonCounted: a wrapped BulkAppendTree is still one.
+        match element.into_underlying() {
             Element::BulkAppendTree(total_count, chunk_power, _) => {
                 Ok(total_count / (1u32 << chunk_power) as u64).wrap_with_cost(cost)
             }
@@ -499,7 +505,8 @@ impl GroveDb {
                 )
             );
 
-            let (total_count, chunk_power, _flags) = match &element {
+            // Look through NonCounted: a wrapped BulkAppendTree is still one.
+            let (total_count, chunk_power, _flags) = match element.underlying() {
                 Element::BulkAppendTree(tc, cp, flags) => (*tc, *cp, flags.clone()),
                 _ => {
                     return Err(Error::InvalidInput("element is not a BulkAppendTree"))

--- a/grovedb/src/operations/commitment_tree.rs
+++ b/grovedb/src/operations/commitment_tree.rs
@@ -111,7 +111,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let (total_count, chunk_power, existing_flags) = match &element {
+        // Look through NonCounted: a wrapped CommitmentTree is still one.
+        let (total_count, chunk_power, existing_flags) = match element.underlying() {
             Element::CommitmentTree(total_count, chunk_power, flags) => {
                 (*total_count, *chunk_power, flags.clone())
             }
@@ -262,7 +263,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let (total_count, chunk_power) = match &element {
+        // Look through NonCounted: a wrapped CommitmentTree is still one.
+        let (total_count, chunk_power) = match element.underlying() {
             Element::CommitmentTree(tc, cp, _) => (*tc, *cp),
             _ => {
                 return Err(Error::InvalidInput("element is not a commitment tree"))
@@ -313,7 +315,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let (total_count, chunk_power) = match &element {
+        // Look through NonCounted: a wrapped CommitmentTree is still one.
+        let (total_count, chunk_power) = match element.underlying() {
             Element::CommitmentTree(tc, cp, _) => (*tc, *cp),
             _ => {
                 return Err(Error::InvalidInput("element is not a commitment tree"))
@@ -393,7 +396,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path, key, true, transaction, grove_version)
         );
 
-        match element {
+        // Look through NonCounted: a wrapped CommitmentTree is still one.
+        match element.into_underlying() {
             Element::CommitmentTree(total_count, ..) => Ok(total_count).wrap_with_cost(cost),
             _ => Err(Error::InvalidInput("element is not a commitment tree")).wrap_with_cost(cost),
         }
@@ -484,7 +488,8 @@ impl GroveDb {
                 )
             );
 
-            let (total_count, chunk_power) = match &element {
+            // Look through NonCounted: a wrapped CommitmentTree is still one.
+            let (total_count, chunk_power) = match element.underlying() {
                 Element::CommitmentTree(tc, cp, _) => (*tc, *cp),
                 _ => {
                     return Err(Error::InvalidInput("element is not a commitment tree"))

--- a/grovedb/src/operations/dense_tree.rs
+++ b/grovedb/src/operations/dense_tree.rs
@@ -54,7 +54,9 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let (existing_count, height, existing_flags) = match &element {
+        // Look through NonCounted: a wrapped DenseAppendOnlyFixedSizeTree
+        // is still one.
+        let (existing_count, height, existing_flags) = match element.underlying() {
             Element::DenseAppendOnlyFixedSizeTree(count, h, flags) => (*count, *h, flags.clone()),
             _ => {
                 return Err(Error::InvalidInput("element is not a dense tree"))
@@ -183,7 +185,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let count = match &element {
+        // Look through NonCounted: a wrapped dense tree is still one.
+        let count = match element.underlying() {
             Element::DenseAppendOnlyFixedSizeTree(count, ..) => *count,
             _ => {
                 return Err(Error::InvalidInput("element is not a dense tree"))
@@ -238,7 +241,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let (count, height) = match &element {
+        // Look through NonCounted: a wrapped dense tree is still one.
+        let (count, height) = match element.underlying() {
             Element::DenseAppendOnlyFixedSizeTree(count, h, _) => (*count, *h),
             _ => {
                 return Err(Error::InvalidInput("element is not a dense tree"))
@@ -294,7 +298,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path, key, true, transaction, grove_version)
         );
 
-        match element {
+        // Look through NonCounted: a wrapped dense tree is still one.
+        match element.into_underlying() {
             Element::DenseAppendOnlyFixedSizeTree(count, ..) => Ok(count).wrap_with_cost(cost),
             _ => Err(Error::InvalidInput("element is not a dense tree")).wrap_with_cost(cost),
         }
@@ -377,7 +382,8 @@ impl GroveDb {
                 )
             );
 
-            let (existing_count, height) = match &element {
+            // Look through NonCounted: a wrapped dense tree is still one.
+            let (existing_count, height) = match element.underlying() {
                 Element::DenseAppendOnlyFixedSizeTree(count, h, _) => (*count, *h),
                 _ => {
                     return Err(Error::InvalidInput("element is not a dense tree"))

--- a/grovedb/src/operations/get/mod.rs
+++ b/grovedb/src/operations/get/mod.rs
@@ -70,6 +70,8 @@ impl GroveDb {
 
         let mut cost = OperationCost::default();
 
+        // Look through `NonCounted` so a wrapped reference still resolves.
+        // The wrapper is transparent at the get/query layer.
         match cost_return_on_error!(
             &mut cost,
             self.get_raw_caching_optional(
@@ -79,7 +81,9 @@ impl GroveDb {
                 transaction,
                 grove_version
             )
-        ) {
+        )
+        .into_underlying()
+        {
             Element::Reference(reference_path, ..) => {
                 let path_owned = cost_return_on_error_into!(
                     &mut cost,
@@ -156,7 +160,9 @@ impl GroveDb {
                 return Err(Error::CorruptedPath("empty path".to_string())).wrap_with_cost(cost);
             }
             visited.insert(current_path.clone());
-            match current_element {
+            // Look through `NonCounted` so a chain that hops via a wrapped
+            // reference is followed instead of being returned as a value.
+            match current_element.into_underlying() {
                 Element::Reference(reference_path, ..) => {
                     current_path = cost_return_on_error_into!(
                         &mut cost,

--- a/grovedb/src/operations/get/mod.rs
+++ b/grovedb/src/operations/get/mod.rs
@@ -390,7 +390,12 @@ impl GroveDb {
                     .map_err(|e| e.into())
             }
             .unwrap_add_cost(&mut cost);
-            match element {
+            // Look through `NonCounted` so a parent stored as
+            // `NonCounted(Tree)` (or any wrapped tree variant) still
+            // validates as a subtree. Without this, APIs that gate on
+            // check_subtree_exists would reject paths through wrapped
+            // parents — breaking the wrapper-transparency contract.
+            match element.map(|e| e.into_underlying()) {
                 Ok(Element::Tree(..))
                 | Ok(Element::SumTree(..))
                 | Ok(Element::BigSumTree(..))

--- a/grovedb/src/operations/get/query.rs
+++ b/grovedb/src/operations/get/query.rs
@@ -87,33 +87,42 @@ impl GroveDb {
         let results_wrapped = elements
             .into_iterator()
             .map(|result_item| match result_item {
-                QueryResultElement::ElementResultItem(Element::Reference(reference_path, ..)) => {
-                    match reference_path {
-                        ReferencePathType::AbsolutePathReference(absolute_path) => {
-                            // While `map` on iterator is lazy, we should accumulate costs even if
-                            // `collect` will end in `Err`, so we'll use
-                            // external costs accumulator instead of
-                            // returning costs from `map` call.
-                            let maybe_item = self
-                                .follow_reference(
-                                    absolute_path.as_slice().into(),
-                                    allow_cache,
-                                    transaction,
-                                    grove_version,
-                                )
-                                .unwrap_add_cost(&mut cost)?;
+                QueryResultElement::ElementResultItem(element) => {
+                    // Look through `NonCounted` so a wrapped reference still
+                    // resolves; the wrapper is transparent at the query
+                    // layer.
+                    match element.into_underlying() {
+                        Element::Reference(reference_path, ..) => match reference_path {
+                            ReferencePathType::AbsolutePathReference(absolute_path) => {
+                                // While `map` on iterator is lazy, we should accumulate costs
+                                // even if `collect` will end in `Err`, so we'll use
+                                // external costs accumulator instead of
+                                // returning costs from `map` call.
+                                let maybe_item = self
+                                    .follow_reference(
+                                        absolute_path.as_slice().into(),
+                                        allow_cache,
+                                        transaction,
+                                        grove_version,
+                                    )
+                                    .unwrap_add_cost(&mut cost)?;
 
-                            match maybe_item {
-                                Element::Item(item, _) => Ok(item),
-                                Element::ItemWithSumItem(item, ..) => Ok(item),
-                                Element::SumItem(value, _) => Ok(value.encode_var_vec()),
-                                _ => {
-                                    Err(Error::InvalidQuery("the reference must result in an item"))
+                                // Same treatment for the resolved value.
+                                match maybe_item.into_underlying() {
+                                    Element::Item(item, _) => Ok(item),
+                                    Element::ItemWithSumItem(item, ..) => Ok(item),
+                                    Element::SumItem(value, _) => Ok(value.encode_var_vec()),
+                                    _ => Err(Error::InvalidQuery(
+                                        "the reference must result in an item",
+                                    )),
                                 }
                             }
-                        }
-                        _ => Err(Error::CorruptedCodeExecution(
-                            "reference after query must have absolute paths",
+                            _ => Err(Error::CorruptedCodeExecution(
+                                "reference after query must have absolute paths",
+                            )),
+                        },
+                        _ => Err(Error::InvalidQuery(
+                            "path_queries can only refer to references",
                         )),
                     }
                 }

--- a/grovedb/src/operations/get/query.rs
+++ b/grovedb/src/operations/get/query.rs
@@ -222,6 +222,9 @@ where {
                         // end in `Err`, so we'll use
                         // external costs accumulator instead of
                         // returning costs from `map` call.
+                        // Normalize the resolved value too, so a Reference
+                        // pointing at NonCounted(Item) returns the same shape
+                        // as a directly-queried NonCounted(Item).
                         let maybe_item = self
                             .follow_reference(
                                 absolute_path.as_slice().into(),
@@ -229,7 +232,8 @@ where {
                                 transaction,
                                 grove_version,
                             )
-                            .unwrap_add_cost(cost)?;
+                            .unwrap_add_cost(cost)?
+                            .into_underlying();
 
                         if maybe_item.is_any_item() {
                             Ok(maybe_item)

--- a/grovedb/src/operations/get/query.rs
+++ b/grovedb/src/operations/get/query.rs
@@ -209,6 +209,10 @@ where {
                 .query
                 .follow_element
         );
+        // Look through NonCounted: a NonCounted-wrapped reference still
+        // resolves; a NonCounted item still returns itself. The wrapper's
+        // sole effect is on parent count aggregation.
+        let element = element.into_underlying();
         match element {
             Element::Reference(reference_path, ..) => {
                 match reference_path {
@@ -254,6 +258,7 @@ where {
             | Element::DenseAppendOnlyFixedSizeTree(..) => {
                 Err(Error::InvalidQuery("path_queries can not refer to trees"))
             }
+            Element::NonCounted(_) => unreachable!("unwrapped above"),
         }
     }
 
@@ -338,6 +343,8 @@ where {
             .into_iterator()
             .map(|result_item| match result_item {
                 QueryResultElement::ElementResultItem(element) => {
+                    // NonCounted is transparent at this layer.
+                    let element = element.into_underlying();
                     match element {
                         Element::Reference(reference_path, ..) => {
                             match reference_path {
@@ -356,7 +363,7 @@ where {
                                         )
                                         .unwrap_add_cost(&mut cost)?;
 
-                                    match maybe_item {
+                                    match maybe_item.into_underlying() {
                                         Element::Item(item, _)
                                         | Element::ItemWithSumItem(item, ..) => Ok(item),
                                         Element::SumItem(item, _) => Ok(item.encode_var_vec()),
@@ -385,6 +392,7 @@ where {
                         | Element::DenseAppendOnlyFixedSizeTree(..) => Err(Error::InvalidQuery(
                             "path_queries can only refer to items and references",
                         )),
+                        Element::NonCounted(_) => unreachable!("unwrapped above"),
                     }
                 }
                 _ => Err(Error::CorruptedCodeExecution(
@@ -435,6 +443,8 @@ where {
             .into_iterator()
             .map(|result_item| match result_item {
                 QueryResultElement::ElementResultItem(element) => {
+                    // NonCounted is transparent at this layer.
+                    let element = element.into_underlying();
                     match element {
                         Element::Reference(reference_path, ..) => {
                             match reference_path {
@@ -453,7 +463,7 @@ where {
                                         )
                                         .unwrap_add_cost(&mut cost)?;
 
-                                    match maybe_item {
+                                    match maybe_item.into_underlying() {
                                         Element::Item(item, _) => {
                                             Ok(QueryItemOrSumReturnType::ItemData(item))
                                         }
@@ -535,6 +545,7 @@ where {
                             "path_queries can only refer to items, sum items, references and sum \
                              trees",
                         )),
+                        Element::NonCounted(_) => unreachable!("unwrapped above"),
                     }
                 }
                 _ => Err(Error::CorruptedCodeExecution(
@@ -665,6 +676,8 @@ where {
             .into_iterator()
             .map(|result_item| match result_item {
                 QueryResultElement::ElementResultItem(element) => {
+                    // NonCounted is transparent at this layer.
+                    let element = element.into_underlying();
                     match element {
                         Element::Reference(reference_path, ..) => {
                             match reference_path {
@@ -683,7 +696,8 @@ where {
                                         )
                                         .unwrap_add_cost(&mut cost)?;
 
-                                    if let Element::SumItem(item, _) = maybe_item {
+                                    if let Element::SumItem(item, _) = maybe_item.into_underlying()
+                                    {
                                         Ok(item)
                                     } else {
                                         Err(Error::InvalidQuery(
@@ -714,6 +728,7 @@ where {
                             "path_queries over sum items can only refer to sum items and \
                              references",
                         )),
+                        Element::NonCounted(_) => unreachable!("unwrapped above"),
                     }
                 }
                 _ => Err(Error::CorruptedCodeExecution(

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -241,8 +241,12 @@ impl GroveDb {
             }
         }
 
-        match element {
-            Element::Reference(ref reference_path, ..) => {
+        // Dispatch via the underlying element so a NonCounted wrapper takes
+        // the same path as its inner element. The actual `element.insert*`
+        // calls operate on the outer wrapper, which is what we want — the
+        // serialized wrapper bytes go to storage.
+        match element.underlying() {
+            Element::Reference(reference_path, ..) => {
                 let path = path.to_vec(); // TODO: need for support for references in path library
                 let reference_path = cost_return_on_error_into!(
                     &mut cost,
@@ -276,13 +280,13 @@ impl GroveDb {
                     )
                 );
             }
-            Element::Tree(ref value, _)
-            | Element::SumTree(ref value, ..)
-            | Element::BigSumTree(ref value, ..)
-            | Element::CountTree(ref value, ..)
-            | Element::CountSumTree(ref value, ..)
-            | Element::ProvableCountTree(ref value, ..)
-            | Element::ProvableCountSumTree(ref value, ..) => {
+            Element::Tree(value, _)
+            | Element::SumTree(value, ..)
+            | Element::BigSumTree(value, ..)
+            | Element::CountTree(value, ..)
+            | Element::CountSumTree(value, ..)
+            | Element::ProvableCountTree(value, ..)
+            | Element::ProvableCountSumTree(value, ..) => {
                 if value.is_some() {
                     return Err(Error::InvalidCodeExecution(
                         "a tree should be empty at the moment of insertion when not using batches",
@@ -343,6 +347,7 @@ impl GroveDb {
                     )
                 );
             }
+            Element::NonCounted(_) => unreachable!("unwrapped above"),
         }
 
         Ok(subtree_to_insert_into).wrap_with_cost(cost)

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -347,7 +347,16 @@ impl GroveDb {
                     )
                 );
             }
-            Element::NonCounted(_) => unreachable!("unwrapped above"),
+            // `underlying()` only unwraps one level; nested NonCounted is
+            // forbidden by the constructor and (de)serializer, but the public
+            // insert path can still receive a hand-built nested wrapper —
+            // return a typed error rather than panic.
+            Element::NonCounted(_) => {
+                return Err(Error::InvalidInput(
+                    "nested NonCounted wrappers are not allowed",
+                ))
+                .wrap_with_cost(cost);
+            }
         }
 
         Ok(subtree_to_insert_into).wrap_with_cost(cost)

--- a/grovedb/src/operations/mmr_tree.rs
+++ b/grovedb/src/operations/mmr_tree.rs
@@ -57,7 +57,10 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let (mmr_size, existing_flags) = match &element {
+        // Look through `NonCounted`: a wrapped MmrTree is still an MmrTree
+        // for typed-API purposes; the wrapper only affects parent count
+        // aggregation.
+        let (mmr_size, existing_flags) = match element.underlying() {
             Element::MmrTree(size, flags) => (*size, flags.clone()),
             _ => {
                 return Err(Error::InvalidInput("element is not an MMR tree")).wrap_with_cost(cost);
@@ -199,7 +202,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let mmr_size = match &element {
+        // Look through NonCounted: a wrapped MmrTree is still an MmrTree.
+        let mmr_size = match element.underlying() {
             Element::MmrTree(size, _) => *size,
             _ => {
                 return Err(Error::InvalidInput("element is not an MMR tree")).wrap_with_cost(cost);
@@ -257,7 +261,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path.clone(), key, true, transaction, grove_version)
         );
 
-        let mmr_size = match &element {
+        // Look through NonCounted: a wrapped MmrTree is still an MmrTree.
+        let mmr_size = match element.underlying() {
             Element::MmrTree(size, _) => *size,
             _ => {
                 return Err(Error::InvalidInput("element is not an MMR tree")).wrap_with_cost(cost);
@@ -320,7 +325,8 @@ impl GroveDb {
             self.get_raw_caching_optional(path, key, true, transaction, grove_version)
         );
 
-        match element {
+        // Look through NonCounted: a wrapped MmrTree is still an MmrTree.
+        match element.into_underlying() {
             Element::MmrTree(mmr_size, _) => {
                 Ok(mmr_size_to_leaf_count(mmr_size)).wrap_with_cost(cost)
             }
@@ -412,7 +418,8 @@ impl GroveDb {
                 )
             );
 
-            let mmr_size = match &element {
+            // Look through NonCounted: a wrapped MmrTree is still an MmrTree.
+            let mmr_size = match element.underlying() {
                 Element::MmrTree(size, _) => *size,
                 _ => {
                     return Err(Error::InvalidInput("element is not an MMR tree"))

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -332,7 +332,11 @@ impl GroveDb {
                     | Node::KVValueHashFeatureType(key, value, ..)
                         if !done_with_results =>
                     {
-                        let elem = Element::deserialize(value, grove_version);
+                        // Look through NonCounted: dispatch on inner type.
+                        // The serialized `value` (which is what's hashed in
+                        // the proof) keeps its wrapper byte either way.
+                        let elem =
+                            Element::deserialize(value, grove_version).map(|e| e.into_underlying());
                         match elem {
                             Ok(Element::Reference(reference_path, ..)) => {
                                 let absolute_path = cost_return_on_error_into!(
@@ -524,6 +528,8 @@ impl GroveDb {
                             | Ok(Element::MmrTree(..))
                             | Ok(Element::BulkAppendTree(..))
                             | Ok(Element::DenseAppendOnlyFixedSizeTree(..)) => continue,
+                            // NonCounted is unwrapped above via into_underlying().
+                            Ok(Element::NonCounted(_)) => unreachable!("unwrapped above"),
                             Err(e) => {
                                 return Err(Error::CorruptedData(format!(
                                     "failed to deserialize element during proof generation: {e}"
@@ -1047,7 +1053,11 @@ impl GroveDb {
                     | Node::KVValueHashFeatureType(key, value, ..)
                         if !done_with_results =>
                     {
-                        let elem = Element::deserialize(value, grove_version);
+                        // Look through NonCounted: dispatch on inner type.
+                        // The serialized `value` (which is what's hashed in
+                        // the proof) keeps its wrapper byte either way.
+                        let elem =
+                            Element::deserialize(value, grove_version).map(|e| e.into_underlying());
                         match elem {
                             Ok(Element::Reference(reference_path, ..)) => {
                                 let absolute_path = cost_return_on_error_into!(
@@ -1353,6 +1363,8 @@ impl GroveDb {
                             | Ok(Element::MmrTree(..))
                             | Ok(Element::BulkAppendTree(..))
                             | Ok(Element::DenseAppendOnlyFixedSizeTree(..)) => continue,
+                            // NonCounted is unwrapped above via into_underlying().
+                            Ok(Element::NonCounted(_)) => unreachable!("unwrapped above"),
                             Err(e) => {
                                 return Err(Error::CorruptedData(format!(
                                     "failed to deserialize element during proof generation: {e}"

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -482,7 +482,11 @@ impl GroveDb {
                 let key = &proved_key_value.key;
                 let hash = &proved_key_value.proof;
                 if let Some(value_bytes) = &proved_key_value.value {
-                    let element = Element::deserialize(value_bytes, grove_version)?;
+                    // Look through NonCounted: dispatch on inner element. The
+                    // serialized value bytes used for hashing keep their
+                    // wrapper byte, so cryptographic verification still works.
+                    let element =
+                        Element::deserialize(value_bytes, grove_version)?.into_underlying();
 
                     verified_keys.insert(key.clone());
 
@@ -639,6 +643,7 @@ impl GroveDb {
                                     "V1 proof has lower layer for a non-tree element.".to_string(),
                                 ));
                             }
+                            Element::NonCounted(_) => unreachable!("unwrapped above"),
                         }
                     } else if element.is_any_item()
                         || !internal_query.has_subquery_or_matching_in_path_on_key(key)
@@ -1446,7 +1451,10 @@ impl GroveDb {
                 let key = &proved_key_value.key;
                 let hash = &proved_key_value.proof;
                 if let Some(value_bytes) = &proved_key_value.value {
-                    let element = Element::deserialize(value_bytes, grove_version)?;
+                    // Look through NonCounted: dispatch on inner element. The
+                    // serialized value bytes still hash to the on-disk value.
+                    let element =
+                        Element::deserialize(value_bytes, grove_version)?.into_underlying();
 
                     verified_keys.insert(key.clone());
 
@@ -1598,6 +1606,7 @@ impl GroveDb {
                                     "Proof has lower layer for a non Tree.".to_string(),
                                 ));
                             }
+                            Element::NonCounted(_) => unreachable!("unwrapped above"),
                         }
                     } else if element.is_any_item()
                         || !internal_query.has_subquery_or_matching_in_path_on_key(key)

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -2670,9 +2670,11 @@ impl GroveDb {
     }
 
     /// Extract the count from a CountTree, CountSumTree, ProvableCountTree,
-    /// or ProvableCountSumTree element.
+    /// or ProvableCountSumTree element. Looks through `NonCounted` so that a
+    /// trunk proof rooted at a wrapped count tree still extracts the inner
+    /// tree's count.
     fn extract_count_from_element(element: &Element) -> Option<u64> {
-        match element {
+        match element.underlying() {
             Element::CountTree(_, count, _)
             | Element::CountSumTree(_, count, ..)
             | Element::ProvableCountTree(_, count, _)

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -160,7 +160,7 @@ impl GroveDb {
                     .is_empty()
                     .then(Vec::new)
                     .into_iter()
-                    .chain(nested_chunk_ids.into_iter())
+                    .chain(nested_chunk_ids)
                 {
                     let (chunk, _) =
                         chunk_producer

--- a/grovedb/src/tests/batch_coverage_tests.rs
+++ b/grovedb/src/tests/batch_coverage_tests.rs
@@ -539,6 +539,8 @@ mod tests {
                 root_key: None,
                 flags: None,
                 aggregate_data: AggregateData::NoAggregateData,
+
+                non_counted: false,
             },
         };
 
@@ -582,6 +584,8 @@ mod tests {
                 flags: None,
                 aggregate_data: AggregateData::NoAggregateData,
                 meta: NonMerkTreeMeta::MmrTree { mmr_size: 0 },
+
+                non_counted: false,
             },
         };
 

--- a/grovedb/src/tests/batch_rejection_tests.rs
+++ b/grovedb/src/tests/batch_rejection_tests.rs
@@ -74,6 +74,8 @@ fn test_apply_batch_rejects_insert_tree_with_root_hash() {
             root_key: None,
             flags: None,
             aggregate_data: AggregateData::NoAggregateData,
+
+            non_counted: false,
         },
     };
 
@@ -111,6 +113,8 @@ fn test_apply_batch_rejects_insert_non_merk_tree() {
             flags: None,
             aggregate_data: AggregateData::NoAggregateData,
             meta: NonMerkTreeMeta::MmrTree { mmr_size: 0 },
+
+            non_counted: false,
         },
     };
 

--- a/grovedb/src/tests/batch_unit_tests.rs
+++ b/grovedb/src/tests/batch_unit_tests.rs
@@ -93,6 +93,8 @@ mod tests {
                 root_key: None,
                 flags: None,
                 aggregate_data: AggregateData::NoAggregateData,
+
+                non_counted: false,
             },
             GroveOp::ReplaceTreeRootKey {
                 // 4
@@ -150,6 +152,8 @@ mod tests {
                 flags: None,
                 aggregate_data: AggregateData::NoAggregateData,
                 meta: meta_commitment,
+
+                non_counted: false,
             },
         ];
 
@@ -467,6 +471,8 @@ mod tests {
                 root_key: None,
                 flags: None,
                 aggregate_data: AggregateData::NoAggregateData,
+
+                non_counted: false,
             },
         };
         let dbg = format!("{:?}", internal_op2);
@@ -496,6 +502,8 @@ mod tests {
                 flags: None,
                 aggregate_data: AggregateData::NoAggregateData,
                 meta: meta2,
+
+                non_counted: false,
             },
         };
         let dbg = format!("{:?}", internal_op4);

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -27,6 +27,7 @@ mod grove_query_result_tests;
 mod is_empty_tree_tests;
 mod misc_coverage_tests;
 mod mmr_tree_tests;
+mod non_counted_tests;
 mod operations_coverage_tests;
 mod partial_batch_consistency_tests;
 mod proof_advanced_tests;

--- a/grovedb/src/tests/non_counted_tests.rs
+++ b/grovedb/src/tests/non_counted_tests.rs
@@ -98,10 +98,16 @@ mod tests {
             nc_item,
         );
 
-        let result = db.apply_batch(vec![op], None, None, grove_version).unwrap();
+        let err = db
+            .apply_batch(vec![op], None, None, grove_version)
+            .unwrap()
+            .expect_err("batch insert of NonCounted into NormalTree must fail");
+        // Make sure we're catching the parent-type guard, not some unrelated
+        // batch validation error.
+        let msg = format!("{err:?}");
         assert!(
-            result.is_err(),
-            "batch insert of NonCounted into NormalTree must fail"
+            msg.contains("non-counted"),
+            "expected NonCounted parent-type guard error, got: {msg}"
         );
     }
 
@@ -177,5 +183,78 @@ mod tests {
             "wrapper must survive batch propagation; got {:?}",
             stored
         );
+
+        // The outer count tree's aggregate must NOT include the
+        // NonCounted subtree. Only `plain` should count, so the outer's
+        // root aggregate count is 1. (If propagation dropped the wrapper,
+        // the subtree would be counted as a regular tree → 2.)
+        use grovedb_storage::StorageBatch;
+        let batch = StorageBatch::new();
+        let tx = db.start_transaction();
+        let outer_merk = db
+            .open_transactional_merk_at_path(
+                [TEST_LEAF, b"outer"].as_ref().into(),
+                &tx,
+                Some(&batch),
+                grove_version,
+            )
+            .unwrap()
+            .expect("open outer merk");
+        let aggregate = outer_merk
+            .aggregate_data()
+            .expect("read outer aggregate data");
+        assert_eq!(
+            aggregate.as_count_u64(),
+            1,
+            "non-counted subtree must not contribute to outer count tree's aggregate; got {:?}",
+            aggregate
+        );
+    }
+
+    #[test]
+    fn check_subtree_exists_through_non_counted_wrapper() {
+        // A NonCounted-wrapped tree at the parent path must satisfy
+        // check_subtree_exists, otherwise APIs that gate on it (e.g.
+        // inserts into the wrapped tree) would reject paths through
+        // wrapped parents.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Outer count tree under TEST_LEAF.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ct",
+            Element::empty_count_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert ct");
+
+        // A NonCounted(CountTree) inside the outer count tree.
+        db.insert(
+            [TEST_LEAF, b"ct"].as_ref(),
+            b"nc_ct",
+            Element::new_non_counted(Element::empty_count_tree()).expect("wrap ok"),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert nc inner");
+
+        // Inserting into the wrapped subtree exercises check_subtree_exists
+        // on a path whose parent is `NonCounted(CountTree)` — should succeed.
+        db.insert(
+            [TEST_LEAF, b"ct", b"nc_ct"].as_ref(),
+            b"child",
+            Element::new_item(b"v".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert into wrapped subtree must succeed");
     }
 }

--- a/grovedb/src/tests/non_counted_tests.rs
+++ b/grovedb/src/tests/non_counted_tests.rs
@@ -212,6 +212,49 @@ mod tests {
     }
 
     #[test]
+    fn typed_mmr_api_works_through_non_counted_wrapper() {
+        // A NonCounted-wrapped MmrTree should still work with the typed
+        // mmr_tree_* methods. Without the underlying() lookups in
+        // operations/mmr_tree.rs, the typed APIs would reject wrapped
+        // trees as "not an MMR tree".
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Outer count tree to host the wrapped MmrTree.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ct",
+            Element::empty_count_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert ct");
+
+        // Wrap an empty MmrTree in NonCounted and insert it inside the
+        // count tree. The wrapper suppresses the count contribution.
+        let wrapped_mmr = Element::new_non_counted(Element::empty_mmr_tree()).expect("wrap ok");
+        db.insert(
+            [TEST_LEAF, b"ct"].as_ref(),
+            b"mmr",
+            wrapped_mmr,
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert wrapped mmr");
+
+        // mmr_tree_leaf_count must look through the wrapper.
+        let count = db
+            .mmr_tree_leaf_count([TEST_LEAF, b"ct"].as_ref(), b"mmr", None, grove_version)
+            .unwrap()
+            .expect("leaf count must succeed for wrapped MmrTree");
+        assert_eq!(count, 0, "fresh MMR has zero leaves");
+    }
+
+    #[test]
     fn check_subtree_exists_through_non_counted_wrapper() {
         // A NonCounted-wrapped tree at the parent path must satisfy
         // check_subtree_exists, otherwise APIs that gate on it (e.g.

--- a/grovedb/src/tests/non_counted_tests.rs
+++ b/grovedb/src/tests/non_counted_tests.rs
@@ -1,0 +1,181 @@
+//! Regression tests for `Element::NonCounted` end-to-end behavior.
+//!
+//! These cover the issues found in the Codex review of PR #654:
+//! - Wrapped references resolve via the get path (P2 #5).
+//! - Batch insert rejects NonCounted into non-count-bearing parents (P2 #4).
+//! - Batch propagation preserves the wrapper through
+//!   `InsertTreeWithRootHash` / `InsertNonMerkTree` so the on-disk parent
+//!   element keeps its wrapper byte and the count aggregate excludes the
+//!   subtree (P1 #2).
+
+#[cfg(test)]
+mod tests {
+    use grovedb_version::version::GroveVersion;
+
+    use crate::{
+        batch::QualifiedGroveDbOp,
+        reference_path::ReferencePathType,
+        tests::{make_test_grovedb, TEST_LEAF},
+        Element,
+    };
+
+    #[test]
+    fn get_follows_non_counted_reference() {
+        // A NonCounted-wrapped reference inside a count tree should still
+        // be followed by `get`, returning the referenced item's value
+        // rather than the bare reference element.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Set up a count tree under TEST_LEAF.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ct",
+            Element::empty_count_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert ct");
+
+        // Insert the target item the reference will point at, also inside
+        // the count tree.
+        let target_value = b"target-value".to_vec();
+        db.insert(
+            [TEST_LEAF, b"ct"].as_ref(),
+            b"target",
+            Element::new_item(target_value.clone()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert target");
+
+        // Insert a NonCounted-wrapped reference that points at the target.
+        let reference = Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+            TEST_LEAF.to_vec(),
+            b"ct".to_vec(),
+            b"target".to_vec(),
+        ]));
+        let nc_reference = Element::new_non_counted(reference).expect("wrap ok");
+        db.insert(
+            [TEST_LEAF, b"ct"].as_ref(),
+            b"nc_ref",
+            nc_reference,
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert nc reference");
+
+        // get() resolves through the wrapper and returns the target item.
+        let resolved = db
+            .get([TEST_LEAF, b"ct"].as_ref(), b"nc_ref", None, grove_version)
+            .unwrap()
+            .expect("get should resolve through NonCounted reference");
+        assert_eq!(
+            resolved,
+            Element::new_item(target_value),
+            "wrapped reference must resolve to the referenced item"
+        );
+    }
+
+    #[test]
+    fn batch_insert_rejects_non_counted_into_normal_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // TEST_LEAF is a normal tree; inserting a NonCounted-wrapped item
+        // into it via batch must be rejected, mirroring the per-merk
+        // insert guard.
+        let nc_item = Element::new_non_counted(Element::new_item(b"x".to_vec())).expect("wrap ok");
+        let op = QualifiedGroveDbOp::insert_or_replace_op(
+            vec![TEST_LEAF.to_vec()],
+            b"k".to_vec(),
+            nc_item,
+        );
+
+        let result = db.apply_batch(vec![op], None, None, grove_version).unwrap();
+        assert!(
+            result.is_err(),
+            "batch insert of NonCounted into NormalTree must fail"
+        );
+    }
+
+    #[test]
+    fn batch_propagation_preserves_non_counted_wrapper_on_subtree() {
+        // A batch that inserts a NonCounted(CountTree) AND writes a child
+        // under it forces the propagation path through
+        // InsertTreeWithRootHash. The on-disk parent element must come
+        // back wrapped, and the outer count tree's aggregate must
+        // exclude the subtree's count.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Outer count tree (counts all children that aren't NonCounted).
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"outer",
+            Element::empty_count_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert outer count tree");
+
+        // One ordinary child contributes 1 to outer's count.
+        db.insert(
+            [TEST_LEAF, b"outer"].as_ref(),
+            b"plain",
+            Element::new_item(b"a".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert plain child");
+
+        // Now batch: insert a NonCounted(CountTree) under outer AND a
+        // child under that NonCounted tree in the same batch. This
+        // exercises the propagation path that previously dropped the
+        // wrapper.
+        let nc_inner = Element::new_non_counted(Element::empty_count_tree()).expect("wrap ok");
+        let inner_child = Element::new_item(b"b".to_vec());
+        let ops = vec![
+            QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec(), b"outer".to_vec()],
+                b"nc".to_vec(),
+                nc_inner,
+            ),
+            QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec(), b"outer".to_vec(), b"nc".to_vec()],
+                b"child".to_vec(),
+                inner_child,
+            ),
+        ];
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("batch should succeed");
+
+        // The element stored at outer/nc must STILL be NonCounted after
+        // propagation (the bug was: wrapper was silently dropped).
+        let stored = db
+            .get_raw(
+                grovedb_path::SubtreePath::from(&[TEST_LEAF, b"outer"]),
+                b"nc",
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("get_raw nc");
+        assert!(
+            matches!(stored, Element::NonCounted(_)),
+            "wrapper must survive batch propagation; got {:?}",
+            stored
+        );
+    }
+}

--- a/merk/src/element/costs.rs
+++ b/merk/src/element/costs.rs
@@ -51,7 +51,8 @@ pub trait ElementCostPrivateExtensions {
 }
 
 impl ElementCostPrivateExtensions for Element {
-    /// Get tree cost for the element
+    /// Get tree cost for the element. For `NonCounted`, delegates to the
+    /// inner element and adds 1 byte for the wrapper discriminant.
     fn get_specialized_cost(&self, grove_version: &GroveVersion) -> Result<u32, Error> {
         check_grovedb_v0!(
             "get_specialized_cost",
@@ -70,6 +71,7 @@ impl ElementCostPrivateExtensions for Element {
             Element::CountSumTree(..) => Ok(COUNT_SUM_TREE_COST_SIZE),
             Element::ProvableCountTree(..) => Ok(COUNT_TREE_COST_SIZE),
             Element::ProvableCountSumTree(..) => Ok(COUNT_SUM_TREE_COST_SIZE),
+            Element::NonCounted(inner) => Ok(inner.get_specialized_cost(grove_version)? + 1),
             _ => Err(Error::CorruptedCodeExecution(
                 "trying to get tree cost from non tree element",
             )),
@@ -94,6 +96,12 @@ impl ElementCostExtensions for Element {
         );
         // todo: we actually don't need to deserialize the whole element
         let element = Element::deserialize(value, grove_version)?;
+        // Look through NonCounted: the wrapper itself has no per-variant cost
+        // semantics — the cost is determined by the inner element's type. The
+        // +1 byte for the wrapper discriminant is reflected in the catch-all
+        // (Item) path via value.len(); for the tree/sum-item paths that use
+        // cost-size constants, it is a 1-byte under-count we accept.
+        let element = element.into_underlying();
         let cost = match element {
             Element::Tree(_, flags) => {
                 let flags_len = flags.map_or(0, |flags| {
@@ -244,7 +252,8 @@ impl ElementCostExtensions for Element {
     }
 
     /// Get the value defined cost for a serialized value item with sum item or
-    /// sum item
+    /// sum item. Looks through `NonCounted` (the +1 wrapper-byte cost is
+    /// already folded in by `get_specialized_cost`).
     fn specialized_value_defined_cost(&self, grove_version: &GroveVersion) -> Option<u32> {
         let value_cost = self.get_specialized_cost(grove_version).ok()?;
 
@@ -253,7 +262,7 @@ impl ElementCostExtensions for Element {
                 let flags_len = flags.len() as u32;
                 flags_len + flags_len.required_space() as u32
             });
-        match self {
+        match self.underlying() {
             Element::SumItem(..) => Some(cost),
             Element::ItemWithSumItem(item, ..) => {
                 let item_len = item.len() as u32;
@@ -263,7 +272,8 @@ impl ElementCostExtensions for Element {
         }
     }
 
-    /// Get the value defined cost for a serialized value item with a tree
+    /// Get the value defined cost for a serialized value item with a tree.
+    /// Looks through `NonCounted`.
     fn layered_value_defined_cost(&self, grove_version: &GroveVersion) -> Option<u32> {
         let value_cost = self.get_specialized_cost(grove_version).ok()?;
 
@@ -272,7 +282,7 @@ impl ElementCostExtensions for Element {
                 let flags_len = flags.len() as u32;
                 flags_len + flags_len.required_space() as u32
             });
-        match self {
+        match self.underlying() {
             Element::Tree(..)
             | Element::SumTree(..)
             | Element::BigSumTree(..)
@@ -288,7 +298,8 @@ impl ElementCostExtensions for Element {
         }
     }
 
-    /// Get the value defined cost for a serialized value
+    /// Get the value defined cost for a serialized value. Looks through
+    /// `NonCounted`.
     fn value_defined_cost(&self, grove_version: &GroveVersion) -> Option<ValueDefinedCostType> {
         let value_cost = self.get_specialized_cost(grove_version).ok()?;
 
@@ -297,7 +308,7 @@ impl ElementCostExtensions for Element {
                 let flags_len = flags.len() as u32;
                 flags_len + flags_len.required_space() as u32
             });
-        match self {
+        match self.underlying() {
             Element::Tree(..)
             | Element::CommitmentTree(..)
             | Element::MmrTree(..)

--- a/merk/src/element/costs.rs
+++ b/merk/src/element/costs.rs
@@ -96,19 +96,23 @@ impl ElementCostExtensions for Element {
         );
         // todo: we actually don't need to deserialize the whole element
         let element = Element::deserialize(value, grove_version)?;
-        // Look through NonCounted: the wrapper itself has no per-variant cost
-        // semantics — the cost is determined by the inner element's type. The
-        // +1 byte for the wrapper discriminant is reflected in the catch-all
-        // (Item) path via value.len(); for the tree/sum-item paths that use
-        // cost-size constants, it is a 1-byte under-count we accept.
-        let element = element.into_underlying();
+        // Look through NonCounted: the wrapper has no per-variant cost
+        // semantics — the cost is determined by the inner element's type.
+        // For the catch-all (Item / Reference) path, value.len() already
+        // includes the wrapper byte. For tree- and sum-item paths that use
+        // cost-size constants, we add 1 byte of `wrapper_overhead` to keep
+        // the on-disk byte count exact.
+        let (element, wrapper_overhead) = match element {
+            Element::NonCounted(inner) => (*inner, 1u32),
+            other => (other, 0u32),
+        };
         let cost = match element {
             Element::Tree(_, flags) => {
                 let flags_len = flags.map_or(0, |flags| {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = TREE_COST_SIZE + flags_len;
+                let value_len = TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -119,7 +123,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = SUM_TREE_COST_SIZE + flags_len;
+                let value_len = SUM_TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -130,7 +134,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = BIG_SUM_TREE_COST_SIZE + flags_len;
+                let value_len = BIG_SUM_TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -141,7 +145,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = COUNT_TREE_COST_SIZE + flags_len;
+                let value_len = COUNT_TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -152,7 +156,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = COUNT_SUM_TREE_COST_SIZE + flags_len;
+                let value_len = COUNT_SUM_TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -163,7 +167,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = COUNT_TREE_COST_SIZE + flags_len;
+                let value_len = COUNT_TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -174,7 +178,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = COUNT_SUM_TREE_COST_SIZE + flags_len;
+                let value_len = COUNT_SUM_TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -185,7 +189,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = COMMITMENT_TREE_COST_SIZE + flags_len;
+                let value_len = COMMITMENT_TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -196,7 +200,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = MMR_TREE_COST_SIZE + flags_len;
+                let value_len = MMR_TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -207,7 +211,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = BULK_APPEND_TREE_COST_SIZE + flags_len;
+                let value_len = BULK_APPEND_TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -218,7 +222,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = DENSE_TREE_COST_SIZE + flags_len;
+                let value_len = DENSE_TREE_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                     key_len, value_len, node_type,
@@ -229,7 +233,7 @@ impl ElementCostExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = SUM_ITEM_COST_SIZE + flags_len;
+                let value_len = SUM_ITEM_COST_SIZE + flags_len + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::node_value_byte_cost_size(key_len, value_len, node_type)
             }
@@ -242,10 +246,14 @@ impl ElementCostExtensions for Element {
                 let value_len = item_value_len
                     + item_value_len.required_space() as u32
                     + SUM_ITEM_COST_SIZE
-                    + flags_len;
+                    + flags_len
+                    + wrapper_overhead;
                 let key_len = key.len() as u32;
                 KV::node_value_byte_cost_size(key_len, value_len, node_type)
             }
+            // Item / Reference / NonCounted-of-NonCounted (impossible by
+            // construction): catch-all uses raw value.len() which already
+            // includes any wrapper byte present.
             _ => KV::node_value_byte_cost_size(key.len() as u32, value.len() as u32, node_type),
         };
         Ok(cost)

--- a/merk/src/element/get.rs
+++ b/merk/src/element/get.rs
@@ -408,7 +408,13 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
                 })
                 .transpose()
         );
-        match &element {
+        // Look through `NonCounted` for cost computation: the wrapper does
+        // not change which cost path applies — its inner element type does.
+        // (The +1 wrapper byte is already accounted for via value.as_ref()
+        // .unwrap().len() for items; for trees it's a 1-byte under-count we
+        // accept, consistent with `costs.rs`.)
+        let element_for_cost = element.as_ref().map(|e| e.underlying());
+        match element_for_cost {
             Some(Element::Item(..)) | Some(Element::Reference(..)) => {
                 // while the loaded item might be a sum item, it is given for free
                 // as it would be very hard to know in advance
@@ -451,6 +457,8 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
             | Some(Element::MmrTree(_, flags))
             | Some(Element::BulkAppendTree(.., flags))
             | Some(Element::DenseAppendOnlyFixedSizeTree(.., flags)) => {
+                // tree_type() looks through NonCounted, so this works for both
+                // a bare tree and a NonCounted(tree).
                 let tree_cost_size = element.as_ref().unwrap().tree_type().unwrap().cost_size();
                 let flags_len = flags.as_ref().map_or(0, |flags| {
                     let flags_len = flags.len() as u32;
@@ -464,6 +472,10 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
                         NodeType::NormalNode,
                     ) as u64
             }
+            // NonCounted wrappers are unwrapped above; reaching this arm means
+            // the inner type wasn't one of the explicit arms (impossible given
+            // exhaustiveness above).
+            Some(Element::NonCounted(_)) => {}
             None => {}
         }
         Ok(element).wrap_with_cost(cost)
@@ -506,7 +518,10 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
                 Error::CorruptedData(format!("unable to deserialize element: {e}"))
             })
         );
-        match &element {
+        // Look through `NonCounted` for cost computation; see V0 path above
+        // for rationale.
+        let element_for_cost = element.underlying();
+        match element_for_cost {
             Element::Item(..) | Element::Reference(..) => {
                 // while the loaded item might be a sum item, it is given for free
                 // as it would be very hard to know in advance
@@ -551,6 +566,7 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
             | Element::MmrTree(_, flags)
             | Element::BulkAppendTree(.., flags)
             | Element::DenseAppendOnlyFixedSizeTree(.., flags) => {
+                // tree_type() looks through NonCounted.
                 let tree_cost_size = element.tree_type().unwrap().cost_size();
                 let flags_len = flags.as_ref().map_or(0, |flags| {
                     let flags_len = flags.len() as u32;
@@ -564,6 +580,8 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
                         node_type,
                     ) as u64
             }
+            // NonCounted wrappers are unwrapped above.
+            Element::NonCounted(_) => {}
         }
         Ok(Some(element)).wrap_with_cost(cost)
     }

--- a/merk/src/element/get.rs
+++ b/merk/src/element/get.rs
@@ -410,9 +410,14 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
         );
         // Look through `NonCounted` for cost computation: the wrapper does
         // not change which cost path applies — its inner element type does.
-        // (The +1 wrapper byte is already accounted for via value.as_ref()
-        // .unwrap().len() for items; for trees it's a 1-byte under-count we
-        // accept, consistent with `costs.rs`.)
+        // For the catch-all (Item / Reference) path, value.len() already
+        // includes the wrapper byte. For tree- and sum-item paths that use
+        // cost-size constants, add `wrapper_overhead` to keep accounting
+        // exact.
+        let wrapper_overhead = element
+            .as_ref()
+            .map(|e| if e.is_non_counted() { 1u32 } else { 0 })
+            .unwrap_or(0);
         let element_for_cost = element.as_ref().map(|e| e.underlying());
         match element_for_cost {
             Some(Element::Item(..)) | Some(Element::Reference(..)) => {
@@ -430,7 +435,7 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = cost_size + flags_len;
+                let value_len = cost_size + flags_len + wrapper_overhead;
                 cost.storage_loaded_bytes = KV::node_value_byte_cost_size(
                     key_ref.len() as u32,
                     value_len,
@@ -464,7 +469,7 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = tree_cost_size + flags_len;
+                let value_len = tree_cost_size + flags_len + wrapper_overhead;
                 cost.storage_loaded_bytes =
                     KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                         key_ref.len() as u32,
@@ -519,7 +524,9 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
             })
         );
         // Look through `NonCounted` for cost computation; see V0 path above
-        // for rationale.
+        // for rationale. Capture the wrapper byte before unwrapping so the
+        // tree- and sum-item arms can include it in value_len.
+        let wrapper_overhead = if element.is_non_counted() { 1u32 } else { 0 };
         let element_for_cost = element.underlying();
         match element_for_cost {
             Element::Item(..) | Element::Reference(..) => {
@@ -537,7 +544,7 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = cost_size + flags_len;
+                let value_len = cost_size + flags_len + wrapper_overhead;
                 cost.storage_loaded_bytes =
                     KV::node_value_byte_cost_size(key_ref.len() as u32, value_len, node_type) as u64
                 // this is changed to sum node in v1
@@ -550,8 +557,11 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len =
-                    item_value_len + item_value_len.required_space() as u32 + cost_size + flags_len;
+                let value_len = item_value_len
+                    + item_value_len.required_space() as u32
+                    + cost_size
+                    + flags_len
+                    + wrapper_overhead;
                 cost.storage_loaded_bytes =
                     KV::node_value_byte_cost_size(key_ref.len() as u32, value_len, node_type) as u64
             }
@@ -572,7 +582,7 @@ impl ElementFetchFromStoragePrivateExtensions for Element {
                     let flags_len = flags.len() as u32;
                     flags_len + flags_len.required_space() as u32
                 });
-                let value_len = tree_cost_size + flags_len;
+                let value_len = tree_cost_size + flags_len + wrapper_overhead;
                 cost.storage_loaded_bytes =
                     KV::layered_value_byte_cost_size_for_key_and_value_lengths(
                         key_ref.len() as u32,

--- a/merk/src/element/insert.rs
+++ b/merk/src/element/insert.rs
@@ -434,6 +434,13 @@ impl ElementInsertToStorageExtensions for Element {
             grove_version.grovedb_versions.element.insert_reference
         );
 
+        if self.is_non_counted() && !merk.tree_type.is_count_bearing() {
+            return Err(Error::InvalidInputError(
+                "non-counted elements may only be inserted into count-bearing trees",
+            ))
+            .wrap_with_cost(Default::default());
+        }
+
         let serialized = match self.serialize(grove_version) {
             Ok(s) => s,
             Err(e) => return Err(e.into()).wrap_with_cost(Default::default()),
@@ -518,6 +525,13 @@ impl ElementInsertToStorageExtensions for Element {
             "insert_subtree",
             grove_version.grovedb_versions.element.insert_subtree
         );
+
+        if self.is_non_counted() && !merk.tree_type.is_count_bearing() {
+            return Err(Error::InvalidInputError(
+                "non-counted elements may only be inserted into count-bearing trees",
+            ))
+            .wrap_with_cost(Default::default());
+        }
 
         let serialized = match self.serialize(grove_version) {
             Ok(s) => s,
@@ -804,6 +818,19 @@ mod tests {
         let agg = merk.aggregate_data().expect("aggregate ok");
         assert_eq!(agg.as_count_u64(), 0);
         assert_eq!(agg.as_sum_i64(), 10);
+    }
+
+    #[test]
+    fn non_counted_subtree_rejected_via_insert_subtree_in_normal_tree() {
+        // Wrap a tree element and try inserting it into a non-count-bearing
+        // tree via the subtree path (used by GroveDB for tree elements).
+        let grove_version = GroveVersion::latest();
+        let mut merk = TempMerk::new_with_tree_type(grove_version, TreeType::NormalTree);
+        let nc_tree = Element::new_non_counted(Element::empty_tree()).expect("wrap ok");
+        let result = nc_tree
+            .insert_subtree(&mut merk, b"k", [0u8; 32], None, grove_version)
+            .unwrap();
+        assert!(matches!(result, Err(Error::InvalidInputError(_))));
     }
 
     #[test]

--- a/merk/src/element/insert.rs
+++ b/merk/src/element/insert.rs
@@ -6,7 +6,7 @@ use grovedb_costs::{
     cost_return_on_error_into_default, cost_return_on_error_no_add, CostResult, CostsExt,
     OperationCost,
 };
-use grovedb_element::{Element, Element::SumItem};
+use grovedb_element::Element;
 use grovedb_storage::StorageContext;
 use grovedb_version::{check_grovedb_v0_with_cost, version::GroveVersion};
 
@@ -163,6 +163,13 @@ impl ElementInsertToStorageExtensions for Element {
 
         let serialized = cost_return_on_error_into_default!(self.serialize(grove_version));
 
+        if self.is_non_counted() && !merk.tree_type.is_count_bearing() {
+            return Err(Error::InvalidInputError(
+                "non-counted elements may only be inserted into count-bearing trees",
+            ))
+            .wrap_with_cost(Default::default());
+        }
+
         if !merk.tree_type.allows_sum_item() && self.is_sum_item() {
             return Err(Error::InvalidInputError(
                 "cannot add sum item to non sum tree",
@@ -172,7 +179,10 @@ impl ElementInsertToStorageExtensions for Element {
 
         let merk_feature_type =
             cost_return_on_error_into_default!(self.get_feature_type(merk.tree_type));
-        let batch_operations = if matches!(self, SumItem(..) | Element::ItemWithSumItem(..)) {
+        // Use is_sum_item() (which looks through NonCounted) so that a
+        // NonCounted(SumItem(..)) takes the same specialized cost path as a
+        // bare SumItem(..).
+        let batch_operations = if self.is_sum_item() {
             let cost = cost_return_on_error_default!(self
                 .specialized_value_defined_cost(grove_version)
                 .ok_or(Error::CorruptedCodeExecution(
@@ -228,7 +238,10 @@ impl ElementInsertToStorageExtensions for Element {
             Err(e) => return Err(e.into()).wrap_with_cost(Default::default()),
         };
 
-        let entry = if matches!(self, SumItem(..) | Element::ItemWithSumItem(..)) {
+        // Use is_sum_item() (which looks through NonCounted) so that a
+        // NonCounted(SumItem(..)) takes the same specialized cost path as a
+        // bare SumItem(..).
+        let entry = if self.is_sum_item() {
             let cost = cost_return_on_error_default!(self
                 .specialized_value_defined_cost(grove_version)
                 .ok_or(Error::CorruptedCodeExecution(
@@ -602,6 +615,7 @@ mod tests {
     use crate::{
         element::get::ElementFetchFromStorageExtensions,
         test_utils::{empty_path_merk, empty_path_merk_read_only, TempMerk},
+        TreeType,
     };
 
     #[test]
@@ -725,6 +739,96 @@ mod tests {
                 .unwrap()
                 .expect("expected successful get"),
             Element::new_item(b"value2".to_vec()),
+        );
+    }
+
+    #[test]
+    fn non_counted_rejected_in_normal_tree() {
+        let grove_version = GroveVersion::latest();
+        let mut merk = TempMerk::new_with_tree_type(grove_version, TreeType::NormalTree);
+        let nc = Element::new_non_counted(Element::new_item(b"x".to_vec())).expect("wrap ok");
+        let result = nc.insert(&mut merk, b"k", None, grove_version).unwrap();
+        assert!(matches!(result, Err(Error::InvalidInputError(_))));
+    }
+
+    #[test]
+    fn non_counted_rejected_in_sum_tree() {
+        let grove_version = GroveVersion::latest();
+        let mut merk = TempMerk::new_with_tree_type(grove_version, TreeType::SumTree);
+        let nc = Element::new_non_counted(Element::new_sum_item(7)).expect("wrap ok");
+        let result = nc.insert(&mut merk, b"k", None, grove_version).unwrap();
+        assert!(matches!(result, Err(Error::InvalidInputError(_))));
+    }
+
+    #[test]
+    fn non_counted_accepted_in_count_tree_contributes_zero() {
+        let grove_version = GroveVersion::latest();
+        let mut merk = TempMerk::new_with_tree_type(grove_version, TreeType::CountTree);
+
+        // Two regular items contribute 1 each; one NonCounted contributes 0.
+        Element::new_item(b"a".to_vec())
+            .insert(&mut merk, b"k1", None, grove_version)
+            .unwrap()
+            .expect("insert k1");
+        Element::new_item(b"b".to_vec())
+            .insert(&mut merk, b"k2", None, grove_version)
+            .unwrap()
+            .expect("insert k2");
+        Element::new_non_counted(Element::new_item(b"c".to_vec()))
+            .expect("wrap ok")
+            .insert(&mut merk, b"k3", None, grove_version)
+            .unwrap()
+            .expect("insert k3 non-counted");
+
+        let agg = merk.aggregate_data().expect("aggregate ok");
+        assert_eq!(
+            agg.as_count_u64(),
+            2,
+            "non-counted item should not be counted"
+        );
+    }
+
+    #[test]
+    fn non_counted_accepted_in_provable_count_sum_tree_keeps_sum() {
+        let grove_version = GroveVersion::latest();
+        let mut merk = TempMerk::new_with_tree_type(grove_version, TreeType::ProvableCountSumTree);
+
+        // A NonCounted(SumItem(10)) inside a ProvableCountSumTree contributes
+        // count = 0 and sum = 10.
+        Element::new_non_counted(Element::new_sum_item(10))
+            .expect("wrap ok")
+            .insert(&mut merk, b"k", None, grove_version)
+            .unwrap()
+            .expect("insert nc sum item");
+
+        let agg = merk.aggregate_data().expect("aggregate ok");
+        assert_eq!(agg.as_count_u64(), 0);
+        assert_eq!(agg.as_sum_i64(), 10);
+    }
+
+    #[test]
+    fn non_counted_count_tree_inside_count_tree_suppresses_subtree_count() {
+        // Bare ProvableCountTree(_, 5, _) inside CountTree contributes 5.
+        // Wrapped as NonCounted, contributes 0.
+        let grove_version = GroveVersion::latest();
+        let mut merk = TempMerk::new_with_tree_type(grove_version, TreeType::CountTree);
+
+        Element::new_item(b"a".to_vec())
+            .insert(&mut merk, b"k1", None, grove_version)
+            .unwrap()
+            .expect("insert k1");
+        let pct = Element::new_provable_count_tree_with_flags_and_count_value(None, 5, None);
+        Element::new_non_counted(pct)
+            .expect("wrap ok")
+            .insert(&mut merk, b"k_nc", None, grove_version)
+            .unwrap()
+            .expect("insert nc pct");
+
+        let agg = merk.aggregate_data().expect("aggregate ok");
+        assert_eq!(
+            agg.as_count_u64(),
+            1,
+            "nested count tree's 5 should be suppressed; only the bare item should count"
         );
     }
 }

--- a/merk/src/element/reconstruct.rs
+++ b/merk/src/element/reconstruct.rs
@@ -68,7 +68,50 @@ impl ElementReconstructExtensions for Element {
             Element::DenseAppendOnlyFixedSizeTree(c, h, f) => {
                 Some(Element::DenseAppendOnlyFixedSizeTree(*c, *h, f.clone()))
             }
+            // Recurse on the inner element and re-wrap. Without this, a
+            // batch that mutates a subtree under a wrapped tree would lose
+            // the NonCounted wrapper on the parent's stored element when
+            // its root key gets propagated upward.
+            Element::NonCounted(inner) => inner
+                .reconstruct_with_root_key(maybe_root_key, aggregate_data)
+                .map(|reconstructed| Element::NonCounted(Box::new(reconstructed))),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use grovedb_element::Element;
+
+    use super::ElementReconstructExtensions;
+    use crate::tree::AggregateData;
+
+    #[test]
+    fn reconstruct_preserves_non_counted_wrapper() {
+        // A NonCounted-wrapped tree must come back wrapped after a root-key
+        // propagation, otherwise update_tree_item_preserve_flag on a
+        // subtree mutation would silently strip the wrapper from the
+        // on-disk parent element.
+        let inner = Element::new_count_tree_with_flags_and_count_value(None, 7, None);
+        let wrapped = Element::new_non_counted(inner).expect("wrap ok");
+        let new_root = Some(b"new_root".to_vec());
+        let reconstructed = wrapped
+            .reconstruct_with_root_key(new_root.clone(), AggregateData::Count(7))
+            .expect("reconstruct ok");
+        // Outer is still NonCounted.
+        assert!(matches!(reconstructed, Element::NonCounted(_)));
+        // Inner is the same kind of tree with the new root key.
+        if let Element::NonCounted(boxed) = reconstructed {
+            assert!(matches!(*boxed, Element::CountTree(ref k, 7, _) if k == &new_root));
+        }
+    }
+
+    #[test]
+    fn reconstruct_returns_none_for_non_tree() {
+        let item = Element::new_item(b"x".to_vec());
+        assert!(item
+            .reconstruct_with_root_key(None, AggregateData::NoAggregateData)
+            .is_none());
     }
 }

--- a/merk/src/element/tree_type.rs
+++ b/merk/src/element/tree_type.rs
@@ -36,7 +36,7 @@ pub trait ElementTreeTypeExtensions {
 }
 impl ElementTreeTypeExtensions for Element {
     /// Check if the element is a tree and return the root_tree info and tree
-    /// type
+    /// type. Looks through `NonCounted`.
     fn root_key_and_tree_type_owned(self) -> Option<(Option<Vec<u8>>, TreeType)> {
         match self {
             Element::Tree(root_key, _) => Some((root_key, TreeType::NormalTree)),
@@ -60,12 +60,13 @@ impl ElementTreeTypeExtensions for Element {
             Element::DenseAppendOnlyFixedSizeTree(_, height, _) => {
                 Some((None, TreeType::DenseAppendOnlyFixedSizeTree(height)))
             }
+            Element::NonCounted(inner) => inner.root_key_and_tree_type_owned(),
             _ => None,
         }
     }
 
     /// Check if the element is a tree and return the root_tree info and the
-    /// tree type
+    /// tree type. Looks through `NonCounted`.
     fn root_key_and_tree_type(&self) -> Option<(&Option<Vec<u8>>, TreeType)> {
         // We use a const None to return a stable reference for non-Merk tree types.
         const NONE_ROOT_KEY: Option<Vec<u8>> = None;
@@ -92,11 +93,13 @@ impl ElementTreeTypeExtensions for Element {
                 &NONE_ROOT_KEY,
                 TreeType::DenseAppendOnlyFixedSizeTree(*height),
             )),
+            Element::NonCounted(inner) => inner.root_key_and_tree_type(),
             _ => None,
         }
     }
 
-    /// Check if the element is a tree and return the flags and the tree type
+    /// Check if the element is a tree and return the flags and the tree type.
+    /// Looks through `NonCounted`.
     fn tree_flags_and_type(&self) -> Option<(&Option<ElementFlags>, TreeType)> {
         match self {
             Element::Tree(_, flags) => Some((flags, TreeType::NormalTree)),
@@ -118,11 +121,13 @@ impl ElementTreeTypeExtensions for Element {
             Element::DenseAppendOnlyFixedSizeTree(_, height, flags) => {
                 Some((flags, TreeType::DenseAppendOnlyFixedSizeTree(*height)))
             }
+            Element::NonCounted(inner) => inner.tree_flags_and_type(),
             _ => None,
         }
     }
 
-    /// Check if the element is a tree and return the tree type
+    /// Check if the element is a tree and return the tree type. Looks through
+    /// `NonCounted`.
     fn tree_type(&self) -> Option<TreeType> {
         match self {
             Element::Tree(..) => Some(TreeType::NormalTree),
@@ -142,12 +147,13 @@ impl ElementTreeTypeExtensions for Element {
             Element::DenseAppendOnlyFixedSizeTree(_, height, _) => {
                 Some(TreeType::DenseAppendOnlyFixedSizeTree(*height))
             }
+            Element::NonCounted(inner) => inner.tree_type(),
             _ => None,
         }
     }
 
     /// Check if the element is a tree and return the aggregate of elements in
-    /// the tree
+    /// the tree. Looks through `NonCounted`.
     fn tree_feature_type(&self) -> Option<TreeFeatureType> {
         match self {
             Element::Tree(..) => Some(BasicMerkNode),
@@ -165,11 +171,13 @@ impl ElementTreeTypeExtensions for Element {
             Element::MmrTree(..) => Some(BasicMerkNode),
             Element::BulkAppendTree(..) => Some(BasicMerkNode),
             Element::DenseAppendOnlyFixedSizeTree(..) => Some(BasicMerkNode),
+            Element::NonCounted(inner) => inner.tree_feature_type(),
             _ => None,
         }
     }
 
-    /// Check if the element is a tree and return the tree type
+    /// Check if the element is a tree and return the tree type. Looks through
+    /// `NonCounted`.
     fn maybe_tree_type(&self) -> MaybeTree {
         match self {
             Element::Tree(..) => MaybeTree::Tree(TreeType::NormalTree),
@@ -189,11 +197,19 @@ impl ElementTreeTypeExtensions for Element {
             Element::DenseAppendOnlyFixedSizeTree(_, height, _) => {
                 MaybeTree::Tree(TreeType::DenseAppendOnlyFixedSizeTree(*height))
             }
+            Element::NonCounted(inner) => inner.maybe_tree_type(),
             _ => MaybeTree::NotTree,
         }
     }
 
-    /// Get the tree feature type
+    /// Get the tree feature type.
+    ///
+    /// `count_value_or_default` and `count_sum_value_or_default` already
+    /// return 0 (resp. (0, inner_sum)) for `Element::NonCounted`, so the
+    /// existing dispatch produces the right feature type for the wrapper
+    /// without an explicit branch here. Sum-bearing parents still see the
+    /// inner element's sum because `sum_value_or_default` and
+    /// `big_sum_value_or_default` delegate through the wrapper.
     fn get_feature_type(&self, parent_tree_type: TreeType) -> Result<TreeFeatureType, Error> {
         match parent_tree_type {
             TreeType::NormalTree => Ok(BasicMerkNode),

--- a/merk/src/proofs/query/verify.rs
+++ b/merk/src/proofs/query/verify.rs
@@ -689,10 +689,10 @@ pub fn key_exists_as_boundary_in_proof(proof_bytes: &[u8], key: &[u8]) -> Result
             Op::Push(Node::KVDigest(k, _))
             | Op::PushInverted(Node::KVDigest(k, _))
             | Op::Push(Node::KVDigestCount(k, _, _))
-            | Op::PushInverted(Node::KVDigestCount(k, _, _)) => {
-                if k.as_slice() == key {
-                    return Ok(true);
-                }
+            | Op::PushInverted(Node::KVDigestCount(k, _, _))
+                if k.as_slice() == key =>
+            {
+                return Ok(true);
             }
             _ => {}
         }

--- a/merk/src/test_utils/mod.rs
+++ b/merk/src/test_utils/mod.rs
@@ -262,13 +262,10 @@ pub fn make_tree_rand(
     };
     let mut tree = TreeNode::new(vec![0; 20], value, None, feature_type).unwrap();
 
-    let mut seed = initial_seed;
-
     let batch_count = node_count / batch_size;
-    for _ in 0..batch_count {
+    for seed in initial_seed..(initial_seed + batch_count) {
         let batch = make_batch_rand(batch_size, seed);
         tree = apply_memonly(tree, &batch, grove_version);
-        seed += 1;
     }
 
     tree

--- a/merk/src/tree_type/mod.rs
+++ b/merk/src/tree_type/mod.rs
@@ -288,6 +288,21 @@ mod tests {
     }
 
     #[test]
+    fn is_count_bearing() {
+        assert!(!TreeType::NormalTree.is_count_bearing());
+        assert!(!TreeType::SumTree.is_count_bearing());
+        assert!(!TreeType::BigSumTree.is_count_bearing());
+        assert!(TreeType::CountTree.is_count_bearing());
+        assert!(TreeType::CountSumTree.is_count_bearing());
+        assert!(TreeType::ProvableCountTree.is_count_bearing());
+        assert!(TreeType::ProvableCountSumTree.is_count_bearing());
+        assert!(!TreeType::CommitmentTree(0).is_count_bearing());
+        assert!(!TreeType::MmrTree.is_count_bearing());
+        assert!(!TreeType::BulkAppendTree(0).is_count_bearing());
+        assert!(!TreeType::DenseAppendOnlyFixedSizeTree(0).is_count_bearing());
+    }
+
+    #[test]
     fn allows_sum_item() {
         assert!(!TreeType::NormalTree.allows_sum_item());
         assert!(TreeType::SumTree.allows_sum_item());

--- a/merk/src/tree_type/mod.rs
+++ b/merk/src/tree_type/mod.rs
@@ -121,6 +121,20 @@ impl TreeType {
         )
     }
 
+    /// Returns whether this tree type carries a count aggregate that children
+    /// can contribute to. Only count-bearing trees may host
+    /// `Element::NonCounted` children — in any other parent the wrapper would
+    /// have no semantic effect, so it is rejected at insert time.
+    pub const fn is_count_bearing(&self) -> bool {
+        matches!(
+            self,
+            TreeType::CountTree
+                | TreeType::CountSumTree
+                | TreeType::ProvableCountTree
+                | TreeType::ProvableCountSumTree
+        )
+    }
+
     /// Returns whether this tree type allows sum items as children.
     pub fn allows_sum_item(&self) -> bool {
         match self {


### PR DESCRIPTION
## Issue being fixed or feature implemented

GroveDB count-bearing trees (`CountTree`, `ProvableCountTree`, `CountSumTree`, `ProvableCountSumTree`) currently aggregate every child element into the parent's count. There's no way to insert a value that participates in storage and proofs but is exempt from the count — e.g. housekeeping rows, schema markers, or auxiliary indexes inside a count tree.

This adds that escape hatch.

## What was done?

Added a new `Element::NonCounted(Box<Element>)` variant that:
- behaves identically to its inner element for storage, hashing, sum propagation, and internal aggregation,
- contributes **0** to the parent count tree's aggregate count,
- still contributes the inner sum to a parent sum tree (only count is suppressed),
- may **only** be inserted into a count-bearing tree.

### Design choice: single wrapper variant (vs. ~15 explicit variants)

A wrapper means one new discriminant and one dispatch point for the \"is non-counted?\" question. Existing `Element` predicates (\`is_tree\`, \`is_sum_item\`, \`is_any_item\`, \`is_non_empty_tree\`, ...) keep working by looking *through* the wrapper via a new \`underlying()\` helper. Pattern-match sites in cost, proof, query, batch, and insert paths dispatch on the underlying element.

### Cryptographic notes

The wrapper byte is included in the serialized value, so the value hash distinguishes \`NonCounted(X)\` from a bare \`X\`. The parent's \`TreeFeatureType\` for a non-counted child is the inner element's feature type with its count zeroed (via a new \`TreeFeatureType::zero_count()\` helper); no new \`TreeFeatureType\` variants are introduced.

Nested \`NonCounted(NonCounted(...))\` is rejected at construction, serialization, and deserialization to close a stack-overflow vector.

### Scope

Touched 18 files across \`grovedb-element\`, \`grovedb-query\`, \`grovedb-merk\`, and \`grovedb\`:
- enum + discriminant + constructor + helpers + serialization
- \`merk\` insert validation, feature-type dispatch, get/cost paths
- \`grovedb\` batch / insert / query / proof / lib pattern-match sites updated to dispatch on the underlying element

## How Has This Been Tested?

New tests:
- \`grovedb-element\` (10 tests): constructor (wrap, reject-nested, idempotent \`into_non_counted\`); helper passthrough (\`is_*\`, \`count_value_or_default\` returns 0, \`sum_value_or_default\` keeps inner sum, flag accessors); bincode round-trip; reject nested wrapper at deserialize and at serialize.
- \`grovedb-merk\` (5 tests): insert into \`NormalTree\` and \`SumTree\` is rejected; insert into \`CountTree\` succeeds and contributes 0; \`NonCounted(SumItem(10))\` in a \`ProvableCountSumTree\` yields count=0, sum=10; a \`NonCounted(ProvableCountTree)\` whose internal count is 5 contributes 0 to a parent \`CountTree\`.

Full workspace test suite still passes:
- \`cargo test -p grovedb-element\` — 39 passed
- \`cargo test -p grovedb-merk --features minimal,test_utils,full\` — 360 passed
- \`cargo test -p grovedb\` — 1449 passed

\`cargo clippy\` is clean for the changed code (3 pre-existing warnings in unrelated files).

## Breaking Changes

None for existing callers. The change adds a new \`Element\` variant and is additive at the API surface. The on-disk serialization format gains a new bincode discriminant (15) — older code reading data written with this variant would fail to deserialize, so producer/consumer pairs need to be upgraded together. This matches the existing \"ONLY APPEND TO THIS LIST\" comment on the \`Element\` enum.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for non-counted elements that preserve storage/hashing and sums while contributing zero to parent counts
  * New helper APIs for transparent access to underlying elements

* **Behavior Changes**
  * Visualization and display now indicate non-counted wrappers
  * Queries, proofs, batch execution, and cost/accounting now treat non-counted elements as transparent while accounting for wrapper overhead

* **Validation & Safety**
  * Reject nested non-counted wrappers during serialization/deserialization
  * Prevent inserting non-counted elements into non-count-bearing trees

* **Tests**
  * Added end-to-end and unit coverage for non-counted semantics and safeguards
<!-- end of auto-generated comment: release notes by coderabbit.ai -->