### PR TITLE
fix(bulk-append): reject short completed chunk proofs

### DIFF
--- a/grovedb-bulk-append-tree/src/proof/mod.rs
+++ b/grovedb-bulk-append-tree/src/proof/mod.rs
@@ -405,25 +405,13 @@ impl BulkAppendTreeProof {
 
         if validate_completed_chunk_lengths {
             for (chunk_idx, blob) in &chunk_blobs {
-                if *chunk_idx >= completed_chunks {
-                    return Err(BulkAppendError::InvalidProof(format!(
-                        "chunk {} is out of range for {} completed chunks",
-                        chunk_idx, completed_chunks
-                    )));
-                }
-
                 let entries = deserialize_chunk_blob(blob).map_err(|e| {
                     BulkAppendError::CorruptedData(format!(
                         "failed to deserialize chunk blob {}: {}",
                         chunk_idx, e
                     ))
                 })?;
-                let entry_count = u64::try_from(entries.len()).map_err(|_| {
-                    BulkAppendError::InvalidProof(format!(
-                        "chunk {} entry count does not fit in u64",
-                        chunk_idx
-                    ))
-                })?;
+                let entry_count = entries.len() as u64;
                 if entry_count != chunk_item_count {
                     return Err(BulkAppendError::InvalidProof(format!(
                         "chunk {} contains {} entries, expected {}",

--- a/grovedb-bulk-append-tree/src/proof/mod.rs
+++ b/grovedb-bulk-append-tree/src/proof/mod.rs
@@ -357,6 +357,17 @@ impl BulkAppendTreeProof {
         height: u8,
         total_count: u64,
     ) -> Result<([u8; 32], BulkAppendTreeProofResult), BulkAppendError> {
+        self.verify_and_compute_root_for_version(height, total_count, true)
+    }
+
+    /// Verify this proof's internal consistency for a specific proof feature
+    /// version and return the computed state root.
+    pub fn verify_and_compute_root_for_version(
+        &self,
+        height: u8,
+        total_count: u64,
+        validate_completed_chunk_lengths: bool,
+    ) -> Result<([u8; 32], BulkAppendTreeProofResult), BulkAppendError> {
         // 0. Validate height
         if !(1..=16).contains(&height) {
             return Err(BulkAppendError::InvalidProof(format!(
@@ -391,6 +402,36 @@ impl BulkAppendTreeProof {
             })?;
             (root, verified_leaves)
         };
+
+        if validate_completed_chunk_lengths {
+            for (chunk_idx, blob) in &chunk_blobs {
+                if *chunk_idx >= completed_chunks {
+                    return Err(BulkAppendError::InvalidProof(format!(
+                        "chunk {} is out of range for {} completed chunks",
+                        chunk_idx, completed_chunks
+                    )));
+                }
+
+                let entries = deserialize_chunk_blob(blob).map_err(|e| {
+                    BulkAppendError::CorruptedData(format!(
+                        "failed to deserialize chunk blob {}: {}",
+                        chunk_idx, e
+                    ))
+                })?;
+                let entry_count = u64::try_from(entries.len()).map_err(|_| {
+                    BulkAppendError::InvalidProof(format!(
+                        "chunk {} entry count does not fit in u64",
+                        chunk_idx
+                    ))
+                })?;
+                if entry_count != chunk_item_count {
+                    return Err(BulkAppendError::InvalidProof(format!(
+                        "chunk {} contains {} entries, expected {}",
+                        chunk_idx, entry_count, chunk_item_count
+                    )));
+                }
+            }
+        }
 
         // 2. Verify dense tree buffer sub-proof
         let (dense_root, dense_entries) = if dense_count > 0 {

--- a/grovedb-bulk-append-tree/src/proof/tests.rs
+++ b/grovedb-bulk-append-tree/src/proof/tests.rs
@@ -517,6 +517,27 @@ mod proof_tests {
     }
 
     #[test]
+    fn test_verify_compute_root_rejects_malformed_completed_chunk_blob() {
+        let height = 2u8;
+        let total_count = 4u64;
+        let malformed_blob = vec![0xff];
+
+        let proof = BulkAppendTreeProof {
+            chunk_proof: MmrTreeProof::new(1, vec![(0, malformed_blob)], vec![]),
+            buffer_proof: DenseTreeProof {
+                entries: Vec::new(),
+                node_value_hashes: Vec::new(),
+                node_hashes: Vec::new(),
+            },
+        };
+
+        let err = proof
+            .verify_and_compute_root(height, total_count)
+            .expect_err("malformed completed chunk blob must fail");
+        assert!(matches!(err, BulkAppendError::CorruptedData(_)));
+    }
+
+    #[test]
     fn test_verify_compute_root_legacy_version_accepts_short_completed_chunk_blob() {
         let height = 2u8;
         let total_count = 4u64;

--- a/grovedb-bulk-append-tree/src/proof/tests.rs
+++ b/grovedb-bulk-append-tree/src/proof/tests.rs
@@ -1,9 +1,13 @@
 #[cfg(test)]
 mod proof_tests {
-    use grovedb_merkle_mountain_range::MmrTreeProof;
+    use grovedb_dense_fixed_sized_merkle_tree::DenseTreeProof;
+    use grovedb_merkle_mountain_range::{leaf_hash, MmrTreeProof};
     use grovedb_query::{Query, QueryItem};
 
-    use crate::{proof::*, test_utils::MemStorageContext, BulkAppendTree};
+    use crate::{
+        compute_state_root, proof::*, serialize_chunk_blob, test_utils::MemStorageContext,
+        BulkAppendTree,
+    };
 
     /// Helper: build a test tree and return it (tree owns the storage).
     fn build_test_tree(
@@ -483,6 +487,54 @@ mod proof_tests {
             )
             .expect_err("must fail for missing chunk");
         assert!(matches!(err, BulkAppendError::InvalidProof(_)));
+    }
+
+    #[test]
+    fn test_verify_against_query_rejects_short_completed_chunk_blob() {
+        let height = 2u8;
+        let total_count = 4u64;
+        let short_blob =
+            serialize_chunk_blob(&[b"only".to_vec()]).expect("serialize short chunk blob");
+        let chunk_root = leaf_hash(&short_blob);
+        let state_root = compute_state_root(&chunk_root, &[0; 32]);
+
+        let proof = BulkAppendTreeProof {
+            chunk_proof: MmrTreeProof::new(1, vec![(0, short_blob)], vec![]),
+            buffer_proof: DenseTreeProof {
+                entries: Vec::new(),
+                node_value_hashes: Vec::new(),
+                node_hashes: Vec::new(),
+            },
+        };
+
+        let mut query = Query::default();
+        query.items.push(QueryItem::Key(pos_bytes(3)));
+
+        let err = proof
+            .verify_against_query::<Vec<(u64, Vec<u8>)>>(&state_root, height, total_count, &query)
+            .expect_err("short completed chunk blob must fail");
+        assert!(matches!(err, BulkAppendError::InvalidProof(_)));
+    }
+
+    #[test]
+    fn test_verify_compute_root_legacy_version_accepts_short_completed_chunk_blob() {
+        let height = 2u8;
+        let total_count = 4u64;
+        let short_blob =
+            serialize_chunk_blob(&[b"only".to_vec()]).expect("serialize short chunk blob");
+
+        let proof = BulkAppendTreeProof {
+            chunk_proof: MmrTreeProof::new(1, vec![(0, short_blob)], vec![]),
+            buffer_proof: DenseTreeProof {
+                entries: Vec::new(),
+                node_value_hashes: Vec::new(),
+                node_hashes: Vec::new(),
+            },
+        };
+
+        proof
+            .verify_and_compute_root_for_version(height, total_count, false)
+            .expect("legacy version should not validate completed chunk length");
     }
 
     #[test]

--- a/grovedb-version/src/version/grovedb_versions.rs
+++ b/grovedb-version/src/version/grovedb_versions.rs
@@ -105,6 +105,7 @@ pub struct GroveDBOperationsProofVersions {
     pub verify_subset_query_with_absence_proof: FeatureVersion,
     pub verify_query_with_chained_path_queries: FeatureVersion,
     pub verify_query_get_parent_tree_info_with_options: FeatureVersion,
+    pub verify_bulk_append_completed_chunk_lengths: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -164,6 +164,7 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
                 verify_subset_query_with_absence_proof: 0,
                 verify_query_with_chained_path_queries: 0,
                 verify_query_get_parent_tree_info_with_options: 0,
+                verify_bulk_append_completed_chunk_lengths: 0,
             },
             average_case: GroveDBOperationsAverageCaseVersions {
                 add_average_case_get_merk_at_path: 0,

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -164,6 +164,7 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
                 verify_subset_query_with_absence_proof: 0,
                 verify_query_with_chained_path_queries: 0,
                 verify_query_get_parent_tree_info_with_options: 0,
+                verify_bulk_append_completed_chunk_lengths: 0,
             },
             average_case: GroveDBOperationsAverageCaseVersions {
                 add_average_case_get_merk_at_path: 0,

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -164,6 +164,7 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
                 verify_subset_query_with_absence_proof: 0,
                 verify_query_with_chained_path_queries: 0,
                 verify_query_get_parent_tree_info_with_options: 0,
+                verify_bulk_append_completed_chunk_lengths: 1,
             },
             average_case: GroveDBOperationsAverageCaseVersions {
                 add_average_case_get_merk_at_path: 0,

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -1121,8 +1121,18 @@ impl GroveDb {
             grovedb_bulk_append_tree::BulkAppendTreeProof::decode_from_slice(bulk_bytes)
                 .map_err(|e| Error::CorruptedData(format!("{}", e)))?;
 
+        let validate_completed_chunk_lengths = grove_version
+            .grovedb_versions
+            .operations
+            .proof
+            .verify_bulk_append_completed_chunk_lengths
+            > 0;
         let (bulk_state_root, proof_result) = bulk_proof
-            .verify_and_compute_root(element_height, element_total_count)
+            .verify_and_compute_root_for_version(
+                element_height,
+                element_total_count,
+                validate_completed_chunk_lengths,
+            )
             .map_err(|e| Error::InvalidProof(query.clone(), format!("{}", e)))?;
 
         // Get the query range from the path query to extract matching values


### PR DESCRIPTION
## Summary
- validate every verified completed chunk blob has exactly the expected chunk item count
- reject out-of-range chunk indices before exposing verified proof results
- add a forged one-leaf proof regression where a short authenticated chunk would otherwise verify and omit queried positions

Fixes #688.

## Verification
- cargo test -p grovedb-bulk-append-tree test_verify_against_query_rejects_short_completed_chunk_blob
- cargo test -p grovedb-bulk-append-tree verify_against_query
- cargo test -p grovedb-bulk-append-tree