### PR TITLE
test: cover element type discriminant 20

### DIFF
--- a/grovedb-element/src/element_type.rs
+++ b/grovedb-element/src/element_type.rs
@@ -177,7 +177,7 @@ pub enum ProofNodeType {
 
 /// Element type discriminants.
 ///
-/// Base types (0..=14, 18, 19) match the bincode serialization order of
+/// Base types (0..=14, 18..=20) match the bincode serialization order of
 /// the `Element` enum. The `Element` enum has indices 15, 16, and 17
 /// reserved for the `NonCounted`, `NotSummed`, and `NotCountedOrSummed`
 /// wrapper variants respectively (none has a direct `ElementType`
@@ -228,7 +228,7 @@ pub enum ProofNodeType {
 /// and `from_serialized_value` resolves `[16, inner_byte]` to the matching
 /// twin via an explicit `inner_byte → twin` match.
 ///
-/// IMPORTANT: Base values (0..=14, 18, 19) must match the order of
+/// IMPORTANT: Base values (0..=14, 18..=20) must match the order of
 /// variants in the `Element` enum. The
 /// `test_element_serialization_discriminants_match_element_type` test
 /// catches drift.
@@ -1709,7 +1709,7 @@ mod tests {
 
         let grove_version = GroveVersion::latest();
 
-        // Build vector of (Element, ElementType, variant_name) for all 10 variants
+        // Build vector of (Element, ElementType, variant_name) for all base variants.
         let test_cases: Vec<(Element, ElementType, &str)> = vec![
             // discriminant 0
             (
@@ -1810,16 +1810,22 @@ mod tests {
                 ElementType::ProvableSumTree,
                 "ProvableSumTree",
             ),
+            // discriminant 20
+            (
+                Element::ProvableCountProvableSumTree(None, 0, 0, None),
+                ElementType::ProvableCountProvableSumTree,
+                "ProvableCountProvableSumTree",
+            ),
         ];
 
-        // Verify we're testing all 17 base discriminants: 0..=14, 18, 19.
+        // Verify we're testing all 18 base discriminants: 0..=14, 18..=20.
         // (15 = NonCounted wrapper byte, 16 = NotSummed wrapper byte,
         // 17 = NotCountedOrSummed wrapper byte — none has a base
         // ElementType variant.)
         assert_eq!(
             test_cases.len(),
-            17,
-            "Expected 17 base Element variants in test, got {}",
+            18,
+            "Expected 18 base Element variants in test, got {}",
             test_cases.len()
         );
 


### PR DESCRIPTION
# PR Body

## Summary

- Add `Element::ProvableCountProvableSumTree` to the serialization
  discriminant drift test
- Update the base-discriminant comments and assertion count from `17` to `18`
- Cover discriminant `20` so future `Element` enum reorderings are caught

Fixes dashpay/grovedb#718.

## Validation

- `cargo test -p grovedb-element test_element_serialization_discriminants_match_element_type`
- Code review gate: Recommendation: ship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected element type discriminant handling to properly encompass all expected variant types.

* **Documentation**
  * Updated element type documentation to accurately reflect the complete range of supported discriminants.

* **Tests**
  * Enhanced test coverage for element type serialization to validate all expected variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/grovedb/pull/742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->