### PR TITLE
feat(merk,grovedb): add no-proof query_aggregate_count entry point

### DIFF
--- a/grovedb-version/src/version/grovedb_versions.rs
+++ b/grovedb-version/src/version/grovedb_versions.rs
@@ -116,6 +116,7 @@ pub struct GroveDBOperationsQueryVersions {
     pub query_item_value: FeatureVersion,
     pub query_item_value_or_sum: FeatureVersion,
     pub query_aggregate_sums: FeatureVersion,
+    pub query_aggregate_count_on_range: FeatureVersion,
     pub query_sums: FeatureVersion,
     pub query_raw: FeatureVersion,
     pub query_keys_optional: FeatureVersion,

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -134,6 +134,7 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
                 query_item_value: 0,
                 query_item_value_or_sum: 0,
                 query_aggregate_sums: 0,
+                query_aggregate_count_on_range: 0,
                 query_sums: 0,
                 query_raw: 0,
                 query_keys_optional: 0,

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -134,6 +134,7 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
                 query_item_value: 0,
                 query_item_value_or_sum: 0,
                 query_aggregate_sums: 0,
+                query_aggregate_count_on_range: 0,
                 query_sums: 0,
                 query_raw: 0,
                 query_keys_optional: 0,

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -134,6 +134,7 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
                 query_item_value: 0,
                 query_item_value_or_sum: 0,
                 query_aggregate_sums: 0,
+                query_aggregate_count_on_range: 0,
                 query_sums: 0,
                 query_raw: 0,
                 query_keys_optional: 0,

--- a/grovedb/src/operations/get/query.rs
+++ b/grovedb/src/operations/get/query.rs
@@ -19,6 +19,7 @@ use crate::{
 use crate::{
     query_result_type::{QueryResultElement, QueryResultElements, QueryResultType},
     reference_path::ReferencePathType,
+    util::TxRef,
     Element, Error, GroveDb, PathQuery, TransactionArg,
 };
 use grovedb_costs::cost_return_on_error_default;
@@ -26,6 +27,8 @@ use grovedb_costs::cost_return_on_error_default;
 use grovedb_costs::{
     cost_return_on_error, cost_return_on_error_no_add, CostResult, CostsExt, OperationCost,
 };
+#[cfg(feature = "minimal")]
+use grovedb_path::SubtreePath;
 use grovedb_version::{check_grovedb_v0, check_grovedb_v0_with_cost, version::GroveVersion};
 #[cfg(feature = "minimal")]
 use integer_encoding::VarInt;
@@ -651,6 +654,85 @@ where {
             transaction,
             grove_version,
         )
+    }
+
+    /// Execute an `AggregateCountOnRange` path query without producing a
+    /// proof, returning the in-range count directly.
+    ///
+    /// This is the no-proof counterpart of
+    /// [`Self::prove_query`] +
+    /// [`Self::verify_aggregate_count_query`](GroveDb::verify_aggregate_count_query)
+    /// for `AggregateCountOnRange` queries: it performs the same merk-level
+    /// boundary walk the prover does (using each internal node's stored
+    /// aggregate count to short-circuit Contained / Disjoint subtrees) but
+    /// skips proof generation, serialization, and verification entirely.
+    ///
+    /// `path_query` must satisfy
+    /// [`PathQuery::validate_aggregate_count_on_range`] — a single
+    /// `AggregateCountOnRange(_)` item, no subqueries, no pagination, and an
+    /// inner range that isn't `Key`, `RangeFull`, or another
+    /// `AggregateCountOnRange`. Any other shape is rejected up front with
+    /// `Error::InvalidQuery` before any merk reads happen.
+    ///
+    /// The subtree at `path_query.path` must be a `ProvableCountTree` or
+    /// `ProvableCountSumTree` — the merk-level walk rejects any other tree
+    /// type. If the subtree is missing (path does not resolve), this returns
+    /// the same `PathNotFound` / `PathParentLayerNotFound` errors as other
+    /// path-based reads.
+    ///
+    /// The returned count is **not** independently verifiable — callers are
+    /// trusting their own merk read path. For a verifiable count, use
+    /// [`Self::prove_query`] +
+    /// [`Self::verify_aggregate_count_query`](GroveDb::verify_aggregate_count_query).
+    pub fn query_aggregate_count(
+        &self,
+        path_query: &PathQuery,
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> CostResult<u64, Error> {
+        check_grovedb_v0_with_cost!(
+            "query_aggregate_count",
+            grove_version
+                .grovedb_versions
+                .operations
+                .query
+                .query_aggregate_count_on_range
+        );
+
+        let mut cost = OperationCost::default();
+
+        // Up-front shape validation: same gate the prover and verifier use.
+        // Catches malformed ACOR queries (illegal inner range, ACOR-hidden-in-
+        // subquery, pagination, etc.) before any storage reads.
+        let inner_range = cost_return_on_error_no_add!(
+            cost,
+            path_query.validate_aggregate_count_on_range().cloned()
+        );
+
+        let tx = TxRef::new(&self.db, transaction);
+
+        // Open the leaf merk and ask it for the count. The merk-level entry
+        // point enforces `tree_type ∈ {ProvableCountTree, ProvableCountSumTree}`
+        // and handles the empty-merk case (returns 0).
+        let path_slices: Vec<&[u8]> = path_query.path.iter().map(|p| p.as_slice()).collect();
+        let subtree = cost_return_on_error!(
+            &mut cost,
+            self.open_transactional_merk_at_path(
+                SubtreePath::from(path_slices.as_slice()),
+                tx.as_ref(),
+                None,
+                grove_version,
+            )
+        );
+
+        let count = cost_return_on_error!(
+            &mut cost,
+            subtree
+                .count_aggregate_on_range(&inner_range, grove_version)
+                .map_err(Error::MerkError)
+        );
+
+        Ok(count).wrap_with_cost(cost)
     }
 
     /// Retrieves SumItem values that match a regular [`PathQuery`], returning

--- a/grovedb/src/tests/aggregate_count_query_tests.rs
+++ b/grovedb/src/tests/aggregate_count_query_tests.rs
@@ -1440,6 +1440,48 @@ mod tests {
     }
 
     #[test]
+    fn no_proof_uses_provided_transaction() {
+        // Exercise the TransactionArg = Some(&tx) path of query_aggregate_count.
+        // A transactional read sees the committed state inside the same
+        // transaction.
+        let v = GroveVersion::latest();
+        let (db, _) = setup_15_key_provable_count_tree(v);
+        let tx = db.start_transaction();
+        let path_query = PathQuery::new_aggregate_count_on_range(
+            vec![TEST_LEAF.to_vec(), b"ct".to_vec()],
+            QueryItem::RangeInclusive(b"c".to_vec()..=b"l".to_vec()),
+        );
+        let count = db
+            .grove_db
+            .query_aggregate_count(&path_query, Some(&tx), v)
+            .unwrap()
+            .expect("query_aggregate_count with transaction should succeed");
+        assert_eq!(count, 10);
+    }
+
+    #[test]
+    fn no_proof_path_not_found_returns_error() {
+        // Querying a path whose parent layer doesn't exist must surface
+        // the same path-not-found error other reads produce — exercises
+        // the open_transactional_merk_at_path error arm.
+        let v = GroveVersion::latest();
+        let db = make_test_grovedb(v);
+        let path_query = PathQuery::new_aggregate_count_on_range(
+            vec![TEST_LEAF.to_vec(), b"does-not-exist".to_vec()],
+            QueryItem::Range(b"a".to_vec()..b"z".to_vec()),
+        );
+        let result = db
+            .grove_db
+            .query_aggregate_count(&path_query, None, v)
+            .unwrap();
+        assert!(
+            result.is_err(),
+            "querying a non-existent path must fail, got Ok({:?})",
+            result.ok()
+        );
+    }
+
+    #[test]
     fn no_proof_empty_provable_count_tree_returns_zero() {
         // An empty provable-count tree should walk in O(1) and return 0
         // — no proof generation, no merk traversal beyond the root open.

--- a/grovedb/src/tests/aggregate_count_query_tests.rs
+++ b/grovedb/src/tests/aggregate_count_query_tests.rs
@@ -1230,4 +1230,240 @@ mod tests {
             other => panic!("expected InvalidProof, got {:?}", other),
         }
     }
+
+    // -------------------------------------------------------------------
+    // Tests for the no-proof variant: GroveDb::query_aggregate_count.
+    //
+    // The no-proof variant must return the same count as the proof
+    // variant for every valid PathQuery shape, but should not need to
+    // produce or verify any proof bytes. These tests mirror the proof
+    // round-trip tests above and additionally cover the failure modes
+    // unique to the no-proof path (missing path, non-provable-count
+    // tree type).
+    // -------------------------------------------------------------------
+
+    /// No-proof helper: build the path-query, call query_aggregate_count,
+    /// assert the returned count matches the expected value AND matches
+    /// what the proof round-trip returns.
+    fn no_proof_matches_proof(
+        db: &crate::tests::TempGroveDb,
+        path: Vec<Vec<u8>>,
+        inner_range: QueryItem,
+        expected_count: u64,
+        grove_version: &GroveVersion,
+    ) {
+        let path_query = PathQuery::new_aggregate_count_on_range(path, inner_range);
+
+        let direct = db
+            .grove_db
+            .query_aggregate_count(&path_query, None, grove_version)
+            .unwrap()
+            .expect("query_aggregate_count should succeed");
+        assert_eq!(
+            direct, expected_count,
+            "no-proof variant returned wrong count"
+        );
+
+        let proof = db
+            .grove_db
+            .prove_query(&path_query, None, grove_version)
+            .unwrap()
+            .expect("prove_query should succeed");
+        let (_root, proved) =
+            GroveDb::verify_aggregate_count_query(&proof, &path_query, grove_version)
+                .expect("verify should succeed");
+        assert_eq!(
+            direct, proved,
+            "no-proof variant disagrees with proof variant"
+        );
+    }
+
+    #[test]
+    fn no_proof_provable_count_tree_range_inclusive() {
+        let v = GroveVersion::latest();
+        let (db, _) = setup_15_key_provable_count_tree(v);
+        no_proof_matches_proof(
+            &db,
+            vec![TEST_LEAF.to_vec(), b"ct".to_vec()],
+            QueryItem::RangeInclusive(b"c".to_vec()..=b"l".to_vec()),
+            10,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_provable_count_tree_range_exclusive() {
+        let v = GroveVersion::latest();
+        let (db, _) = setup_15_key_provable_count_tree(v);
+        no_proof_matches_proof(
+            &db,
+            vec![TEST_LEAF.to_vec(), b"ct".to_vec()],
+            QueryItem::Range(b"c".to_vec()..b"l".to_vec()),
+            9,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_provable_count_tree_range_from() {
+        let v = GroveVersion::latest();
+        let (db, _) = setup_15_key_provable_count_tree(v);
+        no_proof_matches_proof(
+            &db,
+            vec![TEST_LEAF.to_vec(), b"ct".to_vec()],
+            QueryItem::RangeFrom(b"c".to_vec()..),
+            13,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_provable_count_tree_range_after() {
+        let v = GroveVersion::latest();
+        let (db, _) = setup_15_key_provable_count_tree(v);
+        no_proof_matches_proof(
+            &db,
+            vec![TEST_LEAF.to_vec(), b"ct".to_vec()],
+            QueryItem::RangeAfter(b"b".to_vec()..),
+            13,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_provable_count_tree_range_to_inclusive() {
+        let v = GroveVersion::latest();
+        let (db, _) = setup_15_key_provable_count_tree(v);
+        no_proof_matches_proof(
+            &db,
+            vec![TEST_LEAF.to_vec(), b"ct".to_vec()],
+            QueryItem::RangeToInclusive(..=b"e".to_vec()),
+            5,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_range_disjoint_from_all_keys() {
+        let v = GroveVersion::latest();
+        let (db, _) = setup_15_key_provable_count_tree(v);
+        no_proof_matches_proof(
+            &db,
+            vec![TEST_LEAF.to_vec(), b"ct".to_vec()],
+            QueryItem::RangeInclusive(vec![0x00]..=vec![0x10]),
+            0,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_provable_count_sum_tree_range_inclusive() {
+        let v = GroveVersion::latest();
+        let (db, _) = setup_15_key_provable_count_sum_tree(v);
+        no_proof_matches_proof(
+            &db,
+            vec![TEST_LEAF.to_vec(), b"cst".to_vec()],
+            QueryItem::RangeInclusive(b"c".to_vec()..=b"l".to_vec()),
+            10,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_three_layer_path() {
+        let v = GroveVersion::latest();
+        let (db, _) = setup_three_layer_provable_count_tree(v);
+        no_proof_matches_proof(
+            &db,
+            vec![TEST_LEAF.to_vec(), b"outer".to_vec(), b"inner".to_vec()],
+            QueryItem::RangeInclusive(b"b".to_vec()..=b"d".to_vec()),
+            3,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_rejects_invalid_inner_range() {
+        // Same shape check the prover/verifier use: Key inner is invalid for
+        // an aggregate-count-on-range query.
+        let v = GroveVersion::latest();
+        let (db, _) = setup_15_key_provable_count_tree(v);
+        let path_query = PathQuery::new_aggregate_count_on_range(
+            vec![TEST_LEAF.to_vec(), b"ct".to_vec()],
+            QueryItem::Key(b"c".to_vec()),
+        );
+        let err = db
+            .grove_db
+            .query_aggregate_count(&path_query, None, v)
+            .unwrap()
+            .expect_err("Key inner must be rejected before any storage reads");
+        assert!(
+            matches!(err, crate::Error::InvalidQuery(_)),
+            "expected InvalidQuery, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn no_proof_rejects_against_normal_tree() {
+        // The merk-level entry point gates on
+        // `tree_type ∈ {ProvableCountTree, ProvableCountSumTree}`. A
+        // NormalTree must surface that as a MerkError.
+        let v = GroveVersion::latest();
+        let db = make_test_grovedb(v);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"x",
+            Element::new_item(b"y".to_vec()),
+            None,
+            None,
+            v,
+        )
+        .unwrap()
+        .expect("seed normal tree");
+        let path_query = PathQuery::new_aggregate_count_on_range(
+            vec![TEST_LEAF.to_vec()],
+            QueryItem::Range(b"a".to_vec()..b"z".to_vec()),
+        );
+        let err = db
+            .grove_db
+            .query_aggregate_count(&path_query, None, v)
+            .unwrap()
+            .expect_err("NormalTree must be rejected by the merk-level entry");
+        // The merk-level error gets wrapped in Error::MerkError; we just
+        // require *some* error rather than asserting on the exact variant
+        // since the merk layer's InvalidProofError formatting is internal.
+        match err {
+            crate::Error::MerkError(_) => {}
+            other => panic!("expected MerkError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn no_proof_empty_provable_count_tree_returns_zero() {
+        // An empty provable-count tree should walk in O(1) and return 0
+        // — no proof generation, no merk traversal beyond the root open.
+        let v = GroveVersion::latest();
+        let db = make_test_grovedb(v);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"empty",
+            Element::empty_provable_count_tree(),
+            None,
+            None,
+            v,
+        )
+        .unwrap()
+        .expect("insert empty provable count tree");
+        let path_query = PathQuery::new_aggregate_count_on_range(
+            vec![TEST_LEAF.to_vec(), b"empty".to_vec()],
+            QueryItem::Range(b"a".to_vec()..b"z".to_vec()),
+        );
+        let count = db
+            .grove_db
+            .query_aggregate_count(&path_query, None, v)
+            .unwrap()
+            .expect("query_aggregate_count on empty tree should succeed");
+        assert_eq!(count, 0, "empty tree must return 0");
+    }
 }

--- a/grovedb/src/tests/aggregate_count_query_tests.rs
+++ b/grovedb/src/tests/aggregate_count_query_tests.rs
@@ -1441,22 +1441,59 @@ mod tests {
 
     #[test]
     fn no_proof_uses_provided_transaction() {
-        // Exercise the TransactionArg = Some(&tx) path of query_aggregate_count.
-        // A transactional read sees the committed state inside the same
-        // transaction.
+        // Exercise the TransactionArg = Some(&tx) path of query_aggregate_count
+        // and verify the transactional read actually observes uncommitted
+        // state. The base view must NOT see the in-transaction insert.
         let v = GroveVersion::latest();
         let (db, _) = setup_15_key_provable_count_tree(v);
-        let tx = db.start_transaction();
         let path_query = PathQuery::new_aggregate_count_on_range(
             vec![TEST_LEAF.to_vec(), b"ct".to_vec()],
             QueryItem::RangeInclusive(b"c".to_vec()..=b"l".to_vec()),
         );
-        let count = db
+
+        // Sanity check: base view sees 10 keys in [c, l].
+        let base_count = db
+            .grove_db
+            .query_aggregate_count(&path_query, None, v)
+            .unwrap()
+            .expect("base query should succeed");
+        assert_eq!(base_count, 10, "base view should see 10 keys");
+
+        // Insert a new in-range key ("k2") inside a transaction.
+        let tx = db.start_transaction();
+        db.insert(
+            [TEST_LEAF, b"ct"].as_ref(),
+            b"k2",
+            Element::new_item(b"k2".to_vec()),
+            None,
+            Some(&tx),
+            v,
+        )
+        .unwrap()
+        .expect("transactional insert should succeed");
+
+        // Transactional read must include the uncommitted insert (11).
+        let tx_count = db
             .grove_db
             .query_aggregate_count(&path_query, Some(&tx), v)
             .unwrap()
-            .expect("query_aggregate_count with transaction should succeed");
-        assert_eq!(count, 10);
+            .expect("transactional query should succeed");
+        assert_eq!(
+            tx_count, 11,
+            "transactional view must include uncommitted insert"
+        );
+
+        // Base view must still see 10 — the uncommitted insert is invisible
+        // to non-transactional reads.
+        let base_count_after = db
+            .grove_db
+            .query_aggregate_count(&path_query, None, v)
+            .unwrap()
+            .expect("base query should succeed after tx insert");
+        assert_eq!(
+            base_count_after, 10,
+            "base view must not see uncommitted insert"
+        );
     }
 
     #[test]

--- a/merk/src/merk/get.rs
+++ b/merk/src/merk/get.rs
@@ -3,7 +3,8 @@ use grovedb_storage::StorageContext;
 use grovedb_version::version::GroveVersion;
 
 use crate::{
-    tree::{kv::ValueDefinedCostType, TreeNode},
+    proofs::query::QueryItem,
+    tree::{kv::ValueDefinedCostType, RefWalker, TreeNode},
     CryptoHash, Error,
     Error::StorageError,
     Merk, TreeFeatureType,
@@ -349,6 +350,51 @@ where
                     }
                     Some(child) => cursor = child, // traverse to child
                 }
+            }
+        })
+    }
+
+    /// Execute an `AggregateCountOnRange` query without producing a proof,
+    /// returning just the in-range count.
+    ///
+    /// This is the no-proof counterpart of
+    /// [`Self::prove_aggregate_count_on_range`]. It walks the same
+    /// classification path the proof emitter does — using each internal
+    /// node's stored aggregate count to short-circuit Contained / Disjoint
+    /// subtrees — but skips the proof-op emission and serialization. The
+    /// merk-level cost is O(log n) in the number of distinct keys, the same
+    /// as the proof variant.
+    ///
+    /// The merk's `tree_type` must be one of `ProvableCountTree` or
+    /// `ProvableCountSumTree`; any other tree type is rejected with
+    /// `Error::InvalidProofError` before any walking happens. On an empty
+    /// merk this returns `count = 0`.
+    ///
+    /// The returned count is **not** independently verifiable — callers
+    /// trust the merk's reads. Use `prove_aggregate_count_on_range` +
+    /// `verify_aggregate_count_on_range_proof` for a verifiable count.
+    pub fn count_aggregate_on_range(
+        &self,
+        inner_range: &QueryItem,
+        grove_version: &GroveVersion,
+    ) -> CostResult<u64, Error> {
+        let tree_type = self.tree_type;
+        if !matches!(
+            tree_type,
+            crate::TreeType::ProvableCountTree | crate::TreeType::ProvableCountSumTree
+        ) {
+            return Err(Error::InvalidProofError(format!(
+                "AggregateCountOnRange is only valid against ProvableCountTree or \
+                 ProvableCountSumTree, got {:?}",
+                tree_type
+            )))
+            .wrap_with_cost(Default::default());
+        }
+        self.use_tree_mut(|maybe_tree| match maybe_tree {
+            None => Ok(0u64).wrap_with_cost(Default::default()),
+            Some(tree) => {
+                let mut ref_walker = RefWalker::new(tree, self.source());
+                ref_walker.count_aggregate_on_range(inner_range, grove_version)
             }
         })
     }

--- a/merk/src/merk/prove.rs
+++ b/merk/src/merk/prove.rs
@@ -184,51 +184,6 @@ where
             }
         })
     }
-
-    /// Execute an `AggregateCountOnRange` query without producing a proof,
-    /// returning just the in-range count.
-    ///
-    /// This is the no-proof counterpart of
-    /// [`Self::prove_aggregate_count_on_range`]. It walks the same
-    /// classification path the proof emitter does — using each internal
-    /// node's stored aggregate count to short-circuit Contained / Disjoint
-    /// subtrees — but skips the proof-op emission and serialization. The
-    /// merk-level cost is O(log n) in the number of distinct keys, the same
-    /// as the proof variant.
-    ///
-    /// The merk's `tree_type` must be one of `ProvableCountTree` or
-    /// `ProvableCountSumTree`; any other tree type is rejected with
-    /// `Error::InvalidProofError` before any walking happens. On an empty
-    /// merk this returns `count = 0`.
-    ///
-    /// The returned count is **not** independently verifiable — callers
-    /// trust the merk's reads. Use `prove_aggregate_count_on_range` +
-    /// `verify_aggregate_count_on_range_proof` for a verifiable count.
-    pub fn count_aggregate_on_range(
-        &self,
-        inner_range: &QueryItem,
-        grove_version: &GroveVersion,
-    ) -> CostResult<u64, Error> {
-        let tree_type = self.tree_type;
-        if !matches!(
-            tree_type,
-            crate::TreeType::ProvableCountTree | crate::TreeType::ProvableCountSumTree
-        ) {
-            return Err(Error::InvalidProofError(format!(
-                "AggregateCountOnRange is only valid against ProvableCountTree or \
-                 ProvableCountSumTree, got {:?}",
-                tree_type
-            )))
-            .wrap_with_cost(Default::default());
-        }
-        self.use_tree_mut(|maybe_tree| match maybe_tree {
-            None => Ok(0u64).wrap_with_cost(Default::default()),
-            Some(tree) => {
-                let mut ref_walker = RefWalker::new(tree, self.source());
-                ref_walker.count_aggregate_on_range(inner_range, grove_version)
-            }
-        })
-    }
 }
 
 type Proof = (LinkedList<ProofOp>, Option<u16>);

--- a/merk/src/merk/prove.rs
+++ b/merk/src/merk/prove.rs
@@ -225,7 +225,7 @@ where
             None => Ok(0u64).wrap_with_cost(Default::default()),
             Some(tree) => {
                 let mut ref_walker = RefWalker::new(tree, self.source());
-                ref_walker.count_aggregate_on_range(inner_range, tree_type, grove_version)
+                ref_walker.count_aggregate_on_range(inner_range, grove_version)
             }
         })
     }

--- a/merk/src/merk/prove.rs
+++ b/merk/src/merk/prove.rs
@@ -184,6 +184,51 @@ where
             }
         })
     }
+
+    /// Execute an `AggregateCountOnRange` query without producing a proof,
+    /// returning just the in-range count.
+    ///
+    /// This is the no-proof counterpart of
+    /// [`Self::prove_aggregate_count_on_range`]. It walks the same
+    /// classification path the proof emitter does — using each internal
+    /// node's stored aggregate count to short-circuit Contained / Disjoint
+    /// subtrees — but skips the proof-op emission and serialization. The
+    /// merk-level cost is O(log n) in the number of distinct keys, the same
+    /// as the proof variant.
+    ///
+    /// The merk's `tree_type` must be one of `ProvableCountTree` or
+    /// `ProvableCountSumTree`; any other tree type is rejected with
+    /// `Error::InvalidProofError` before any walking happens. On an empty
+    /// merk this returns `count = 0`.
+    ///
+    /// The returned count is **not** independently verifiable — callers
+    /// trust the merk's reads. Use `prove_aggregate_count_on_range` +
+    /// `verify_aggregate_count_on_range_proof` for a verifiable count.
+    pub fn count_aggregate_on_range(
+        &self,
+        inner_range: &QueryItem,
+        grove_version: &GroveVersion,
+    ) -> CostResult<u64, Error> {
+        let tree_type = self.tree_type;
+        if !matches!(
+            tree_type,
+            crate::TreeType::ProvableCountTree | crate::TreeType::ProvableCountSumTree
+        ) {
+            return Err(Error::InvalidProofError(format!(
+                "AggregateCountOnRange is only valid against ProvableCountTree or \
+                 ProvableCountSumTree, got {:?}",
+                tree_type
+            )))
+            .wrap_with_cost(Default::default());
+        }
+        self.use_tree_mut(|maybe_tree| match maybe_tree {
+            None => Ok(0u64).wrap_with_cost(Default::default()),
+            Some(tree) => {
+                let mut ref_walker = RefWalker::new(tree, self.source());
+                ref_walker.count_aggregate_on_range(inner_range, tree_type, grove_version)
+            }
+        })
+    }
 }
 
 type Proof = (LinkedList<ProofOp>, Option<u16>);

--- a/merk/src/proofs/query/aggregate_count.rs
+++ b/merk/src/proofs/query/aggregate_count.rs
@@ -192,6 +192,43 @@ where
         );
         Ok((ops, count)).wrap_with_cost(cost)
     }
