### PR TITLE
feat(merk,grovedb): reject NonCounted/NotCountedOrSummed in provable count parents

### DIFF
--- a/grovedb-element/src/element/constructor.rs
+++ b/grovedb-element/src/element/constructor.rs
@@ -468,6 +468,10 @@ impl Element {
     /// Use `into_non_counted` to wrap idempotently when `inner` may already
     /// be `NonCounted`; use that helper's `Result` return for the
     /// cross-wrapper case.
+    ///
+    /// Note: at insert time the parent must be `CountTree` or
+    /// `CountSumTree` (the non-provable count-bearing variants). Provable
+    /// count parents reject the wrapper at the merk-layer insert guard.
     pub fn new_non_counted(inner: Element) -> Result<Self, ElementError> {
         if matches!(
             inner,
@@ -566,8 +570,10 @@ impl Element {
     /// `NotSummed`, `NotCountedOrSummed`) — is rejected with
     /// `InvalidInput`.
     ///
-    /// Note: at insert time the parent must be `CountSumTree` or
-    /// `ProvableCountSumTree`. The merk-layer insert guard enforces that.
+    /// Note: at insert time the parent must be `CountSumTree`. Provable
+    /// count-and-sum parents (`ProvableCountSumTree`) reject the wrapper
+    /// at the merk-layer insert guard — they cryptographically commit the
+    /// count into every node hash and must reflect actual contents.
     pub fn new_not_counted_or_summed(inner: Element) -> Result<Self, ElementError> {
         match inner {
             Element::SumTree(..)

--- a/grovedb-element/src/element/mod.rs
+++ b/grovedb-element/src/element/mod.rs
@@ -135,8 +135,13 @@ pub enum Element {
     /// contributes 0 to its parent count tree's aggregate count when inserted.
     /// Sums still propagate to parent sum trees.
     ///
-    /// May only be inserted into count-bearing trees (`CountTree`,
-    /// `ProvableCountTree`, `CountSumTree`, `ProvableCountSumTree`).
+    /// May only be inserted into the non-provable count-bearing trees
+    /// (`CountTree`, `CountSumTree`). `ProvableCountTree` and
+    /// `ProvableCountSumTree` bind their aggregate count into every node
+    /// hash via `node_hash_with_count`, so a `NonCounted` child would
+    /// commit a cryptographic count that diverges from the actual number
+    /// of stored elements; the insert path rejects the wrapper in those
+    /// parents.
     ///
     /// Invariant: a `NonCounted` may not wrap another `NonCounted`. Enforced
     /// at construction and at deserialization.
@@ -164,9 +169,14 @@ pub enum Element {
     /// hashing, and its own internal aggregates, but contributes 0 to
     /// BOTH its parent's running sum AND the parent's count when inserted.
     ///
-    /// May only be inserted into count-AND-sum-bearing trees (`CountSumTree`,
-    /// `ProvableCountSumTree`) — the only tree types where suppressing both
-    /// axes is meaningful. Any other parent rejects the wrapper at insert.
+    /// May only be inserted into `CountSumTree` — the only non-provable
+    /// count-AND-sum-bearing tree, where suppressing both axes is
+    /// meaningful and the parent count is NOT cryptographically committed.
+    /// `ProvableCountSumTree` is rejected for the same reason as in
+    /// `NonCounted`: its count is bound into every node hash, so a
+    /// suppressed-count child would commit a cryptographic count that
+    /// diverges from the actual element count. Any other parent likewise
+    /// rejects the wrapper at insert.
     ///
     /// For `SumTree` / `BigSumTree` / `ProvableSumTree` inners, this wrapper
     /// suppresses the implicit count-of-one a subtree would contribute to a

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -2111,9 +2111,12 @@ where
                     // Without these checks, batch users could persist
                     // wrapped elements into the wrong tree types and silently
                     // violate the wrapper invariant.
-                    if element.is_non_counted() && !in_tree_type.is_count_bearing() {
+                    if element.is_non_counted() && !in_tree_type.accepts_non_counted_children() {
                         return Err(Error::InvalidBatchOperation(
-                            "non-counted elements may only be inserted into count-bearing trees",
+                            "non-counted elements may only be inserted into non-provable \
+                             count-bearing trees (CountTree or CountSumTree); Provable* count \
+                             trees commit the count cryptographically and cannot host \
+                             NonCounted children",
                         ))
                         .wrap_with_cost(cost);
                     }
@@ -2124,12 +2127,12 @@ where
                         .wrap_with_cost(cost);
                     }
                     if element.is_not_counted_or_summed()
-                        && !in_tree_type.is_count_and_sum_bearing()
+                        && !in_tree_type.accepts_not_counted_or_summed_children()
                     {
                         return Err(Error::InvalidBatchOperation(
-                            "not-counted-or-summed elements may only be inserted into trees \
-                             that bear BOTH count and sum (CountSumTree or \
-                             ProvableCountSumTree)",
+                            "not-counted-or-summed elements may only be inserted into \
+                             CountSumTree; ProvableCountSumTree commits the count \
+                             cryptographically and cannot host NotCountedOrSummed children",
                         ))
                         .wrap_with_cost(cost);
                     }
@@ -2496,15 +2499,18 @@ where
                     };
 
                     // Mirror the per-merk wrapper invariant enforced
-                    // for direct inserts: a NonCounted-wrapped
-                    // element may only live in a count-bearing
-                    // parent. Without this guard a trusted refresh
-                    // with `non_counted=true` could persist a
-                    // NonCounted wrapper into a non-count-bearing
-                    // tree.
-                    if element.is_non_counted() && !in_tree_type.is_count_bearing() {
+                    // for direct inserts: a NonCounted-wrapped element
+                    // may only live in a non-provable count-bearing
+                    // parent (`CountTree` or `CountSumTree`). Without
+                    // this guard a trusted refresh with
+                    // `non_counted=true` could persist a NonCounted
+                    // wrapper into a parent that doesn't accept it —
+                    // including any `Provable*` count tree where the
+                    // count is cryptographically committed.
+                    if element.is_non_counted() && !in_tree_type.accepts_non_counted_children() {
                         return Err(Error::InvalidBatchOperation(
-                            "RefreshReference with non_counted=true requires a count-bearing parent",
+                            "RefreshReference with non_counted=true requires a non-provable \
+                             count-bearing parent (CountTree or CountSumTree)",
                         ))
                         .wrap_with_cost(cost);
                     }

--- a/grovedb/src/tests/aggregate_count_query_tests.rs
+++ b/grovedb/src/tests/aggregate_count_query_tests.rs
@@ -1,9 +1,14 @@
 //! End-to-end GroveDB tests for `AggregateCountOnRange` queries.
 //!
 //! These exercise the full prove → encode → decode → verify pipeline against
-//! both `ProvableCountTree` and `ProvableCountSumTree` (and their
-//! `NonCounted*` wrappers via being the *parent* tree, not the queried one),
-//! at various path depths and across the full set of allowed range variants.
+//! both `ProvableCountTree` and `ProvableCountSumTree` at various path
+//! depths and across the full set of allowed range variants.
+//!
+//! NonCounted/NotCountedOrSummed wrappers are NOT accepted as children of
+//! Provable* count parents (the count is cryptographically committed; see
+//! `TreeType::accepts_non_counted_children`). The dedicated rejection
+//! coverage lives in `non_counted_tests.rs` /
+//! `not_counted_or_summed_tests.rs`.
 
 #[cfg(test)]
 mod tests {
@@ -896,26 +901,21 @@ mod tests {
         assert!(pq.validate_aggregate_count_on_range().is_err());
     }
 
-    /// `Element::NonCounted` wrappers tell the parent tree to **skip** the
-    /// wrapped element when aggregating its own count.
-    /// `AggregateCountOnRange` honors that: NonCounted children are
-    /// excluded from the result.
+    /// `Element::NonCounted` wrappers are NOT accepted as children of
+    /// `ProvableCountTree` (or any other `Provable*` count parent).
+    /// The aggregate count baked into every node hash via
+    /// `node_hash_with_count` IS the answer to an
+    /// `AggregateCountOnRange` query, and an opt-out from that count
+    /// would commit a cryptographic value that disagrees with the
+    /// actual number of stored elements. The merk-layer insert guard
+    /// rejects the wrapper before any data lands.
     ///
-    /// Mechanics — every node in a `ProvableCountTree` carries an
-    /// own_count of 1 (normal) or 0 (NonCounted). The merk-recorded
-    /// aggregate at any subtree = sum of own_counts in the subtree
-    /// (NonCounted entries contribute 0). The verifier's shape walk
-    /// derives each boundary node's own_count as
-    /// `node_aggregate − left_struct − right_struct` and credits **only
-    /// own_count** to the in-range total when the key falls in range.
-    /// For a NonCounted leaf, own_count = 0 and the wrapped key
-    /// contributes nothing. The structural counts threaded through the
-    /// walk are hash-bound at every step (every count-bearing proof node
-    /// feeds its count into `node_hash_with_count`), so a malicious
-    /// prover can't lie about a NonCounted node's status without
-    /// breaking the parent's hash chain.
+    /// This test pins the rejection so the `AggregateCountOnRange`
+    /// query never has to reason about a "NonCounted leaf in a
+    /// ProvableCountTree" shape — the shape is impossible to construct
+    /// going forward.
     #[test]
-    fn non_counted_children_are_excluded_from_aggregate_count() {
+    fn non_counted_child_rejected_in_provable_count_tree() {
         use crate::tests::TEST_LEAF;
 
         let v = GroveVersion::latest();
@@ -931,45 +931,16 @@ mod tests {
         .unwrap()
         .expect("insert ct");
 
-        // Five regular items — each contributes 1.
-        for c in [b'a', b'b', b'c', b'd', b'e'] {
-            db.insert(
-                [TEST_LEAF, b"ct"].as_ref(),
-                &[c],
-                Element::new_item(vec![c]),
-                None,
-                None,
-                v,
-            )
-            .unwrap()
-            .expect("insert regular item");
-        }
-
-        // One NonCounted-wrapped item, key "f" — in-range but contributes
-        // 0 (own_count = 0).
         let nc_item =
             Element::new_non_counted(Element::new_item(b"hidden".to_vec())).expect("wrap ok");
-        db.insert([TEST_LEAF, b"ct"].as_ref(), b"f", nc_item, None, None, v)
+        let err = db
+            .insert([TEST_LEAF, b"ct"].as_ref(), b"f", nc_item, None, None, v)
             .unwrap()
-            .expect("insert NonCounted item");
-
-        let root = db.grove_db.root_hash(None, v).unwrap().expect("root_hash");
-
-        let path_query = PathQuery::new_aggregate_count_on_range(
-            vec![TEST_LEAF.to_vec(), b"ct".to_vec()],
-            QueryItem::RangeInclusive(b"a".to_vec()..=b"z".to_vec()),
-        );
-        let proof = db
-            .grove_db
-            .prove_query(&path_query, None, v)
-            .unwrap()
-            .expect("prove");
-        let (got_root, got_count) =
-            GroveDb::verify_aggregate_count_query(&proof, &path_query, v).expect("verify");
-        assert_eq!(got_root, root, "root mismatch");
-        assert_eq!(
-            got_count, 5,
-            "NonCounted-wrapped child must be excluded from the aggregate count"
+            .expect_err("insert NonCounted into ProvableCountTree must fail");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("non-counted"),
+            "expected NonCounted parent-type guard error, got: {msg}"
         );
     }
 

--- a/grovedb/src/tests/non_counted_tests.rs
+++ b/grovedb/src/tests/non_counted_tests.rs
@@ -300,4 +300,181 @@ mod tests {
         .unwrap()
         .expect("insert into wrapped subtree must succeed");
     }
+
+    /// Helper: assert the error's debug rendering carries the
+    /// NonCounted parent-type guard wording. Used by the Provable*
+    /// rejection coverage below.
+    fn assert_is_non_counted_guard_error(err: &crate::Error) {
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("non-counted"),
+            "expected NonCounted parent-type guard error, got: {msg}"
+        );
+    }
+
+    /// `Element::NonCounted` is rejected as a child of `ProvableCountTree`
+    /// at insert time. The provable variant commits its aggregate count
+    /// into every node hash, so a NonCounted child would commit a
+    /// cryptographic count that disagrees with the actual number of
+    /// stored elements.
+    #[test]
+    fn direct_insert_rejects_non_counted_into_provable_count_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"pct",
+            Element::empty_provable_count_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert pct");
+
+        let nc = Element::new_non_counted(Element::new_item(b"x".to_vec())).expect("wrap ok");
+        let err = db
+            .insert(
+                [TEST_LEAF, b"pct"].as_ref(),
+                b"k",
+                nc,
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect_err("direct insert into ProvableCountTree must fail");
+        assert_is_non_counted_guard_error(&err);
+    }
+
+    /// Same rejection via the batch path. Pinned separately because the
+    /// batch flow has its own validator (`grovedb/src/batch/mod.rs`)
+    /// rather than going through the per-merk insert guard, and we
+    /// want to assert both surfaces enforce the rule consistently.
+    #[test]
+    fn batch_insert_rejects_non_counted_into_provable_count_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"pct",
+            Element::empty_provable_count_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert pct");
+
+        let nc = Element::new_non_counted(Element::new_item(b"x".to_vec())).expect("wrap ok");
+        let op = QualifiedGroveDbOp::insert_or_replace_op(
+            vec![TEST_LEAF.to_vec(), b"pct".to_vec()],
+            b"k".to_vec(),
+            nc,
+        );
+
+        let err = db
+            .apply_batch(vec![op], None, None, grove_version)
+            .unwrap()
+            .expect_err("batch insert into ProvableCountTree must fail");
+        assert_is_non_counted_guard_error(&err);
+    }
+
+    /// Same rejection against a `ProvableCountSumTree` parent. Both
+    /// provable count variants commit the count into node hashes, so
+    /// both must reject the wrapper.
+    #[test]
+    fn direct_insert_rejects_non_counted_into_provable_count_sum_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"pcst",
+            Element::empty_provable_count_sum_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert pcst");
+
+        let nc = Element::new_non_counted(Element::new_sum_item(7)).expect("wrap ok");
+        let err = db
+            .insert(
+                [TEST_LEAF, b"pcst"].as_ref(),
+                b"k",
+                nc,
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect_err("direct insert into ProvableCountSumTree must fail");
+        assert_is_non_counted_guard_error(&err);
+    }
+
+    #[test]
+    fn batch_insert_rejects_non_counted_into_provable_count_sum_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"pcst",
+            Element::empty_provable_count_sum_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert pcst");
+
+        let nc = Element::new_non_counted(Element::new_sum_item(7)).expect("wrap ok");
+        let op = QualifiedGroveDbOp::insert_or_replace_op(
+            vec![TEST_LEAF.to_vec(), b"pcst".to_vec()],
+            b"k".to_vec(),
+            nc,
+        );
+
+        let err = db
+            .apply_batch(vec![op], None, None, grove_version)
+            .unwrap()
+            .expect_err("batch insert into ProvableCountSumTree must fail");
+        assert_is_non_counted_guard_error(&err);
+    }
+
+    /// `NonCounted` IS still accepted in `CountSumTree` (non-provable
+    /// count+sum parent). Pin this so a future tightening of the
+    /// wrapper rule (e.g., "only `CountTree`") shows up here.
+    #[test]
+    fn non_counted_still_accepted_in_count_sum_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"cst",
+            Element::empty_count_sum_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert cst");
+
+        let nc = Element::new_non_counted(Element::new_sum_item(11)).expect("wrap ok");
+        db.insert(
+            [TEST_LEAF, b"cst"].as_ref(),
+            b"k",
+            nc,
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("NonCounted must still be accepted in CountSumTree");
+    }
 }

--- a/grovedb/src/tests/not_counted_or_summed_tests.rs
+++ b/grovedb/src/tests/not_counted_or_summed_tests.rs
@@ -1,10 +1,13 @@
 //! Regression tests for `Element::NotCountedOrSummed` end-to-end behavior.
 //!
 //! Symmetric to `not_summed_tests.rs` / `non_counted_tests.rs`. The wrapper:
-//! - May only be inserted into trees that bear BOTH a count and a sum
-//!   (`CountSumTree`, `ProvableCountSumTree`).
-//! - Inner element must be one of the four sum-tree variants (`SumTree`,
-//!   `BigSumTree`, `CountSumTree`, `ProvableCountSumTree`).
+//! - May only be inserted into `CountSumTree` (the non-provable
+//!   count-and-sum-bearing parent). `ProvableCountSumTree` rejects the
+//!   wrapper at insert time because the count is cryptographically
+//!   committed and must reflect actual contents.
+//! - Inner element must be one of the five sum-bearing tree variants
+//!   (`SumTree`, `BigSumTree`, `CountSumTree`, `ProvableCountSumTree`,
+//!   `ProvableSumTree`).
 //! - Contributes 0 to BOTH the parent's running sum AND its count. Internal
 //!   aggregates of the wrapped tree itself remain intact.
 
@@ -227,60 +230,43 @@ mod tests {
     }
 
     #[test]
-    fn direct_insert_not_counted_or_summed_in_provable_count_sum_tree_excludes_both_axes() {
-        // Same scenario but with a ProvableCountSumTree parent.
+    fn direct_insert_not_counted_or_summed_rejected_in_provable_count_sum_tree() {
+        // `ProvableCountSumTree` commits its aggregate count into every
+        // node hash, so a `NotCountedOrSummed` child would commit a
+        // cryptographic count that diverges from the actual element
+        // count. The direct-insert path must reject it. The only
+        // accepted count-and-sum parent for the wrapper is the
+        // non-provable `CountSumTree` (covered by
+        // `direct_insert_not_counted_or_summed_in_count_sum_tree_excludes_both_axes`).
         let grove_version = GroveVersion::latest();
         let db = make_test_grovedb(grove_version);
 
         make_provable_count_sum_tree_parent(&db, b"outer", grove_version);
 
-        // A plain item contributes (1, 0).
-        db.insert(
-            [TEST_LEAF, b"outer"].as_ref(),
-            b"plain",
-            Element::new_item(b"x".to_vec()),
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("insert plain item");
-
-        // NotCountedOrSummed(ProvableCountSumTree(_, 3, 100)) contributes
-        // (0, 0) even though the inner aggregates are non-trivial.
         let inner = Element::new_provable_count_sum_tree_with_flags_and_sum_and_count_value(
             None, 3, 100, None,
         );
         let wrapped = Element::new_not_counted_or_summed(inner).expect("wrap ok");
-        db.insert(
-            [TEST_LEAF, b"outer"].as_ref(),
-            b"w",
-            wrapped,
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("insert wrapped provable count sum tree");
 
-        // Aggregate must be (count=1, sum=0): only `plain` contributes the
-        // count; the wrapped tree's count=3 and sum=100 are both suppressed.
-        let batch = StorageBatch::new();
-        let tx = db.start_transaction();
-        let outer_merk = db
-            .open_transactional_merk_at_path(
-                [TEST_LEAF, b"outer"].as_ref().into(),
-                &tx,
-                Some(&batch),
+        let err = db
+            .insert(
+                [TEST_LEAF, b"outer"].as_ref(),
+                b"w",
+                wrapped,
+                None,
+                None,
                 grove_version,
             )
             .unwrap()
-            .expect("open outer merk");
-        let aggregate = outer_merk
-            .aggregate_data()
-            .expect("read outer aggregate data");
-        assert_eq!(aggregate.as_count_u64(), 1);
-        assert_eq!(aggregate.as_sum_i64(), 0);
+            .expect_err("insert into ProvableCountSumTree must fail");
+        // Direct insert surfaces the merk-layer guard as
+        // `InvalidInputError`, not the batch-flavored
+        // `InvalidBatchOperation`.
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("not-counted-or-summed"),
+            "expected NotCountedOrSummed parent-type guard error, got: {msg}"
+        );
     }
 
     #[test]
@@ -371,59 +357,35 @@ mod tests {
     }
 
     #[test]
-    fn direct_insert_not_counted_or_summed_provable_sum_tree_in_provable_count_sum_tree_excludes_both_axes(
-    ) {
-        // Same as the test above but with a ProvableCountSumTree parent —
-        // confirms the wrapper also works against the provable variant of
-        // the count-and-sum-bearing parent.
+    fn direct_insert_not_counted_or_summed_provable_sum_tree_rejected_in_provable_count_sum_tree() {
+        // Same parent-type rejection as
+        // `direct_insert_not_counted_or_summed_rejected_in_provable_count_sum_tree`,
+        // but with a `ProvableSumTree` inner — exercises that the guard
+        // fires on the parent type alone and does not depend on the
+        // wrapped variant.
         let grove_version = GroveVersion::latest();
         let db = make_test_grovedb(grove_version);
 
         make_provable_count_sum_tree_parent(&db, b"outer", grove_version);
 
-        // Plain item contributes (1, 0).
-        db.insert(
-            [TEST_LEAF, b"outer"].as_ref(),
-            b"plain",
-            Element::new_item(b"x".to_vec()),
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("insert plain item");
-
-        // NotCountedOrSummed(ProvableSumTree) → contributes (0, 0).
-        let inner = Element::new_provable_sum_tree(None);
-        let wrapped = Element::new_not_counted_or_summed(inner).expect("wrap ok");
-        db.insert(
-            [TEST_LEAF, b"outer"].as_ref(),
-            b"w",
-            wrapped,
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("insert wrapped provable sum tree");
-
-        // Outer aggregate must be (count=1, sum=0).
-        let batch = StorageBatch::new();
-        let tx = db.start_transaction();
-        let outer_merk = db
-            .open_transactional_merk_at_path(
-                [TEST_LEAF, b"outer"].as_ref().into(),
-                &tx,
-                Some(&batch),
+        let wrapped = Element::new_not_counted_or_summed(Element::new_provable_sum_tree(None))
+            .expect("wrap ok");
+        let err = db
+            .insert(
+                [TEST_LEAF, b"outer"].as_ref(),
+                b"w",
+                wrapped,
+                None,
+                None,
                 grove_version,
             )
             .unwrap()
-            .expect("open outer merk");
-        let aggregate = outer_merk
-            .aggregate_data()
-            .expect("read outer aggregate data");
-        assert_eq!(aggregate.as_count_u64(), 1);
-        assert_eq!(aggregate.as_sum_i64(), 0);
+            .expect_err("insert into ProvableCountSumTree must fail");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("not-counted-or-summed"),
+            "expected NotCountedOrSummed parent-type guard error, got: {msg}"
+        );
     }
 
     #[test]
@@ -519,79 +481,33 @@ mod tests {
     }
 
     #[test]
-    fn batch_propagation_preserves_wrapper_under_provable_count_sum_tree() {
-        // Same as the CountSumTree propagation test but with a
-        // ProvableCountSumTree parent — exercises the
-        // ProvableCountSumTree propagation arm in batch_structure.
+    fn batch_insert_rejects_not_counted_or_summed_into_provable_count_sum_tree() {
+        // Mirror of `batch_propagation_preserves_wrapper_under_count_sum_tree`,
+        // but the parent is `ProvableCountSumTree` — which commits its
+        // aggregate count into every node hash and therefore rejects the
+        // wrapper at the batch validation guard before any propagation
+        // can run. The corresponding accepted case (non-provable
+        // `CountSumTree` parent) lives in
+        // `batch_propagation_preserves_not_counted_or_summed_wrapper_on_subtree`.
         let grove_version = GroveVersion::latest();
         let db = make_test_grovedb(grove_version);
 
         make_provable_count_sum_tree_parent(&db, b"outer", grove_version);
 
-        // Plain item contributes (1, 0).
-        db.insert(
-            [TEST_LEAF, b"outer"].as_ref(),
-            b"plain",
-            Element::new_item(b"x".to_vec()),
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("insert plain");
-
         let wrapped =
             Element::new_not_counted_or_summed(Element::new_provable_count_sum_tree(None))
                 .expect("wrap ok");
-        let inner_child = Element::new_sum_item(99);
-        let ops = vec![
-            QualifiedGroveDbOp::insert_or_replace_op(
-                vec![TEST_LEAF.to_vec(), b"outer".to_vec()],
-                b"w".to_vec(),
-                wrapped,
-            ),
-            QualifiedGroveDbOp::insert_or_replace_op(
-                vec![TEST_LEAF.to_vec(), b"outer".to_vec(), b"w".to_vec()],
-                b"child".to_vec(),
-                inner_child,
-            ),
-        ];
-        db.apply_batch(ops, None, None, grove_version)
-            .unwrap()
-            .expect("batch should succeed");
-
-        // Wrapper must survive propagation.
-        let stored = db
-            .get_raw(
-                grovedb_path::SubtreePath::from(&[TEST_LEAF, b"outer"]),
-                b"w",
-                None,
-                grove_version,
-            )
-            .unwrap()
-            .expect("get_raw w");
-        assert!(
-            matches!(stored, Element::NotCountedOrSummed(_)),
-            "wrapper must survive batch propagation; got {:?}",
-            stored
+        let op = QualifiedGroveDbOp::insert_or_replace_op(
+            vec![TEST_LEAF.to_vec(), b"outer".to_vec()],
+            b"w".to_vec(),
+            wrapped,
         );
 
-        // Outer aggregate: count=1 (plain only), sum=0.
-        use grovedb_storage::StorageBatch;
-        let batch = StorageBatch::new();
-        let tx = db.start_transaction();
-        let outer_merk = db
-            .open_transactional_merk_at_path(
-                [TEST_LEAF, b"outer"].as_ref().into(),
-                &tx,
-                Some(&batch),
-                grove_version,
-            )
+        let err = db
+            .apply_batch(vec![op], None, None, grove_version)
             .unwrap()
-            .expect("open outer merk");
-        let aggregate = outer_merk.aggregate_data().expect("read aggregate");
-        assert_eq!(aggregate.as_count_u64(), 1);
-        assert_eq!(aggregate.as_sum_i64(), 0);
+            .expect_err("batch insert into ProvableCountSumTree must fail");
+        assert_is_not_counted_or_summed_guard_error(&err);
     }
 
     #[test]

--- a/merk/src/element/insert.rs
+++ b/merk/src/element/insert.rs
@@ -163,9 +163,11 @@ impl ElementInsertToStorageExtensions for Element {
 
         let serialized = cost_return_on_error_into_default!(self.serialize(grove_version));
 
-        if self.is_non_counted() && !merk.tree_type.is_count_bearing() {
+        if self.is_non_counted() && !merk.tree_type.accepts_non_counted_children() {
             return Err(Error::InvalidInputError(
-                "non-counted elements may only be inserted into count-bearing trees",
+                "non-counted elements may only be inserted into non-provable count-bearing \
+                 trees (CountTree or CountSumTree); Provable* count trees commit the count \
+                 cryptographically and cannot host NonCounted children",
             ))
             .wrap_with_cost(Default::default());
         }
@@ -177,10 +179,13 @@ impl ElementInsertToStorageExtensions for Element {
             .wrap_with_cost(Default::default());
         }
 
-        if self.is_not_counted_or_summed() && !merk.tree_type.is_count_and_sum_bearing() {
+        if self.is_not_counted_or_summed()
+            && !merk.tree_type.accepts_not_counted_or_summed_children()
+        {
             return Err(Error::InvalidInputError(
-                "not-counted-or-summed elements may only be inserted into trees that bear \
-                 BOTH count and sum (CountSumTree or ProvableCountSumTree)",
+                "not-counted-or-summed elements may only be inserted into CountSumTree; \
+                 ProvableCountSumTree commits the count cryptographically and cannot host \
+                 NotCountedOrSummed children",
             ))
             .wrap_with_cost(Default::default());
         }
@@ -449,9 +454,11 @@ impl ElementInsertToStorageExtensions for Element {
             grove_version.grovedb_versions.element.insert_reference
         );
 
-        if self.is_non_counted() && !merk.tree_type.is_count_bearing() {
+        if self.is_non_counted() && !merk.tree_type.accepts_non_counted_children() {
             return Err(Error::InvalidInputError(
-                "non-counted elements may only be inserted into count-bearing trees",
+                "non-counted elements may only be inserted into non-provable count-bearing \
+                 trees (CountTree or CountSumTree); Provable* count trees commit the count \
+                 cryptographically and cannot host NonCounted children",
             ))
             .wrap_with_cost(Default::default());
         }
@@ -463,10 +470,13 @@ impl ElementInsertToStorageExtensions for Element {
             .wrap_with_cost(Default::default());
         }
 
-        if self.is_not_counted_or_summed() && !merk.tree_type.is_count_and_sum_bearing() {
+        if self.is_not_counted_or_summed()
+            && !merk.tree_type.accepts_not_counted_or_summed_children()
+        {
             return Err(Error::InvalidInputError(
-                "not-counted-or-summed elements may only be inserted into trees that bear \
-                 BOTH count and sum (CountSumTree or ProvableCountSumTree)",
+                "not-counted-or-summed elements may only be inserted into CountSumTree; \
+                 ProvableCountSumTree commits the count cryptographically and cannot host \
+                 NotCountedOrSummed children",
             ))
             .wrap_with_cost(Default::default());
         }
@@ -556,9 +566,11 @@ impl ElementInsertToStorageExtensions for Element {
             grove_version.grovedb_versions.element.insert_subtree
         );
 
-        if self.is_non_counted() && !merk.tree_type.is_count_bearing() {
+        if self.is_non_counted() && !merk.tree_type.accepts_non_counted_children() {
             return Err(Error::InvalidInputError(
-                "non-counted elements may only be inserted into count-bearing trees",
+                "non-counted elements may only be inserted into non-provable count-bearing \
+                 trees (CountTree or CountSumTree); Provable* count trees commit the count \
+                 cryptographically and cannot host NonCounted children",
             ))
             .wrap_with_cost(Default::default());
         }
@@ -570,10 +582,13 @@ impl ElementInsertToStorageExtensions for Element {
             .wrap_with_cost(Default::default());
         }
 
-        if self.is_not_counted_or_summed() && !merk.tree_type.is_count_and_sum_bearing() {
+        if self.is_not_counted_or_summed()
+            && !merk.tree_type.accepts_not_counted_or_summed_children()
+        {
             return Err(Error::InvalidInputError(
-                "not-counted-or-summed elements may only be inserted into trees that bear \
-                 BOTH count and sum (CountSumTree or ProvableCountSumTree)",
+                "not-counted-or-summed elements may only be inserted into CountSumTree; \
+                 ProvableCountSumTree commits the count cryptographically and cannot host \
+                 NotCountedOrSummed children",
             ))
             .wrap_with_cost(Default::default());
         }
@@ -848,21 +863,42 @@ mod tests {
     }
 
     #[test]
-    fn non_counted_accepted_in_provable_count_sum_tree_keeps_sum() {
+    fn non_counted_rejected_in_provable_count_sum_tree() {
+        // ProvableCountSumTree commits its aggregate count into every node
+        // hash, so a NonCounted child would commit a cryptographic count
+        // that diverges from the actual element count. The merk-layer
+        // insert guard rejects the wrapper. Symmetric coverage for
+        // ProvableCountTree lives in
+        // `non_counted_rejected_in_provable_count_tree`.
         let grove_version = GroveVersion::latest();
         let mut merk = TempMerk::new_with_tree_type(grove_version, TreeType::ProvableCountSumTree);
+        let nc = Element::new_non_counted(Element::new_sum_item(10)).expect("wrap ok");
+        let result = nc.insert(&mut merk, b"k", None, grove_version).unwrap();
+        assert!(matches!(result, Err(Error::InvalidInputError(_))));
+    }
 
-        // A NonCounted(SumItem(10)) inside a ProvableCountSumTree contributes
-        // count = 0 and sum = 10.
-        Element::new_non_counted(Element::new_sum_item(10))
-            .expect("wrap ok")
-            .insert(&mut merk, b"k", None, grove_version)
-            .unwrap()
-            .expect("insert nc sum item");
+    #[test]
+    fn non_counted_rejected_in_provable_count_tree() {
+        // Same rejection as above, against a `ProvableCountTree` parent.
+        let grove_version = GroveVersion::latest();
+        let mut merk = TempMerk::new_with_tree_type(grove_version, TreeType::ProvableCountTree);
+        let nc = Element::new_non_counted(Element::new_item(b"x".to_vec())).expect("wrap ok");
+        let result = nc.insert(&mut merk, b"k", None, grove_version).unwrap();
+        assert!(matches!(result, Err(Error::InvalidInputError(_))));
+    }
 
-        let agg = merk.aggregate_data().expect("aggregate ok");
-        assert_eq!(agg.as_count_u64(), 0);
-        assert_eq!(agg.as_sum_i64(), 10);
+    #[test]
+    fn non_counted_subtree_rejected_in_provable_count_tree() {
+        // Same rejection via the subtree entry point (used for tree
+        // children). This is the entry point a NonCounted-wrapped tree
+        // would actually hit when inserted under a ProvableCountTree.
+        let grove_version = GroveVersion::latest();
+        let mut merk = TempMerk::new_with_tree_type(grove_version, TreeType::ProvableCountTree);
+        let nc_tree = Element::new_non_counted(Element::empty_count_tree()).expect("wrap ok");
+        let result = nc_tree
+            .insert_subtree(&mut merk, b"k", [0u8; 32], None, grove_version)
+            .unwrap();
+        assert!(matches!(result, Err(Error::InvalidInputError(_))));
     }
 
     #[test]
@@ -1048,28 +1084,25 @@ mod tests {
     }
 
     #[test]
-    fn not_counted_or_summed_in_provable_count_sum_tree_excludes_both_axes() {
-        // Symmetric to the CountSumTree case below but with a
-        // ProvableCountSumTree parent — exercises the second
-        // is_count_and_sum_bearing variant.
+    fn not_counted_or_summed_rejected_in_provable_count_sum_tree() {
+        // `ProvableCountSumTree` commits its count into every node hash,
+        // so a NotCountedOrSummed child would commit a cryptographic
+        // count that diverges from the actual element count. The only
+        // accepted parent for this wrapper is the non-provable
+        // `CountSumTree` (see
+        // `not_counted_or_summed_in_count_sum_tree_excludes_both_axes`).
         let grove_version = GroveVersion::latest();
         let mut merk = TempMerk::new_with_tree_type(grove_version, TreeType::ProvableCountSumTree);
-
-        // Bare ProvableCountSumTree(_, 3, 100) contributes (3, 100).
-        // Wrapped, contributes (0, 0).
         let w = Element::new_not_counted_or_summed(
             Element::new_provable_count_sum_tree_with_flags_and_sum_and_count_value(
                 None, 3, 100, None,
             ),
         )
         .expect("wrap ok");
-        w.insert_subtree(&mut merk, b"k", [0u8; 32], None, grove_version)
-            .unwrap()
-            .expect("insert wrapped");
-
-        let agg = merk.aggregate_data().expect("aggregate ok");
-        assert_eq!(agg.as_count_u64(), 0);
-        assert_eq!(agg.as_sum_i64(), 0);
+        let result = w
+            .insert_subtree(&mut merk, b"k", [0u8; 32], None, grove_version)
+            .unwrap();
+        assert!(matches!(result, Err(Error::InvalidInputError(_))));
     }
 
     #[test]

--- a/merk/src/tree_type/mod.rs
+++ b/merk/src/tree_type/mod.rs
@@ -166,16 +166,47 @@ impl TreeType {
     }
 
     /// Returns whether this tree type carries BOTH a count and a sum
-    /// aggregate. Only these tree types may host
-    /// `Element::NotCountedOrSummed` children — in any other parent the
-    /// wrapper would suppress an aggregate the parent doesn't track, so it
-    /// is rejected at insert time. Equivalent to `is_count_bearing() &&
-    /// is_sum_bearing()`.
+    /// aggregate. Equivalent to `is_count_bearing() && is_sum_bearing()`.
+    ///
+    /// NOTE: this predicate intentionally still includes
+    /// `ProvableCountSumTree`. It answers the structural question
+    /// "does this tree track both axes?" — used by aggregate logic.
+    /// For the wrapper-acceptance question ("may this parent host a
+    /// `NotCountedOrSummed` child?"), use
+    /// `accepts_not_counted_or_summed_children`, which additionally
+    /// rejects the `Provable*` variants.
     pub const fn is_count_and_sum_bearing(&self) -> bool {
         matches!(
             self,
             TreeType::CountSumTree | TreeType::ProvableCountSumTree
         )
+    }
+
+    /// Returns whether this parent tree type may host an
+    /// `Element::NonCounted` child.
+    ///
+    /// Stricter than `is_count_bearing`: the wrapper is allowed only in
+    /// the non-provable count-bearing trees (`CountTree`, `CountSumTree`).
+    /// `ProvableCountTree` / `ProvableCountSumTree` bind their aggregate
+    /// count into every node's hash via `node_hash_with_count`, so a
+    /// `NonCounted` child would commit a cryptographic count that
+    /// diverges from the actual number of stored elements — confusing
+    /// for callers and a footgun for proof-driven readers. The wrapper
+    /// is rejected at insert time in those parents.
+    pub const fn accepts_non_counted_children(&self) -> bool {
+        matches!(self, TreeType::CountTree | TreeType::CountSumTree)
+    }
+
+    /// Returns whether this parent tree type may host an
+    /// `Element::NotCountedOrSummed` child.
+    ///
+    /// Stricter than `is_count_and_sum_bearing`: only the non-provable
+    /// count-and-sum-bearing tree (`CountSumTree`) is accepted.
+    /// `ProvableCountSumTree` is excluded for the same reason as in
+    /// `accepts_non_counted_children` — the count (and sum) are
+    /// cryptographically committed and must reflect actual contents.
+    pub const fn accepts_not_counted_or_summed_children(&self) -> bool {
+        matches!(self, TreeType::CountSumTree)
     }
 
     /// Returns whether this tree type allows sum items as children.
@@ -409,6 +440,63 @@ mod tests {
                 tt
             );
         }
+    }
+
+    #[test]
+    fn accepts_non_counted_children() {
+        // Allowed: non-provable count-bearing parents.
+        assert!(TreeType::CountTree.accepts_non_counted_children());
+        assert!(TreeType::CountSumTree.accepts_non_counted_children());
+        // Rejected: provable count-bearing parents (cryptographic count
+        // would diverge from actual element count).
+        assert!(!TreeType::ProvableCountTree.accepts_non_counted_children());
+        assert!(!TreeType::ProvableCountSumTree.accepts_non_counted_children());
+        // Everything else: also rejected.
+        assert!(!TreeType::NormalTree.accepts_non_counted_children());
+        assert!(!TreeType::SumTree.accepts_non_counted_children());
+        assert!(!TreeType::BigSumTree.accepts_non_counted_children());
+        assert!(!TreeType::CommitmentTree(0).accepts_non_counted_children());
+        assert!(!TreeType::MmrTree.accepts_non_counted_children());
+        assert!(!TreeType::BulkAppendTree(0).accepts_non_counted_children());
+        assert!(!TreeType::DenseAppendOnlyFixedSizeTree(0).accepts_non_counted_children());
+        assert!(!TreeType::ProvableSumTree.accepts_non_counted_children());
+
+        // Implication: every parent that accepts a NonCounted child is
+        // count-bearing, but not vice-versa (Provable* are count-bearing
+        // and reject the wrapper).
+        for tt in [
+            TreeType::NormalTree,
+            TreeType::SumTree,
+            TreeType::BigSumTree,
+            TreeType::CountTree,
+            TreeType::CountSumTree,
+            TreeType::ProvableCountTree,
+            TreeType::ProvableCountSumTree,
+            TreeType::ProvableSumTree,
+        ] {
+            if tt.accepts_non_counted_children() {
+                assert!(tt.is_count_bearing(), "{:?}", tt);
+            }
+        }
+    }
+
+    #[test]
+    fn accepts_not_counted_or_summed_children() {
+        // Only CountSumTree accepts NotCountedOrSummed.
+        assert!(TreeType::CountSumTree.accepts_not_counted_or_summed_children());
+        // ProvableCountSumTree is rejected — provable count is committed.
+        assert!(!TreeType::ProvableCountSumTree.accepts_not_counted_or_summed_children());
+        // Single-axis trees: rejected (would suppress an axis they don't track).
+        assert!(!TreeType::NormalTree.accepts_not_counted_or_summed_children());
+        assert!(!TreeType::SumTree.accepts_not_counted_or_summed_children());
+        assert!(!TreeType::BigSumTree.accepts_not_counted_or_summed_children());
+        assert!(!TreeType::CountTree.accepts_not_counted_or_summed_children());
+        assert!(!TreeType::ProvableCountTree.accepts_not_counted_or_summed_children());
+        assert!(!TreeType::CommitmentTree(0).accepts_not_counted_or_summed_children());
+        assert!(!TreeType::MmrTree.accepts_not_counted_or_summed_children());
+        assert!(!TreeType::BulkAppendTree(0).accepts_not_counted_or_summed_children());
+        assert!(!TreeType::DenseAppendOnlyFixedSizeTree(0).accepts_not_counted_or_summed_children());
+        assert!(!TreeType::ProvableSumTree.accepts_not_counted_or_summed_children());
     }
 
     #[test]


### PR DESCRIPTION
## Why

`ProvableCountTree` and `ProvableCountSumTree` bind their aggregate count into every node hash via `node_hash_with_count`. That committed count IS the answer to an `AggregateCountOnRange` query.

Today, `NonCounted` and `NotCountedOrSummed` children are accepted in those parents (via `is_count_bearing` / `is_count_and_sum_bearing`). They contribute `own_count = 0`, so the cryptographically-committed count silently disagrees with the actual number of stored elements — confusing for callers, and a footgun for proof-driven readers who reasonably assume "if I iterate this range I'll get the same number the proof returned."

This PR makes that shape impossible going forward, while leaving the wrappers fully usable in the non-provable count-bearing parents where the count is plain bookkeeping rather than a cryptographic commitment.

## Rule

| Wrapper | Allowed parent(s) | Newly rejected parent(s) |
|---|---|---|
| `NonCounted` | `CountTree`, `CountSumTree` | `ProvableCountTree`, `ProvableCountSumTree` |
| `NotCountedOrSummed` | `CountSumTree` | `ProvableCountSumTree` |
| `NotSummed` | unchanged (uses `is_sum_bearing`) | — |

`is_count_bearing` and `is_count_and_sum_bearing` are unchanged — they still answer the structural question "does this tree track count/sum?" for the aggregate logic that legitimately needs that. The new wrapper-acceptance rule lives in two new dedicated predicates:

```rust
TreeType::accepts_non_counted_children()          // CountTree | CountSumTree
TreeType::accepts_not_counted_or_summed_children() // CountSumTree
```

## Guard sites updated

- `merk/src/element/insert.rs` — `insert`, `insert_reference`, `insert_subtree`.
- `grovedb/src/batch/mod.rs` — batch validation guard, plus the `RefreshReference` trusted path.

Direct (per-merk) and batch surfaces both now reject the disallowed combinations with `InvalidInputError` / `InvalidBatchOperation`.

## Tests

- 6 existing acceptance tests in `merk/src/element/insert.rs`, `grovedb/src/tests/not_counted_or_summed_tests.rs`, and `grovedb/src/tests/aggregate_count_query_tests.rs` flipped to assert rejection.
- 4 new direct + batch rejection tests in `non_counted_tests.rs` pin both wrappers against both `Provable*` count parents.
- `non_counted_still_accepted_in_count_sum_tree` pins the deliberate remaining acceptance so a future tightening (e.g., "only `CountTree`") surfaces here.
- TreeType-level unit tests for the two new predicates.

Full local results:
- `cargo test -p grovedb-merk --lib` → 497 / 497 pass.
- `cargo test -p grovedb --lib` → 1718 / 1718 pass.
- `cargo test -p grovedb-element` → 4 / 4 pass.
- `cargo fmt --all -- --check` → clean.

## Compatibility

No grove-version gate — same approach used when the wrappers were originally added in [#654](https://github.com/dashpay/grovedb/pull/654) and [#666](https://github.com/dashpay/grovedb/pull/666). Platform upgrades are coordinated, and no production data currently uses the now-rejected shape (these wrappers landed recently). The dead verifier paths that handled `own_count = 0` in proof walks remain in place as defensive code for any historical reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)