### PR TITLE
ci: drop broken self-hosted macOS runner

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -62,39 +62,7 @@ jobs:
             echo "needs-tests=${{ steps.filter.outputs.any-code }}" >> "$GITHUB_OUTPUT"
           fi
 
-  # Fast path: run all tests on self-hosted Mac runner (no sharding needed)
-  test-mac:
-    name: Test (macOS)
-    needs: detect-changes
-    if: >-
-      needs.detect-changes.outputs.needs-tests == 'true'
-      && (github.event_name != 'pull_request'
-          || github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [self-hosted, macOS, ARM64]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@cargo-nextest
-      - name: Run all tests
-        run: >
-          cargo llvm-cov nextest
-          --workspace
-          --all-features
-          --lcov --output-path lcov.info
-      - name: Upload coverage
-        if: always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-
-  # Fallback: if Mac runner doesn't pick up the job within 15s, run sharded on Ubuntu
+  # Run tests sharded on Ubuntu
   test-ubuntu:
     name: Test Ubuntu (${{ matrix.partition }}/3)
     needs: detect-changes
@@ -105,41 +73,19 @@ jobs:
       matrix:
         partition: [1, 2, 3]
     steps:
-      - name: Wait and check if Mac runner is available
-        id: check-mac
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          sleep 15
-          MAC_STATUS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-            --jq '.jobs[] | select(.name == "Test (macOS)") | .status' 2>/dev/null || echo "unknown")
-          echo "mac-status=$MAC_STATUS" >> "$GITHUB_OUTPUT"
-          if [ "$MAC_STATUS" = "in_progress" ]; then
-            echo "Mac runner picked up the job — skipping Ubuntu fallback"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Mac runner not available (status: $MAC_STATUS) — running on Ubuntu"
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
       - uses: actions/checkout@v4
-        if: steps.check-mac.outputs.skip == 'false'
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.check-mac.outputs.skip == 'false'
         with:
           components: llvm-tools
       - uses: Swatinem/rust-cache@v2
-        if: steps.check-mac.outputs.skip == 'false'
         with:
           cache-on-failure: "false"
           workspaces: ". -> target/llvm-cov-target"
       - uses: taiki-e/install-action@cargo-llvm-cov
-        if: steps.check-mac.outputs.skip == 'false'
       - uses: taiki-e/install-action@cargo-nextest
-        if: steps.check-mac.outputs.skip == 'false'
       - name: Run tests (shard ${{ matrix.partition }}/3)
-        if: steps.check-mac.outputs.skip == 'false'
         run: >
           cargo llvm-cov nextest
           --workspace
@@ -147,7 +93,7 @@ jobs:
           --partition count:${{ matrix.partition }}/3
           --lcov --output-path lcov.info
       - name: Upload coverage
-        if: always() && steps.check-mac.outputs.skip == 'false'
+        if: always()
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info


### PR DESCRIPTION
## Issue being fixed or feature implemented

The self-hosted macOS ARM64 runner currently doesn't work — the \`test-mac\` job either never gets picked up or fails. The Ubuntu fallback in \`test-ubuntu\` was burning ~15 seconds on every CI run waiting to see if Mac would maybe claim the job before falling through to its sharded matrix.

Since the Linux runners are fast enough on their own (3 nextest shards, fully covers the workspace with \`--all-features\`), there's no reason to keep paying that latency tax.

## What was done?

- Removed the \`test-mac\` job entirely from [.github/workflows/grovedb.yml](.github/workflows/grovedb.yml).
- Removed the \`check-mac\` step in \`test-ubuntu\` (the \`sleep 15\` + \`gh api\` poll) and the \`if: steps.check-mac.outputs.skip == 'false'\` guard on every subsequent step. The Ubuntu sharded matrix now just runs unconditionally when tests are needed.
- Net diff: 1 file changed, 2 insertions(+), 56 deletions(-).

The rest of the pipeline (\`detect-changes\`, \`linting\`, \`formatting\`, \`security\`) is unchanged.

## How Has This Been Tested?

YAML parses cleanly (\`python3 -c "import yaml; yaml.safe_load(...)"\`). CI on this PR itself will exercise the simplified \`test-ubuntu\` path end-to-end.

## Breaking Changes

None at the code level. However: **if \`Test (macOS)\` is configured as a required status check in branch protection rules** on \`master\` / \`develop\`, that entry will need to be removed in repo settings — otherwise PRs will block forever waiting for a check that no longer runs. Worth confirming with:

\`\`\`
gh api repos/dashpay/grovedb/branches/develop/protection
\`\`\`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests (N/A — CI config only)
- [x] I have made corresponding changes to the documentation (N/A — no docs reference the Mac runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)