### PR TITLE
fix(proofs): reject trailing bytes in append-only decoders

### DIFF
--- a/grovedb-bulk-append-tree/src/proof/mod.rs
+++ b/grovedb-bulk-append-tree/src/proof/mod.rs
@@ -560,9 +560,20 @@ impl BulkAppendTreeProof {
         let config = bincode::config::standard()
             .with_big_endian()
             .with_limit::<{ 100 * 1024 * 1024 }>();
-        let (proof, _) = bincode::decode_from_slice(bytes, config).map_err(|e| {
-            BulkAppendError::CorruptedData(format!("failed to decode BulkAppendTreeProof: {}", e))
-        })?;
+        let (proof, consumed): (Self, usize) =
+            bincode::decode_from_slice(bytes, config).map_err(|e| {
+                BulkAppendError::CorruptedData(format!(
+                    "failed to decode BulkAppendTreeProof: {}",
+                    e
+                ))
+            })?;
+        if consumed != bytes.len() {
+            return Err(BulkAppendError::CorruptedData(format!(
+                "BulkAppendTreeProof decode did not consume all bytes: consumed {}, total {}",
+                consumed,
+                bytes.len()
+            )));
+        }
         Ok(proof)
     }
 }

--- a/grovedb-bulk-append-tree/src/proof/tests.rs
+++ b/grovedb-bulk-append-tree/src/proof/tests.rs
@@ -266,6 +266,24 @@ mod proof_tests {
     }
 
     #[test]
+    fn test_bulk_proof_decode_rejects_trailing_bytes() {
+        let height = 2u8;
+        let values: Vec<Vec<u8>> = (0..4u32).map(|i| format!("r_{}", i).into_bytes()).collect();
+        let (_state_root, tree) = build_test_tree(height, &values);
+        let proof =
+            BulkAppendTreeProof::generate(&range_query(0, 4), &tree).expect("generate proof");
+
+        let mut bytes = proof.encode_to_vec().expect("encode proof");
+        bytes.push(0xff);
+
+        let err =
+            BulkAppendTreeProof::decode_from_slice(&bytes).expect_err("trailing bytes must fail");
+        assert!(
+            matches!(err, BulkAppendError::CorruptedData(message) if message.contains("did not consume all bytes"))
+        );
+    }
+
+    #[test]
     fn test_bytes_to_global_position_rejects_invalid_lengths() {
         assert_eq!(super::super::bytes_to_global_position(&[7]).unwrap(), 7);
         assert_eq!(

--- a/grovedb-dense-fixed-sized-merkle-tree/src/proof/mod.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/proof/mod.rs
@@ -312,8 +312,15 @@ impl DenseTreeProof {
         let config = bincode::config::standard()
             .with_big_endian()
             .with_limit::<{ 100 * 1024 * 1024 }>(); // 100MB limit
-        let (proof, _): (Self, _) = bincode::decode_from_slice(bytes, config)
+        let (proof, consumed): (Self, usize) = bincode::decode_from_slice(bytes, config)
             .map_err(|e| DenseMerkleError::InvalidProof(format!("decode error: {}", e)))?;
+        if consumed != bytes.len() {
+            return Err(DenseMerkleError::InvalidProof(format!(
+                "DenseTreeProof decode did not consume all bytes: consumed {}, total {}",
+                consumed,
+                bytes.len()
+            )));
+        }
         Ok(proof)
     }
 }

--- a/grovedb-dense-fixed-sized-merkle-tree/src/proof/tests.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/proof/tests.rs
@@ -189,6 +189,22 @@ mod proof_tests {
     }
 
     #[test]
+    fn test_proof_decode_rejects_trailing_bytes() {
+        let tree = make_tree_h3_full();
+        let proof = DenseTreeProof::generate(&tree, &[2, 4])
+            .unwrap()
+            .expect("generate should succeed");
+        let mut bytes = proof.encode_to_vec().expect("encode should succeed");
+        bytes.push(0xff);
+
+        let err = DenseTreeProof::decode_from_slice(&bytes)
+            .expect_err("trailing bytes should be rejected");
+        assert!(
+            matches!(err, DenseMerkleError::InvalidProof(message) if message.contains("did not consume all bytes"))
+        );
+    }
+
+    #[test]
     fn test_proof_partially_filled_tree() {
         let mut tree = DenseFixedSizedMerkleTree::new(3, MemStorageContext::new())
             .expect("height 3 should be valid");

--- a/grovedb-merkle-mountain-range/src/proof.rs
+++ b/grovedb-merkle-mountain-range/src/proof.rs
@@ -616,8 +616,15 @@ impl MmrTreeProof {
         let config = bincode::config::standard()
             .with_big_endian()
             .with_limit::<{ 100 * 1024 * 1024 }>();
-        let (proof, _) = bincode::decode_from_slice(bytes, config)
+        let (proof, consumed): (Self, usize) = bincode::decode_from_slice(bytes, config)
             .map_err(|e| Error::InvalidData(format!("failed to decode MmrTreeProof: {}", e)))?;
+        if consumed != bytes.len() {
+            return Err(Error::InvalidData(format!(
+                "MmrTreeProof decode did not consume all bytes: consumed {}, total {}",
+                consumed,
+                bytes.len()
+            )));
+        }
         Ok(proof)
     }
 }
@@ -802,6 +809,21 @@ mod tests {
         assert_eq!(verified.len(), 2);
         assert_eq!(verified[0].1, b"item_0".to_vec());
         assert_eq!(verified[1].1, b"item_2".to_vec());
+    }
+
+    #[test]
+    fn test_mmr_proof_decode_rejects_trailing_bytes() {
+        let (store, mmr_size) = build_mmr(&[b"item_0", b"item_1", b"item_2"]);
+        let proof = MmrTreeProof::generate(mmr_size, &[0, 2], get_node_from_store(&store))
+            .expect("generate proof");
+
+        let mut bytes = proof.encode_to_vec().expect("encode proof");
+        bytes.push(0xff);
+
+        let err = MmrTreeProof::decode_from_slice(&bytes).expect_err("trailing bytes must fail");
+        assert!(
+            matches!(err, Error::InvalidData(message) if message.contains("did not consume all bytes"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require MMR, bulk append, and dense proof bincode decoders to consume the full input
- add trailing-byte regression tests for each proof type

Fixes #678.

## Verification
- cargo test -p grovedb-merkle-mountain-range test_mmr_proof_decode_rejects_trailing_bytes --lib
- cargo test -p grovedb-bulk-append-tree test_bulk_proof_decode_rejects_trailing_bytes --lib
- cargo test -p grovedb-dense-fixed-sized-merkle-tree test_proof_decode_rejects_trailing_bytes --lib
- cargo test -p grovedb-merkle-mountain-range -p grovedb-bulk-append-tree -p grovedb-dense-fixed-sized-merkle-tree