### PR TITLE
fix(element): version trailing-byte deserialization rejection

### DIFF
--- a/grovedb-element/src/element/serialize.rs
+++ b/grovedb-element/src/element/serialize.rs
@@ -2,7 +2,9 @@
 //! Implements serialization functions in Element
 
 use bincode::config;
-use grovedb_version::{check_grovedb_v0, version::GroveVersion};
+use grovedb_version::{
+    check_grovedb_v0, check_grovedb_v0_or_v1, error::GroveVersionError, version::GroveVersion,
+};
 
 use crate::{
     element::Element,
@@ -100,7 +102,7 @@ impl Element {
     /// the three wrapper discriminants (15 NonCounted, 16 NotSummed,
     /// 17 NotCountedOrSummed) — nine in total.
     pub fn deserialize(bytes: &[u8], grove_version: &GroveVersion) -> Result<Self, ElementError> {
-        check_grovedb_v0!(
+        let deserialize_version = check_grovedb_v0_or_v1!(
             "Element::deserialize",
             grove_version.grovedb_versions.element.deserialize
         );
@@ -130,7 +132,7 @@ impl Element {
             .map_err(|e| {
                 ElementError::CorruptedData(format!("unable to deserialize element {}", e))
             })?;
-        if consumed != bytes.len() {
+        if deserialize_version > 0 && consumed != bytes.len() {
             return Err(ElementError::CorruptedData(format!(
                 "element deserialization did not consume all bytes: consumed {}, total {}",
                 consumed,
@@ -342,5 +344,20 @@ mod tests {
                 "unexpected error: {err:?}"
             );
         }
+    }
+
+    #[test]
+    fn deserialize_legacy_version_accepts_trailing_bytes() {
+        let mut legacy_version = GroveVersion::latest().clone();
+        legacy_version.grovedb_versions.element.deserialize = 0;
+        let grove_version = &legacy_version;
+
+        let element = Element::new_item(b"abc".to_vec());
+        let mut serialized = element.serialize(grove_version).expect("serialize element");
+        serialized.push(0xff);
+
+        let decoded =
+            Element::deserialize(&serialized, grove_version).expect("legacy deserialize element");
+        assert_eq!(decoded, element);
     }
 }

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -73,7 +73,7 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
             basic_aggregate_sum_push: 0,
             serialize: 0,
             serialized_size: 0,
-            deserialize: 0,
+            deserialize: 1,
             get_with_value_hash: 0,
             insert_reference_if_changed_value: 0,
             aggregate_sum_query_item: 0,


### PR DESCRIPTION
## Summary
- gate element trailing-byte deserialization rejection behind element.deserialize version 1
- keep legacy version 0 behavior for old protocol versions
- add regression coverage for the legacy and latest behaviors

## Tests
- cargo test -p grovedb-element deserialize_ --lib
- cargo check -p grovedb-element --lib
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved legacy element deserialization to properly handle version-specific validation rules, allowing trailing bytes in legacy data formats.
* Enhanced protocol v3 version definitions to enable element deserialization support.

## Tests
* Added regression test for legacy element deserialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/grovedb/pull/738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->