### PR TITLE
chore(audit): ignore accepted bincode advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+[advisories]
+ignore = [
+    # Reviewed in https://github.com/dashpay/grovedb/issues/722.
+    # The bincode 2.0.1 unmaintained advisory is intentionally accepted for
+    # this workspace; decoding canonicality is tracked separately.
+    "RUSTSEC-2025-0141",
+]


### PR DESCRIPTION
## Summary
- add a cargo-audit config that ignores RUSTSEC-2025-0141
- document that the bincode 2.0.1 advisory was reviewed in #722 and intentionally accepted
- keep decoding canonicality tracked separately from the dependency maintenance warning

## Verification
- /tmp/grovedb-cargo-audit-root/bin/cargo-audit audit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cargo audit configuration for security advisory management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/grovedb/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->