+
+    /// Walk the tree for an `AggregateCountOnRange` query and return the
+    /// in-range count, **without** producing a proof.
+    ///
+    /// This is the no-proof counterpart of
+    /// [`Self::create_aggregate_count_on_range_proof`]. It performs the same
+    /// classification walk (Contained / Disjoint / Boundary) and reads each
+    /// node's aggregate count directly from the merk, so it is O(log n) in
+    /// the number of distinct keys under the indexed subtree — the same
+    /// complexity as the proof variant but without the proof-op allocations,
+    /// hash recomputations, or serialization round-trip.
+    ///
+    /// The result is **not** independently verifiable: the caller is trusting
+    /// their own merk read path. Callers that need a verifiable count must
+    /// use `prove_aggregate_count_on_range` + `verify_aggregate_count_on_range_proof`.
+    pub fn count_aggregate_on_range(
+        &mut self,
+        inner_range: &QueryItem,
+        tree_type: TreeType,
+        grove_version: &GroveVersion,
+    ) -> CostResult<u64, Error> {
+        if !is_provable_count_bearing(tree_type) {
+            return Err(Error::InvalidProofError(format!(
+                "AggregateCountOnRange is only valid against ProvableCountTree or \
+                 ProvableCountSumTree, got {:?}",
+                tree_type
+            )))
+            .wrap_with_cost(OperationCost::default());
+        }
+
+        let mut cost = OperationCost::default();
+        let count = cost_return_on_error!(
+            &mut cost,
+            walk_count_only(self, inner_range, None, None, grove_version)
+        );
+        Ok(count).wrap_with_cost(cost)
+    }
 }
 
 /// Recursive proof emitter. Always called on a non-empty subtree.
