### PR TITLE
ci: raise patch coverage requirement from 80% to 90%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,7 +20,7 @@ coverage:
         threshold: 2%
     patch:
       default:
-        target: 80%
+        target: 90%
 
 comment:
   layout: "condensed_header, diff, components, condensed_files"


### PR DESCRIPTION
## Summary
- Bumps the Codecov `patch` target in `.codecov.yml` from 80% to 90%, so new code in PRs must hit at least 90% coverage to pass the patch check.
- The project-level `auto` target (with 2% threshold) is unchanged.

This aligns the CI requirement with the project's stated coverage goal of 90% (current overall is ~88.6%).

## Test plan
- [ ] Codecov runs against this PR and the new 90% patch threshold is reported in the status check.