### PR TITLE
fix(replication): keep state sync restore atomic until commit

### DIFF
--- a/grovedb/src/replication/state_sync_session.rs
+++ b/grovedb/src/replication/state_sync_session.rs
@@ -2,7 +2,6 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
     marker::PhantomPinned,
-    mem,
     pin::Pin,
 };
 
@@ -248,11 +247,8 @@ impl<'db> MultiStateSyncSession<'db> {
         // Individual subtree chunks are hash-verified during restore, but we must also
         // verify the overall GroveDB root to ensure the composition is correct.
         //
-        // TODO: This check is not fully atomic. apply_chunk() flushes completed
-        // subtree batches via set_new_transaction()/commit_transaction(), so on
-        // mismatch only the last transaction is rolled back while earlier subtrees
-        // remain on disk. A full fix requires staging all subtree commits and only
-        // persisting them after root hash verification passes.
+        // apply_chunk() keeps all restored subtree batches inside this transaction,
+        // so a mismatch rolls back the whole sync when the session is dropped.
         let actual_root_hash = session
             .db
             .root_hash(Some(&session.transaction), grove_version)
@@ -273,24 +269,6 @@ impl<'db> MultiStateSyncSession<'db> {
             .commit_transaction(session.transaction)
             .value
             .map_err(|e| Error::InternalError(format!("failed to commit sync transaction: {e}")))?;
-        Ok(())
-    }
-
-    // SAFETY: This is unsafe as it requires `self.current_prefixes` to be empty
-    // so no storage contexts hold references to the transaction being replaced.
-    unsafe fn set_new_transaction(
-        self: &mut Pin<Box<MultiStateSyncSession<'db>>>,
-    ) -> Result<(), Error> {
-        if !self.current_prefixes.is_empty() {
-            return Err(Error::InternalError(
-                "current_prefixes must be empty before replacing transaction".to_string(),
-            ));
-        }
-        let this = unsafe { Pin::as_mut(self).get_unchecked_mut() };
-        let old_tx = mem::replace(&mut this.transaction, this.db.start_transaction());
-        self.db.commit_transaction(old_tx).value.map_err(|e| {
-            Error::InternalError(format!("failed to commit old transaction during sync: {e}"))
-        })?;
         Ok(())
     }
 
@@ -590,12 +568,6 @@ impl<'db> MultiStateSyncSession<'db> {
         if self.num_processed_subtrees_in_batch >= self.subtrees_batch_size
             && self.current_prefixes.is_empty()
         {
-            // SAFETY: we made sure `self.current_prefixes` is empty so there are no
-            // references to the transaction we're about to replace
-            unsafe {
-                self.set_new_transaction()?;
-            }
-
             let new_subtrees_metadata =
                 self.as_mut()
                     .pending_discovered_subtrees()

--- a/grovedb/src/tests/replication_session_tests.rs
+++ b/grovedb/src/tests/replication_session_tests.rs
@@ -583,6 +583,108 @@ mod tests {
     }
 
     #[test]
+    fn failed_chunk_after_batched_sync_rolls_back_all_restored_subtrees() {
+        let grove_version = GroveVersion::latest();
+        let source = make_test_grovedb(grove_version);
+
+        source
+            .insert(
+                [TEST_LEAF].as_ref(),
+                b"sub",
+                Element::empty_tree(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("should insert subtree");
+        source
+            .insert(
+                [TEST_LEAF, b"sub"].as_ref(),
+                b"nested",
+                Element::new_item(b"value".to_vec()),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("should insert nested item");
+
+        let source_hash = source
+            .root_hash(None, grove_version)
+            .unwrap()
+            .expect("should get source hash");
+
+        let dest = make_empty_grovedb();
+        let empty_dest_hash = dest
+            .root_hash(None, grove_version)
+            .unwrap()
+            .expect("should get empty destination hash");
+        let mut session = dest
+            .start_snapshot_syncing(source_hash, 1, CURRENT_STATE_SYNC_VERSION, grove_version)
+            .expect("should start snapshot syncing");
+
+        let root_chunk_data = source
+            .fetch_chunk(
+                source_hash.as_slice(),
+                None,
+                CURRENT_STATE_SYNC_VERSION,
+                grove_version,
+            )
+            .expect("should fetch root chunk");
+        let next_chunk_ids = session
+            .apply_chunk(
+                source_hash.as_slice(),
+                &root_chunk_data,
+                CURRENT_STATE_SYNC_VERSION,
+                grove_version,
+            )
+            .expect("should apply root chunk");
+        assert!(
+            !next_chunk_ids.is_empty(),
+            "root chunk should discover child subtree chunks"
+        );
+
+        let next_chunk_id = next_chunk_ids.first().expect("expected next chunk id");
+        let mut corrupt_chunk_data = source
+            .fetch_chunk(
+                next_chunk_id.as_slice(),
+                None,
+                CURRENT_STATE_SYNC_VERSION,
+                grove_version,
+            )
+            .expect("should fetch child chunk");
+        let last_byte = corrupt_chunk_data
+            .last_mut()
+            .expect("chunk data should not be empty");
+        *last_byte ^= 0xFF;
+
+        let err = session
+            .apply_chunk(
+                next_chunk_id.as_slice(),
+                &corrupt_chunk_data,
+                CURRENT_STATE_SYNC_VERSION,
+                grove_version,
+            )
+            .expect_err("corrupt child chunk should fail");
+        let err_msg = format!("{err:?}");
+        assert!(
+            err_msg.contains("Unable to finalize Merk")
+                || err_msg.contains("corrupt")
+                || err_msg.contains("Corrupted"),
+            "unexpected error: {err:?}"
+        );
+        drop(session);
+        assert!(
+            dest.root_hash(None, grove_version)
+                .unwrap()
+                .expect("should get destination hash after failed commit")
+                == empty_dest_hash,
+            "failed sync commit must not persist restored root data"
+        );
+    }
+
+    #[test]
     fn sync_with_empty_subtree_succeeds() {
         let grove_version = GroveVersion::latest();
         let source = make_test_grovedb(grove_version);


### PR DESCRIPTION
## Summary
- stop rotating and committing state-sync transactions between restored subtree batches
- keep all restored chunks in the session transaction until the final commit path verifies the root hash
- add a regression where a later corrupt chunk rolls back an already-restored root batch

Fixes #679.

## Verification
- cargo test -p grovedb failed_chunk_after_batched_sync_rolls_back_all_restored_subtrees --lib
- cargo test -p grovedb replication_session_tests --lib
- git diff --check