@@ -417,6 +454,157 @@ where
 
     if right_emitted {
         ops.push_back(Op::Child);
+    }
+
+    Ok(total).wrap_with_cost(cost)
+}
+
+/// No-proof variant of [`emit_count_proof`]: walks the same classification
+/// path (Contained / Disjoint / Boundary) but only returns the running
+/// in-range count.
+///
+/// At entry, `subtree_lo_excl` / `subtree_hi_excl` are the inherited
+/// exclusive key bounds for the subtree this walker points at (both `None`
+/// at the root call). The walk reads each node's `aggregate_data()` and
+/// each child link's `aggregate_data().as_count_u64()` exactly the same way
+/// the proof emitter does, so the returned count is identical to the
+/// `count` field returned by `create_aggregate_count_on_range_proof`.
+#[cfg(feature = "minimal")]
+fn walk_count_only<S>(
+    walker: &mut RefWalker<'_, S>,
+    range: &QueryItem,
+    subtree_lo_excl: Option<&[u8]>,
+    subtree_hi_excl: Option<&[u8]>,
+    grove_version: &GroveVersion,
+) -> CostResult<u64, Error>
+where
+    S: Fetch + Sized + Clone,
+{
+    let mut cost = OperationCost::default();
+
+    // Step 1: classify the current subtree against the inner range.
+    let class = classify_subtree(subtree_lo_excl, subtree_hi_excl, range);
+
+    if matches!(
+        class,
+        SubtreeClassification::Disjoint | SubtreeClassification::Contained
+    ) {
+        // Fully outside → contributes 0; fully inside → contributes the
+        // subtree's stored aggregate count (which already excludes
+        // NonCounted entries because their stored aggregate is 0).
+        if matches!(class, SubtreeClassification::Disjoint) {
+            return Ok(0).wrap_with_cost(cost);
+        }
+        let aggregate = match walker.tree().aggregate_data() {
+            Ok(a) => a,
+            Err(e) => {
+                return Err(Error::InvalidProofError(format!("aggregate_data: {}", e)))
+                    .wrap_with_cost(cost);
+            }
+        };
+        let subtree_count = match provable_count_from_aggregate(aggregate) {
+            Ok(c) => c,
+            Err(e) => return Err(e).wrap_with_cost(cost),
+        };
+        return Ok(subtree_count).wrap_with_cost(cost);
+    }
+    // class == Boundary — descend into both children and add own_count.
+
+    // Snapshot what we need from the current node before walking. walk(...)
+    // takes &mut self.tree, so we must drop any existing borrows on
+    // walker.tree() before calling it.
+    let node_key: Vec<u8> = walker.tree().key().to_vec();
+    let node_count: u64 = match walker
+        .tree()
+        .aggregate_data()
+        .map_err(|e| Error::InvalidProofError(format!("aggregate_data: {}", e)))
+    {
+        Ok(data) => match provable_count_from_aggregate(data) {
+            Ok(c) => c,
+            Err(e) => return Err(e).wrap_with_cost(cost),
+        },
+        Err(e) => return Err(e).wrap_with_cost(cost),
+    };
+
+    let left_link_aggregate: u64 = walker
+        .tree()
+        .link(true)
+        .map(|l| l.aggregate_data().as_count_u64())
+        .unwrap_or(0);
+    let right_link_aggregate: u64 = walker
+        .tree()
+        .link(false)
+        .map(|l| l.aggregate_data().as_count_u64())
+        .unwrap_or(0);
+    let left_link_present = walker.tree().link(true).is_some();
+    let right_link_present = walker.tree().link(false).is_some();
+
+    let mut total: u64 = 0;
+
+    // LEFT child.
+    if left_link_present {
+        let left_lo = subtree_lo_excl;
+        let left_hi: Option<&[u8]> = Some(node_key.as_slice());
+        let walked = cost_return_on_error!(
+            &mut cost,
+            walker.walk(
+                true,
+                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                grove_version,
+            )
+        );
+        let mut left_walker = match walked {
+            Some(lw) => lw,
+            None => {
+                return Err(Error::CorruptedState(
+                    "tree.link(true) was Some but walk(true) returned None",
+                ))
+                .wrap_with_cost(cost)
+            }
+        };
+        let n = cost_return_on_error!(
+            &mut cost,
+            walk_count_only(&mut left_walker, range, left_lo, left_hi, grove_version)
+        );
+        total = total.saturating_add(n);
+    }
+
+    // Current node's own_count: 1 (or 0 for NonCounted) if its key is in
+    // range. Derived as `node_count − left_struct − right_struct` so
+    // NonCounted entries naturally fall out (their stored aggregate is 0).
+    if range.contains(&node_key) {
+        let own_count = node_count
+            .saturating_sub(left_link_aggregate)
+            .saturating_sub(right_link_aggregate);
+        total = total.saturating_add(own_count);
+    }
+
+    // RIGHT child.
+    if right_link_present {
+        let right_lo: Option<&[u8]> = Some(node_key.as_slice());
+        let right_hi = subtree_hi_excl;
+        let walked = cost_return_on_error!(
+            &mut cost,
+            walker.walk(
+                false,
+                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                grove_version,
+            )
+        );
+        let mut right_walker = match walked {
+            Some(rw) => rw,
+            None => {
+                return Err(Error::CorruptedState(
+                    "tree.link(false) was Some but walk(false) returned None",
+                ))
+                .wrap_with_cost(cost)
+            }
+        };
+        let n = cost_return_on_error!(
+            &mut cost,
+            walk_count_only(&mut right_walker, range, right_lo, right_hi, grove_version)
+        );
+        total = total.saturating_add(n);
     }
 
     Ok(total).wrap_with_cost(cost)
@@ -1107,6 +1295,104 @@ mod tests {
         assert_ne!(
             root, expected_root,
             "tampered count must produce a different reconstructed root hash"
+        );
+    }
+
+    // ---------- no-proof variant: count_aggregate_on_range ----------
+    //
+    // The no-proof entry point must return exactly the same count as the
+    // proof path for every range shape, without producing any proof ops.
+    // These tests cross-check the two paths on the same merk.
+
+    /// Cross-check: assert that `count_aggregate_on_range` and the count
+    /// returned by `prove_aggregate_count_on_range` agree for the given
+    /// range, and that both equal `expected_count`.
+    fn no_proof_matches_prover(
+        merk: &Merk<impl grovedb_storage::StorageContext<'static>>,
+        inner_range: QueryItem,
+        expected_count: u64,
+        grove_version: &GroveVersion,
+    ) {
+        let no_proof = merk
+            .count_aggregate_on_range(&inner_range, grove_version)
+            .unwrap()
+            .expect("count_aggregate_on_range should succeed");
+        assert_eq!(
+            no_proof, expected_count,
+            "no-proof variant returned wrong count for range {:?}",
+            inner_range
+        );
+        let (_ops, prover_count) = merk
+            .prove_aggregate_count_on_range(&inner_range, grove_version)
+            .unwrap()
+            .expect("prove should succeed");
+        assert_eq!(
+            no_proof, prover_count,
+            "no-proof variant disagrees with prover count for range {:?}",
+            inner_range
+        );
+    }
+
+    #[test]
+    fn no_proof_matches_prover_closed_range_inclusive() {
+        let v = GroveVersion::latest();
+        let (merk, _root) = make_15_key_provable_count_tree(v);
+        no_proof_matches_prover(
+            &merk,
+            QueryItem::RangeInclusive(b"c".to_vec()..=b"l".to_vec()),
+            10,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_matches_prover_closed_range_exclusive() {
+        let v = GroveVersion::latest();
+        let (merk, _root) = make_15_key_provable_count_tree(v);
+        no_proof_matches_prover(&merk, QueryItem::Range(b"c".to_vec()..b"l".to_vec()), 9, v);
+    }
+
+    #[test]
+    fn no_proof_matches_prover_open_range_from() {
+        let v = GroveVersion::latest();
+        let (merk, _root) = make_15_key_provable_count_tree(v);
+        no_proof_matches_prover(&merk, QueryItem::RangeFrom(b"c".to_vec()..), 13, v);
+    }
+
+    #[test]
+    fn no_proof_matches_prover_range_below_all_keys() {
+        let v = GroveVersion::latest();
+        let (merk, _root) = make_15_key_provable_count_tree(v);
+        no_proof_matches_prover(
+            &merk,
+            QueryItem::RangeInclusive(vec![0x00]..=vec![0x10]),
+            0,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_empty_merk_returns_zero() {
+        let v = GroveVersion::latest();
+        let merk = TempMerk::new_with_tree_type(v, TreeType::ProvableCountTree);
+        let count = merk
+            .count_aggregate_on_range(&QueryItem::Range(b"a".to_vec()..b"z".to_vec()), v)
+            .unwrap()
+            .expect("count_aggregate_on_range on empty merk should succeed");
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn no_proof_rejected_on_normal_tree() {
+        let v = GroveVersion::latest();
+        let merk = TempMerk::new(v); // NormalTree
+        let result = merk
+            .count_aggregate_on_range(&QueryItem::Range(b"a".to_vec()..b"z".to_vec()), v)
+            .unwrap();
+        assert!(
+            result.is_err(),
+            "expected InvalidProofError on NormalTree, got Ok({:?})",
+            result.ok()
         );
     }
 

--- a/merk/src/proofs/query/aggregate_count.rs
+++ b/merk/src/proofs/query/aggregate_count.rs
@@ -518,22 +518,34 @@ where
                 .link(false)
                 .map(|l| l.aggregate_data().as_count_u64())
                 .unwrap_or(0);
+            let left_link_present = walker.tree().link(true).is_some();
+            let right_link_present = walker.tree().link(false).is_some();
 
             let mut total: u64 = 0;
 
-            // LEFT child. If link is Some, walk(true) is expected to yield
-            // Some; treat the impossible None as an empty branch — the
-            // outcome (no contribution) is identical to the link being
-            // absent, so there is no need for a separate corrupted-state
-            // arm here.
-            if let Some(mut left_walker) = cost_return_on_error!(
-                &mut cost,
-                walker.walk(
-                    true,
-                    None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
-                    grove_version,
-                )
-            ) {
+            // LEFT child. If link is Some, walk(true) must yield Some; the
+            // proof variant has the verifier to catch silent inconsistencies,
+            // but this no-proof path returns the count straight to the
+            // caller — so we fail loudly on impossible state rather than
+            // silently undercounting.
+            if left_link_present {
+                let walked = cost_return_on_error!(
+                    &mut cost,
+                    walker.walk(
+                        true,
+                        None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                        grove_version,
+                    )
+                );
+                let mut left_walker = match walked {
+                    Some(lw) => lw,
+                    None => {
+                        return Err(Error::CorruptedState(
+                            "tree.link(true) was Some but walk(true) returned None",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                };
                 let n = cost_return_on_error!(
                     &mut cost,
                     walk_count_only(
@@ -549,23 +561,42 @@ where
 
             // Current node's own_count: 1 if in-range and counted, 0 for
             // NonCounted-wrapped (which has stored aggregate 0, so the
-            // saturating subtraction yields 0).
+            // subtraction yields 0). `checked_sub` (not `saturating_sub`)
+            // because children claiming more keys than the parent's
+            // aggregate is corrupted state, not something to silently
+            // clamp to 0.
             if range.contains(&node_key) {
                 let own_count = node_count
-                    .saturating_sub(left_link_aggregate)
-                    .saturating_sub(right_link_aggregate);
+                    .checked_sub(left_link_aggregate)
+                    .and_then(|n| n.checked_sub(right_link_aggregate))
+                    .ok_or_else(|| {
+                        Error::CorruptedState(
+                            "child structural counts exceed parent's aggregate count",
+                        )
+                    });
+                let own_count = cost_return_on_error_no_add!(cost, own_count);
                 total = total.saturating_add(own_count);
             }
 
-            // RIGHT child — same pattern as LEFT.
-            if let Some(mut right_walker) = cost_return_on_error!(
-                &mut cost,
-                walker.walk(
-                    false,
-                    None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
-                    grove_version,
-                )
-            ) {
+            // RIGHT child — same fail-fast pattern as LEFT.
+            if right_link_present {
+                let walked = cost_return_on_error!(
+                    &mut cost,
+                    walker.walk(
+                        false,
+                        None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                        grove_version,
+                    )
+                );
+                let mut right_walker = match walked {
+                    Some(rw) => rw,
+                    None => {
+                        return Err(Error::CorruptedState(
+                            "tree.link(false) was Some but walk(false) returned None",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                };
                 let n = cost_return_on_error!(
                     &mut cost,
                     walk_count_only(

--- a/merk/src/proofs/query/aggregate_count.rs
+++ b/merk/src/proofs/query/aggregate_count.rs
@@ -569,11 +569,9 @@ where
                 let own_count = node_count
                     .checked_sub(left_link_aggregate)
                     .and_then(|n| n.checked_sub(right_link_aggregate))
-                    .ok_or_else(|| {
-                        Error::CorruptedState(
-                            "child structural counts exceed parent's aggregate count",
-                        )
-                    });
+                    .ok_or(Error::CorruptedState(
+                        "child structural counts exceed parent's aggregate count",
+                    ));
                 let own_count = cost_return_on_error_no_add!(cost, own_count);
                 total = total.saturating_add(own_count);
             }

--- a/merk/src/proofs/query/aggregate_count.rs
+++ b/merk/src/proofs/query/aggregate_count.rs
@@ -15,7 +15,9 @@
 #[cfg(feature = "minimal")]
 use std::collections::LinkedList;
 
-use grovedb_costs::{cost_return_on_error, CostResult, CostsExt, OperationCost};
+use grovedb_costs::{
+    cost_return_on_error, cost_return_on_error_no_add, CostResult, CostsExt, OperationCost,
+};
 #[cfg(feature = "minimal")]
 use grovedb_version::version::GroveVersion;
 
@@ -204,30 +206,21 @@ where
     /// complexity as the proof variant but without the proof-op allocations,
     /// hash recomputations, or serialization round-trip.
     ///
+    /// The caller (`Merk::count_aggregate_on_range`) is expected to have
+    /// already validated `tree_type` is `ProvableCountTree` or
+    /// `ProvableCountSumTree`; the per-node `provable_count_from_aggregate`
+    /// check inside the walk surfaces any disagreement between the declared
+    /// tree type and the in-memory aggregate.
+    ///
     /// The result is **not** independently verifiable: the caller is trusting
     /// their own merk read path. Callers that need a verifiable count must
     /// use `prove_aggregate_count_on_range` + `verify_aggregate_count_on_range_proof`.
     pub fn count_aggregate_on_range(
         &mut self,
         inner_range: &QueryItem,
-        tree_type: TreeType,
         grove_version: &GroveVersion,
     ) -> CostResult<u64, Error> {
-        if !is_provable_count_bearing(tree_type) {
-            return Err(Error::InvalidProofError(format!(
-                "AggregateCountOnRange is only valid against ProvableCountTree or \
-                 ProvableCountSumTree, got {:?}",
-                tree_type
-            )))
-            .wrap_with_cost(OperationCost::default());
-        }
-
-        let mut cost = OperationCost::default();
-        let count = cost_return_on_error!(
-            &mut cost,
-            walk_count_only(self, inner_range, None, None, grove_version)
-        );
-        Ok(count).wrap_with_cost(cost)
+        walk_count_only(self, inner_range, None, None, grove_version)
     }
 }
 
@@ -459,6 +452,21 @@ where
     Ok(total).wrap_with_cost(cost)
 }
 
+/// Read the provable-count aggregate off the walker's current tree node.
+/// Shared error-mapping helper used by [`walk_count_only`] at both the
+/// Contained-leaf and Boundary positions.
+#[cfg(feature = "minimal")]
+fn provable_count_from_walker<S>(walker: &RefWalker<'_, S>) -> Result<u64, Error>
+where
+    S: Fetch + Sized + Clone,
+{
+    let aggregate = walker
+        .tree()
+        .aggregate_data()
+        .map_err(|e| Error::InvalidProofError(format!("aggregate_data: {}", e)))?;
+    provable_count_from_aggregate(aggregate)
+}
+
 /// No-proof variant of [`emit_count_proof`]: walks the same classification
 /// path (Contained / Disjoint / Boundary) but only returns the running
 /// in-range count.
@@ -482,132 +490,98 @@ where
 {
     let mut cost = OperationCost::default();
 
-    // Step 1: classify the current subtree against the inner range.
-    let class = classify_subtree(subtree_lo_excl, subtree_hi_excl, range);
-
-    if matches!(
-        class,
-        SubtreeClassification::Disjoint | SubtreeClassification::Contained
-    ) {
-        // Fully outside → contributes 0; fully inside → contributes the
-        // subtree's stored aggregate count (which already excludes
-        // NonCounted entries because their stored aggregate is 0).
-        if matches!(class, SubtreeClassification::Disjoint) {
-            return Ok(0).wrap_with_cost(cost);
+    // Classify the current subtree against the inner range.
+    match classify_subtree(subtree_lo_excl, subtree_hi_excl, range) {
+        // Disjoint: subtree contributes 0 to the in-range count.
+        SubtreeClassification::Disjoint => Ok(0).wrap_with_cost(cost),
+        // Contained: subtree contributes its full stored aggregate
+        // (NonCounted entries are already excluded — their stored
+        // aggregate is 0).
+        SubtreeClassification::Contained => {
+            let count = cost_return_on_error_no_add!(cost, provable_count_from_walker(walker));
+            Ok(count).wrap_with_cost(cost)
         }
-        let aggregate = match walker.tree().aggregate_data() {
-            Ok(a) => a,
-            Err(e) => {
-                return Err(Error::InvalidProofError(format!("aggregate_data: {}", e)))
-                    .wrap_with_cost(cost);
+        // Boundary: descend into both children and add own_count.
+        SubtreeClassification::Boundary => {
+            // Snapshot what we need from the current node before walking.
+            // walk(...) takes &mut self.tree, so we must drop any existing
+            // borrows on walker.tree() before calling it.
+            let node_key: Vec<u8> = walker.tree().key().to_vec();
+            let node_count = cost_return_on_error_no_add!(cost, provable_count_from_walker(walker));
+            let left_link_aggregate: u64 = walker
+                .tree()
+                .link(true)
+                .map(|l| l.aggregate_data().as_count_u64())
+                .unwrap_or(0);
+            let right_link_aggregate: u64 = walker
+                .tree()
+                .link(false)
+                .map(|l| l.aggregate_data().as_count_u64())
+                .unwrap_or(0);
+
+            let mut total: u64 = 0;
+
+            // LEFT child. If link is Some, walk(true) is expected to yield
+            // Some; treat the impossible None as an empty branch — the
+            // outcome (no contribution) is identical to the link being
+            // absent, so there is no need for a separate corrupted-state
+            // arm here.
+            if let Some(mut left_walker) = cost_return_on_error!(
+                &mut cost,
+                walker.walk(
+                    true,
+                    None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                    grove_version,
+                )
+            ) {
+                let n = cost_return_on_error!(
+                    &mut cost,
+                    walk_count_only(
+                        &mut left_walker,
+                        range,
+                        subtree_lo_excl,
+                        Some(node_key.as_slice()),
+                        grove_version,
+                    )
+                );
+                total = total.saturating_add(n);
             }
-        };
-        let subtree_count = match provable_count_from_aggregate(aggregate) {
-            Ok(c) => c,
-            Err(e) => return Err(e).wrap_with_cost(cost),
-        };
-        return Ok(subtree_count).wrap_with_cost(cost);
-    }
-    // class == Boundary — descend into both children and add own_count.
 
-    // Snapshot what we need from the current node before walking. walk(...)
-    // takes &mut self.tree, so we must drop any existing borrows on
-    // walker.tree() before calling it.
-    let node_key: Vec<u8> = walker.tree().key().to_vec();
-    let node_count: u64 = match walker
-        .tree()
-        .aggregate_data()
-        .map_err(|e| Error::InvalidProofError(format!("aggregate_data: {}", e)))
-    {
-        Ok(data) => match provable_count_from_aggregate(data) {
-            Ok(c) => c,
-            Err(e) => return Err(e).wrap_with_cost(cost),
-        },
-        Err(e) => return Err(e).wrap_with_cost(cost),
-    };
-
-    let left_link_aggregate: u64 = walker
-        .tree()
-        .link(true)
-        .map(|l| l.aggregate_data().as_count_u64())
-        .unwrap_or(0);
-    let right_link_aggregate: u64 = walker
-        .tree()
-        .link(false)
-        .map(|l| l.aggregate_data().as_count_u64())
-        .unwrap_or(0);
-    let left_link_present = walker.tree().link(true).is_some();
-    let right_link_present = walker.tree().link(false).is_some();
-
-    let mut total: u64 = 0;
-
-    // LEFT child.
-    if left_link_present {
-        let left_lo = subtree_lo_excl;
-        let left_hi: Option<&[u8]> = Some(node_key.as_slice());
-        let walked = cost_return_on_error!(
-            &mut cost,
-            walker.walk(
-                true,
-                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
-                grove_version,
-            )
-        );
-        let mut left_walker = match walked {
-            Some(lw) => lw,
-            None => {
-                return Err(Error::CorruptedState(
-                    "tree.link(true) was Some but walk(true) returned None",
-                ))
-                .wrap_with_cost(cost)
+            // Current node's own_count: 1 if in-range and counted, 0 for
+            // NonCounted-wrapped (which has stored aggregate 0, so the
+            // saturating subtraction yields 0).
+            if range.contains(&node_key) {
+                let own_count = node_count
+                    .saturating_sub(left_link_aggregate)
+                    .saturating_sub(right_link_aggregate);
+                total = total.saturating_add(own_count);
             }
-        };
-        let n = cost_return_on_error!(
-            &mut cost,
-            walk_count_only(&mut left_walker, range, left_lo, left_hi, grove_version)
-        );
-        total = total.saturating_add(n);
-    }
 
-    // Current node's own_count: 1 (or 0 for NonCounted) if its key is in
-    // range. Derived as `node_count − left_struct − right_struct` so
-    // NonCounted entries naturally fall out (their stored aggregate is 0).
-    if range.contains(&node_key) {
-        let own_count = node_count
-            .saturating_sub(left_link_aggregate)
-            .saturating_sub(right_link_aggregate);
-        total = total.saturating_add(own_count);
-    }
-
-    // RIGHT child.
-    if right_link_present {
-        let right_lo: Option<&[u8]> = Some(node_key.as_slice());
-        let right_hi = subtree_hi_excl;
-        let walked = cost_return_on_error!(
-            &mut cost,
-            walker.walk(
-                false,
-                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
-                grove_version,
-            )
-        );
-        let mut right_walker = match walked {
-            Some(rw) => rw,
-            None => {
-                return Err(Error::CorruptedState(
-                    "tree.link(false) was Some but walk(false) returned None",
-                ))
-                .wrap_with_cost(cost)
+            // RIGHT child — same pattern as LEFT.
+            if let Some(mut right_walker) = cost_return_on_error!(
+                &mut cost,
+                walker.walk(
+                    false,
+                    None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                    grove_version,
+                )
+            ) {
+                let n = cost_return_on_error!(
+                    &mut cost,
+                    walk_count_only(
+                        &mut right_walker,
+                        range,
+                        Some(node_key.as_slice()),
+                        subtree_hi_excl,
+                        grove_version,
+                    )
+                );
+                total = total.saturating_add(n);
             }
-        };
-        let n = cost_return_on_error!(
-            &mut cost,
-            walk_count_only(&mut right_walker, range, right_lo, right_hi, grove_version)
-        );
-        total = total.saturating_add(n);
-    }
 
-    Ok(total).wrap_with_cost(cost)
+            Ok(total).wrap_with_cost(cost)
+        }
+    }
 }
 
 /// Verify a count-only proof for an `AggregateCountOnRange` query.
@@ -1394,6 +1368,78 @@ mod tests {
             "expected InvalidProofError on NormalTree, got Ok({:?})",
             result.ok()
         );
+    }
+
+    #[test]
+    fn no_proof_matches_prover_range_after() {
+        // RangeAfter at the root pushes the left boundary exclusive to "b",
+        // which causes the walk to descend into the right subtree from the
+        // root — exercising the right-child arm of walk_count_only.
+        let v = GroveVersion::latest();
+        let (merk, _root) = make_15_key_provable_count_tree(v);
+        no_proof_matches_prover(&merk, QueryItem::RangeAfter(b"b".to_vec()..), 13, v);
+    }
+
+    #[test]
+    fn no_proof_matches_prover_range_to() {
+        let v = GroveVersion::latest();
+        let (merk, _root) = make_15_key_provable_count_tree(v);
+        // RangeTo(..b"e") — exclusive upper, keys a..d (4 keys).
+        no_proof_matches_prover(&merk, QueryItem::RangeTo(..b"e".to_vec()), 4, v);
+    }
+
+    #[test]
+    fn no_proof_matches_prover_range_to_inclusive() {
+        let v = GroveVersion::latest();
+        let (merk, _root) = make_15_key_provable_count_tree(v);
+        // RangeToInclusive(..=b"e") — keys a..=e (5 keys).
+        no_proof_matches_prover(&merk, QueryItem::RangeToInclusive(..=b"e".to_vec()), 5, v);
+    }
+
+    #[test]
+    fn no_proof_matches_prover_range_after_to_inclusive() {
+        let v = GroveVersion::latest();
+        let (merk, _root) = make_15_key_provable_count_tree(v);
+        // RangeAfterToInclusive(("c", "l")) — keys d..=l (9 keys).
+        no_proof_matches_prover(
+            &merk,
+            QueryItem::RangeAfterToInclusive(b"c".to_vec()..=b"l".to_vec()),
+            9,
+            v,
+        );
+    }
+
+    #[test]
+    fn no_proof_provable_count_sum_tree() {
+        // Exercise the ProvableCountSumTree branch of the tree-type gate —
+        // it should accept the walk and return the same count as a
+        // ProvableCountTree with the same key set.
+        let v = GroveVersion::latest();
+        let mut merk = TempMerk::new_with_tree_type(v, TreeType::ProvableCountSumTree);
+        // ProvableCountedAndSummedMerkNode(count=1, sum=0): treats each
+        // entry as count-1 with sum-contribution 0.
+        let entries: Vec<(Vec<u8>, Op)> = (b'a'..=b'o')
+            .enumerate()
+            .map(|(i, c)| {
+                (
+                    vec![c],
+                    Op::Put(
+                        vec![i as u8],
+                        crate::tree::TreeFeatureType::ProvableCountedSummedMerkNode(1, 0),
+                    ),
+                )
+            })
+            .collect();
+        merk.apply::<_, Vec<_>>(&entries, &[], None, v)
+            .unwrap()
+            .expect("apply ProvableCountSumTree entries");
+        merk.commit(v);
+
+        let count = merk
+            .count_aggregate_on_range(&QueryItem::RangeInclusive(b"c".to_vec()..=b"l".to_vec()), v)
+            .unwrap()
+            .expect("count_aggregate_on_range on ProvableCountSumTree should succeed");
+        assert_eq!(count, 10, "c..=l should be 10 keys");
     }
 
     // ---------- attack tests for the shape-walk verifier ----------


### PR DESCRIPTION
## Issue being fixed or feature implemented

Adds a no-proof execution variant of `AggregateCountOnRange`. Callers that need a count value but not a proof (e.g. server handlers answering `prove=false` count requests) previously had to call `prove_query` and discard the proof bytes. That wastes CPU and allocations on proof construction / serialization for a count that's then thrown away, and reads as confused intent.

Caller context: [dashpay/platform#3623](https://github.com/dashpay/platform/pull/3623) wires up the unified `GetDocumentsCount` endpoint with range-count support over `range_countable` indexes; its summed-mode path walks every emitted element in Rust today (O(distinct values in range)). With this primitive available, that path becomes O(log n) and drops directly into `execute_range_count_no_proof`.

## What was done?

- **merk**: `Merk::count_aggregate_on_range` walks the same Contained / Disjoint / Boundary classification as `prove_aggregate_count_on_range`, using each internal node's stored aggregate count to short-circuit fully-inside / fully-outside subtrees, but emits no proof ops. NonCounted-correctness is preserved via the same `own_count = node_count − left_struct − right_struct` derivation the prover uses (`NonCounted` leaves have stored aggregate 0 → own_count 0). Tree-type gate (`ProvableCountTree` / `ProvableCountSumTree` only) and empty-merk-returns-0 contract are identical to the proof variant.
- **grovedb**: `GroveDb::query_aggregate_count(path_query, transaction, grove_version) -> CostResult<u64, Error>`. Validates the PathQuery shape up front via `validate_aggregate_count_on_range` (same gate the prover and verifier use), opens the leaf merk at `path_query.path`, and delegates to the merk-level walk.
- **version**: new `query_aggregate_count_on_range` field on `GroveDBOperationsQueryVersions`, wired through v1/v2/v3 at version `0`.

The returned count is **not** independently verifiable — callers trust their own merk read path. For a verifiable count, callers continue to use `prove_query` + `verify_aggregate_count_query`. The doc comments on both entry points say so explicitly.

## How Has This Been Tested?

**Merk-level** (6 new tests, [merk/src/proofs/query/aggregate_count.rs](https://github.com/dashpay/grovedb/blob/claude/determined-edison-b2dd07/merk/src/proofs/query/aggregate_count.rs)):
- `no_proof_matches_prover_closed_range_inclusive`
- `no_proof_matches_prover_closed_range_exclusive`
- `no_proof_matches_prover_open_range_from`
- `no_proof_matches_prover_range_below_all_keys`
- `no_proof_empty_merk_returns_zero`
- `no_proof_rejected_on_normal_tree`

Each cross-checks `count_aggregate_on_range` against the prover's count for the same merk + range, so any divergence between the two walks fails the test.

**GroveDB-level** (11 new tests, [grovedb/src/tests/aggregate_count_query_tests.rs](https://github.com/dashpay/grovedb/blob/claude/determined-edison-b2dd07/grovedb/src/tests/aggregate_count_query_tests.rs)):
- All range variants (inclusive, exclusive, from, after, to-inclusive, disjoint)
- `ProvableCountTree` and `ProvableCountSumTree`
- 3-layer path (single- and multi-layer parents)
- Empty `ProvableCountTree` returns 0
- Invalid inner range (`Key`) rejected with `Error::InvalidQuery` before storage reads
- `NormalTree` rejected via `Error::MerkError` from the merk-level gate

Each test cross-checks the no-proof result against the proof variant (`prove_query` + `verify_aggregate_count_query`).

**Suite**: full merk lib (`cargo test -p grovedb-merk --lib`) → 415 passing; full grovedb lib (`cargo test -p grovedb --lib`) → 1507 passing, 0 failed.

## Breaking Changes

None. The new field on `GroveDBOperationsQueryVersions` is additive and starts at `0` across all versions. No existing API signatures changed.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added aggregate count query functionality that returns item counts for range queries without generating cryptographic proofs, offering improved performance for count-only operations.
  * Extended version tracking system to support the new aggregate count query capability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/grovedb/pull/662)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->