### PR TITLE
chore: bump orchard to latest dashified rev

### DIFF
--- a/grovedb-commitment-tree/Cargo.toml
+++ b/grovedb-commitment-tree/Cargo.toml
@@ -17,7 +17,7 @@ client = ["shardtree"]
 sqlite = ["client", "rusqlite"]
 
 [dependencies]
-orchard = { git = "https://github.com/dashpay/orchard.git", rev = "41c8f7169f2683c99cf0e0c63e8d25ec12c47a79", features = ["circuit"] }
+orchard = { git = "https://github.com/dashpay/orchard.git", rev = "898258d76aab2822249492aede59a02d49278fff", features = ["circuit"] }
 incrementalmerkletree = "0.8"
 shardtree = { version = "0.6", optional = true }
 rusqlite = { version = "0.38", features = ["bundled"], optional = true }


### PR DESCRIPTION
## Summary

Bumps the `orchard` git dependency in `grovedb-commitment-tree` from `41c8f71` to `898258d` — the new head of [dashpay/orchard `dashified`](https://github.com/dashpay/orchard/tree/dashified) after it was rebased onto upstream `0.13.1` with the memo-generic refactor and `CLAUDE.md` on top.

The previous `dashified` head is preserved on the orchard repo as `dashifiedoldversion12` (`a7244b0`).

## Test plan

- [x] `cargo build -p grovedb-commitment-tree` (default / `client` / `server,sqlite` features) — all succeed
- [x] `cargo test -p grovedb-commitment-tree --features server,sqlite --lib` — 100 passed, 0 failed, 2 ignored
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)