### PR TITLE
chore: remove duplicate workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ members = [
     "grovedb-merkle-mountain-range",
     "grovedb-bulk-append-tree",
     "grovedb-dense-fixed-sized-merkle-tree",
-    "grovedb-bulk-append-tree",
-    "grovedb-commitment-tree",
     "grovedb-query",
 ]
 


### PR DESCRIPTION
# Summary

- Remove duplicate `grovedb-bulk-append-tree` and `grovedb-commitment-tree`
  entries from the root workspace members list.
- Fixes dashpay/grovedb#719.

## Validation

- `cargo metadata --no-deps --format-version 1`
- `code-review dashpay/grovedb upstream/develop origin/fix-duplicate-workspace-members
  "Remove duplicate workspace member entries from root Cargo.toml for
  dashpay/grovedb#719"` → Recommendation: ship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized workspace crate configuration to streamline project structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/grovedb/pull/741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->