### PR TITLE
fix(merk): reject overlong keys before encoding

### DIFF
--- a/grovedb-query/src/proofs/encoding.rs
+++ b/grovedb-query/src/proofs/encoding.rs
@@ -15,12 +15,18 @@ use crate::{
 /// allocations.
 const MAX_VALUE_LEN: u32 = 64 * 1024 * 1024;
 
+fn invalid_key_length_error() -> EdError {
+    EdError::IOError(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "key length must be at most 255 bytes",
+    ))
+}
+
+fn key_len_u8(key: &[u8]) -> ed::Result<u8> {
+    u8::try_from(key.len()).map_err(|_| invalid_key_length_error())
+}
+
 impl Encode for Op {
-    // Note: `key.len() as u8` casts below are safe because GroveDB enforces a
-    // 255-byte maximum key length at insertion time (both direct insert and
-    // batch paths). The `debug_assert!` guards serve as development-time
-    // verification of this invariant. A runtime check here is unnecessary
-    // since keys exceeding 255 bytes can never be stored in the database.
     fn encode_into<W: Write>(&self, dest: &mut W) -> ed::Result<()> {
         match self {
             // Push
@@ -33,29 +39,29 @@ impl Encode for Op {
                 dest.write_all(kv_hash)?;
             }
             Op::Push(Node::KV(key, value)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x03, key.len() as u8])?;
+                    dest.write_all(&[0x03, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                 } else {
-                    dest.write_all(&[0x20, key.len() as u8])?;
+                    dest.write_all(&[0x20, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
                 }
             }
             Op::Push(Node::KVValueHash(key, value, value_hash)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x04, key.len() as u8])?;
+                    dest.write_all(&[0x04, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     dest.write_all(value_hash)?;
                 } else {
-                    dest.write_all(&[0x21, key.len() as u8])?;
+                    dest.write_all(&[0x21, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -63,22 +69,22 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVDigest(key, value_hash)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
 
-                dest.write_all(&[0x05, key.len() as u8])?;
+                dest.write_all(&[0x05, key_len])?;
                 dest.write_all(key)?;
                 dest.write_all(value_hash)?;
             }
             Op::Push(Node::KVRefValueHash(key, value, value_hash)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x06, key.len() as u8])?;
+                    dest.write_all(&[0x06, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     dest.write_all(value_hash)?;
                 } else {
-                    dest.write_all(&[0x22, key.len() as u8])?;
+                    dest.write_all(&[0x22, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -86,16 +92,16 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVValueHashFeatureType(key, value, value_hash, feature_type)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x07, key.len() as u8])?;
+                    dest.write_all(&[0x07, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     dest.write_all(value_hash)?;
                     feature_type.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x23, key.len() as u8])?;
+                    dest.write_all(&[0x23, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -104,15 +110,15 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVCount(key, value, count)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x14, key.len() as u8])?;
+                    dest.write_all(&[0x14, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     count.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x24, key.len() as u8])?;
+                    dest.write_all(&[0x24, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -125,16 +131,16 @@ impl Encode for Op {
                 count.encode_into(dest)?;
             }
             Op::Push(Node::KVRefValueHashCount(key, value, value_hash, count)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x18, key.len() as u8])?;
+                    dest.write_all(&[0x18, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     dest.write_all(value_hash)?;
                     count.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x25, key.len() as u8])?;
+                    dest.write_all(&[0x25, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -143,9 +149,9 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVDigestCount(key, value_hash, count)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
 
-                dest.write_all(&[0x1a, key.len() as u8])?;
+                dest.write_all(&[0x1a, key_len])?;
                 dest.write_all(key)?;
                 dest.write_all(value_hash)?;
                 count.encode_into(dest)?;
@@ -164,9 +170,9 @@ impl Encode for Op {
                 feature_type,
                 child_hash,
             )) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x1c, key.len() as u8])?;
+                    dest.write_all(&[0x1c, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -174,7 +180,7 @@ impl Encode for Op {
                     feature_type.encode_into(dest)?;
                     dest.write_all(child_hash)?;
                 } else {
-                    dest.write_all(&[0x2e, key.len() as u8])?;
+                    dest.write_all(&[0x2e, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -194,29 +200,29 @@ impl Encode for Op {
                 dest.write_all(kv_hash)?;
             }
             Op::PushInverted(Node::KV(key, value)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x0a, key.len() as u8])?;
+                    dest.write_all(&[0x0a, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                 } else {
-                    dest.write_all(&[0x28, key.len() as u8])?;
+                    dest.write_all(&[0x28, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
                 }
             }
             Op::PushInverted(Node::KVValueHash(key, value, value_hash)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x0b, key.len() as u8])?;
+                    dest.write_all(&[0x0b, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     dest.write_all(value_hash)?;
                 } else {
-                    dest.write_all(&[0x29, key.len() as u8])?;
+                    dest.write_all(&[0x29, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -224,22 +230,22 @@ impl Encode for Op {
                 }
             }
             Op::PushInverted(Node::KVDigest(key, value_hash)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
 
-                dest.write_all(&[0x0c, key.len() as u8])?;
+                dest.write_all(&[0x0c, key_len])?;
                 dest.write_all(key)?;
                 dest.write_all(value_hash)?;
             }
             Op::PushInverted(Node::KVRefValueHash(key, value, value_hash)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x0d, key.len() as u8])?;
+                    dest.write_all(&[0x0d, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     dest.write_all(value_hash)?;
                 } else {
-                    dest.write_all(&[0x2a, key.len() as u8])?;
+                    dest.write_all(&[0x2a, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -252,16 +258,16 @@ impl Encode for Op {
                 value_hash,
                 feature_type,
             )) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x0e, key.len() as u8])?;
+                    dest.write_all(&[0x0e, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     dest.write_all(value_hash)?;
                     feature_type.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x2b, key.len() as u8])?;
+                    dest.write_all(&[0x2b, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -270,15 +276,15 @@ impl Encode for Op {
                 }
             }
             Op::PushInverted(Node::KVCount(key, value, count)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x16, key.len() as u8])?;
+                    dest.write_all(&[0x16, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     count.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x2c, key.len() as u8])?;
+                    dest.write_all(&[0x2c, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -291,16 +297,16 @@ impl Encode for Op {
                 count.encode_into(dest)?;
             }
             Op::PushInverted(Node::KVRefValueHashCount(key, value, value_hash, count)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x19, key.len() as u8])?;
+                    dest.write_all(&[0x19, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     dest.write_all(value_hash)?;
                     count.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x2d, key.len() as u8])?;
+                    dest.write_all(&[0x2d, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -309,9 +315,9 @@ impl Encode for Op {
                 }
             }
             Op::PushInverted(Node::KVDigestCount(key, value_hash, count)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
 
-                dest.write_all(&[0x1b, key.len() as u8])?;
+                dest.write_all(&[0x1b, key_len])?;
                 dest.write_all(key)?;
                 dest.write_all(value_hash)?;
                 count.encode_into(dest)?;
@@ -335,9 +341,9 @@ impl Encode for Op {
                 feature_type,
                 child_hash,
             )) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x1d, key.len() as u8])?;
+                    dest.write_all(&[0x1d, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -345,7 +351,7 @@ impl Encode for Op {
                     feature_type.encode_into(dest)?;
                     dest.write_all(child_hash)?;
                 } else {
-                    dest.write_all(&[0x2f, key.len() as u8])?;
+                    dest.write_all(&[0x2f, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -366,15 +372,15 @@ impl Encode for Op {
 
             // Push: ProvableSumTree variants
             Op::Push(Node::KVSum(key, value, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x30, key.len() as u8])?;
+                    dest.write_all(&[0x30, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     sum.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x31, key.len() as u8])?;
+                    dest.write_all(&[0x31, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -387,16 +393,16 @@ impl Encode for Op {
                 sum.encode_into(dest)?;
             }
             Op::Push(Node::KVRefValueHashSum(key, value, value_hash, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x33, key.len() as u8])?;
+                    dest.write_all(&[0x33, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     dest.write_all(value_hash)?;
                     sum.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x34, key.len() as u8])?;
+                    dest.write_all(&[0x34, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -405,9 +411,9 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVDigestSum(key, value_hash, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
 
-                dest.write_all(&[0x35, key.len() as u8])?;
+                dest.write_all(&[0x35, key_len])?;
                 dest.write_all(key)?;
                 dest.write_all(value_hash)?;
                 sum.encode_into(dest)?;
@@ -422,15 +428,15 @@ impl Encode for Op {
 
             // PushInverted: ProvableSumTree variants
             Op::PushInverted(Node::KVSum(key, value, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x37, key.len() as u8])?;
+                    dest.write_all(&[0x37, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     sum.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x38, key.len() as u8])?;
+                    dest.write_all(&[0x38, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -443,16 +449,16 @@ impl Encode for Op {
                 sum.encode_into(dest)?;
             }
             Op::PushInverted(Node::KVRefValueHashSum(key, value, value_hash, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x3a, key.len() as u8])?;
+                    dest.write_all(&[0x3a, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     dest.write_all(value_hash)?;
                     sum.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x3b, key.len() as u8])?;
+                    dest.write_all(&[0x3b, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -461,9 +467,9 @@ impl Encode for Op {
                 }
             }
             Op::PushInverted(Node::KVDigestSum(key, value_hash, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
 
-                dest.write_all(&[0x3c, key.len() as u8])?;
+                dest.write_all(&[0x3c, key_len])?;
                 dest.write_all(key)?;
                 dest.write_all(value_hash)?;
                 sum.encode_into(dest)?;
@@ -491,16 +497,16 @@ impl Encode for Op {
 
             // Push: ProvableCountProvableSumTree variants
             Op::Push(Node::KVCountSum(key, value, count, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x40, key.len() as u8])?;
+                    dest.write_all(&[0x40, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     count.encode_into(dest)?;
                     sum.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x41, key.len() as u8])?;
+                    dest.write_all(&[0x41, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -515,9 +521,9 @@ impl Encode for Op {
                 sum.encode_into(dest)?;
             }
             Op::Push(Node::KVRefValueHashCountSum(key, value, value_hash, count, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x43, key.len() as u8])?;
+                    dest.write_all(&[0x43, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -525,7 +531,7 @@ impl Encode for Op {
                     count.encode_into(dest)?;
                     sum.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x44, key.len() as u8])?;
+                    dest.write_all(&[0x44, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -535,9 +541,9 @@ impl Encode for Op {
                 }
             }
             Op::Push(Node::KVDigestCountSum(key, value_hash, count, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
 
-                dest.write_all(&[0x45, key.len() as u8])?;
+                dest.write_all(&[0x45, key_len])?;
                 dest.write_all(key)?;
                 dest.write_all(value_hash)?;
                 count.encode_into(dest)?;
@@ -560,16 +566,16 @@ impl Encode for Op {
 
             // PushInverted: ProvableCountProvableSumTree variants
             Op::PushInverted(Node::KVCountSum(key, value, count, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x47, key.len() as u8])?;
+                    dest.write_all(&[0x47, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
                     count.encode_into(dest)?;
                     sum.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x48, key.len() as u8])?;
+                    dest.write_all(&[0x48, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -584,9 +590,9 @@ impl Encode for Op {
                 sum.encode_into(dest)?;
             }
             Op::PushInverted(Node::KVRefValueHashCountSum(key, value, value_hash, count, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
                 if value.len() < 65536 {
-                    dest.write_all(&[0x4a, key.len() as u8])?;
+                    dest.write_all(&[0x4a, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u16).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -594,7 +600,7 @@ impl Encode for Op {
                     count.encode_into(dest)?;
                     sum.encode_into(dest)?;
                 } else {
-                    dest.write_all(&[0x4b, key.len() as u8])?;
+                    dest.write_all(&[0x4b, key_len])?;
                     dest.write_all(key)?;
                     (value.len() as u32).encode_into(dest)?;
                     dest.write_all(value)?;
@@ -604,9 +610,9 @@ impl Encode for Op {
                 }
             }
             Op::PushInverted(Node::KVDigestCountSum(key, value_hash, count, sum)) => {
-                debug_assert!(key.len() < 256);
+                let key_len = key_len_u8(key)?;
 
-                dest.write_all(&[0x4c, key.len() as u8])?;
+                dest.write_all(&[0x4c, key_len])?;
                 dest.write_all(key)?;
                 dest.write_all(value_hash)?;
                 count.encode_into(dest)?;
@@ -2263,11 +2269,17 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn encode_push_kv_long_key() {
-        let op = Op::Push(Node::KV(vec![123; 300], vec![4, 5, 6]));
+        let op = Op::Push(Node::KV(vec![123; 256], vec![4, 5, 6]));
         let mut bytes = vec![];
-        op.encode_into(&mut bytes).unwrap();
+        assert!(op.encode_into(&mut bytes).is_err());
+    }
+
+    #[test]
+    fn encode_push_inverted_kvdigest_long_key() {
+        let op = Op::PushInverted(Node::KVDigest(vec![123; 300], [42; HASH_LENGTH]));
+        let mut bytes = vec![];
+        assert!(op.encode_into(&mut bytes).is_err());
     }
 
     #[test]

--- a/merk/src/merk/apply.rs
+++ b/merk/src/merk/apply.rs
@@ -19,6 +19,8 @@ use crate::{
     Error, Merk, MerkBatch, MerkOptions,
 };
 
+const MAX_KEY_LENGTH: usize = u8::MAX as usize;
+
 impl<'db, S> Merk<S>
 where
     S: StorageContext<'db>,
@@ -344,6 +346,15 @@ where
         ) -> Result<(bool, Option<ValueDefinedCostType>), Error>,
         R: FnMut(&Vec<u8>, u32, u32) -> Result<(StorageRemovedBytes, StorageRemovedBytes), Error>,
     {
+        for (key, ..) in batch.iter() {
+            if key.as_ref().len() > MAX_KEY_LENGTH {
+                return Err(Error::InvalidInputError(
+                    "key length must be at most 255 bytes",
+                ))
+                .wrap_with_cost(Default::default());
+            }
+        }
+
         let maybe_walker = self
             .tree
             .take()

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -1088,7 +1088,7 @@ mod test {
     use super::{Merk, RefWalker};
     use crate::{
         merk::source::MerkSource, test_utils::*, tree::kv::ValueDefinedCostType,
-        tree_type::TreeType, Op, TreeFeatureType::BasicMerkNode,
+        tree_type::TreeType, Error, Op, TreeFeatureType::BasicMerkNode,
     };
     // TODO: Close and then reopen test
 
@@ -1117,6 +1117,27 @@ mod test {
                 218, 90, 71, 153, 240, 47, 227, 168, 1, 104, 239, 237, 140, 147
             ]
         );
+    }
+
+    #[test]
+    fn apply_rejects_overlong_keys() {
+        let grove_version = GroveVersion::latest();
+
+        for key_len in [256, 300] {
+            let mut merk = TempMerk::new(grove_version);
+            let batch = [(vec![0xAB; key_len], Op::Put(vec![1], BasicMerkNode))];
+
+            let result = merk
+                .apply::<_, Vec<_>>(&batch, &[], None, grove_version)
+                .unwrap();
+
+            assert!(matches!(
+                result,
+                Err(Error::InvalidInputError(
+                    "key length must be at most 255 bytes"
+                ))
+            ));
+        }
     }
 
     #[test]

--- a/merk/src/tree/link.rs
+++ b/merk/src/tree/link.rs
@@ -21,6 +21,24 @@ use crate::HASH_LENGTH_U32;
 // TODO: optimize memory footprint
 
 #[cfg(feature = "minimal")]
+fn invalid_key_length_error() -> ed::Error {
+    ed::Error::IOError(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "key length must be at most 255 bytes",
+    ))
+}
+
+#[cfg(feature = "minimal")]
+fn key_len_u8(key: &[u8]) -> Result<u8> {
+    u8::try_from(key.len()).map_err(|_| invalid_key_length_error())
+}
+
+#[cfg(feature = "minimal")]
+fn validate_key_length(key: &[u8]) -> Result<()> {
+    key_len_u8(key).map(|_| ())
+}
+
+#[cfg(feature = "minimal")]
 /// Represents a reference to a child tree node. Links may or may not contain
 /// the child's `Tree` instance (storing its key if not).
 #[derive(Clone, Debug, PartialEq)]
@@ -303,7 +321,7 @@ impl Link {
     /// sizes would be a breaking change to cost/fee computations.
     #[inline]
     pub fn encoding_cost(&self) -> Result<usize> {
-        debug_assert!(self.key().len() < 256, "Key length must be less than 256");
+        validate_key_length(self.key())?;
 
         Ok(match self {
             Link::Reference {
@@ -407,9 +425,9 @@ impl Encode for Link {
             }
         };
 
-        debug_assert!(key.len() < 256, "Key length must be less than 256");
+        let key_len = key_len_u8(key)?;
 
-        out.write_all(&[key.len() as u8])?;
+        out.write_all(&[key_len])?;
         out.write_all(key)?;
 
         out.write_all(hash)?;
@@ -473,7 +491,7 @@ impl Encode for Link {
 
     #[inline]
     fn encoding_length(&self) -> Result<usize> {
-        debug_assert!(self.key().len() < 256, "Key length must be less than 256");
+        validate_key_length(self.key())?;
 
         Ok(match self {
             Link::Reference {
@@ -931,7 +949,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn encode_link_long_key() {
         let link = Link::Reference {
             key: vec![123; 300],
@@ -940,7 +957,9 @@ mod test {
             hash: [55; 32],
         };
         let mut bytes = vec![];
-        link.encode_into(&mut bytes).unwrap();
+        assert!(link.encode_into(&mut bytes).is_err());
+        assert!(link.encoding_length().is_err());
+        assert!(link.encoding_cost().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject raw Merk apply batches containing keys longer than 255 bytes before mutating the tree
- make Merk link encoding return an error for overlong keys instead of relying on debug assertions
- make grovedb-query proof op encoding use checked key-length conversion for every key-bearing variant

Fixes #681.

## Verification
- cargo test -p grovedb-merk apply_rejects_overlong_keys --lib
- cargo test -p grovedb-merk encode_link_long_key --lib
- cargo test -p grovedb-query long_key --lib
- cargo test -p grovedb-merk apply_rejects_overlong_keys --lib --release
- cargo test -p grovedb-merk encode_link_long_key --lib --release
- cargo test -p grovedb-query long_key --lib --release
- cargo test -p grovedb-merk -p grovedb-query