### PR TITLE
fix(tree): clamp balance factor for corrupt heights

### DIFF
--- a/merk/src/tree/link.rs
+++ b/merk/src/tree/link.rs
@@ -210,13 +210,21 @@ impl Link {
             }
         }
 
+        const fn saturating_add_one(height: u8) -> u8 {
+            if height == u8::MAX {
+                u8::MAX
+            } else {
+                height + 1
+            }
+        }
+
         let (left_height, right_height) = match self {
             Link::Reference { child_heights, .. } => *child_heights,
             Link::Modified { child_heights, .. } => *child_heights,
             Link::Uncommitted { child_heights, .. } => *child_heights,
             Link::Loaded { child_heights, .. } => *child_heights,
         };
-        1 + max(left_height, right_height)
+        saturating_add_one(max(left_height, right_height))
     }
 
     /// Returns the balance factor of the tree referenced by the link.
@@ -234,8 +242,8 @@ impl Link {
         let diff = right_height as i16 - left_height as i16;
         if diff > i8::MAX as i16 {
             i8::MAX
-        } else if diff < i8::MIN as i16 {
-            i8::MIN
+        } else if diff < (i8::MIN + 1) as i16 {
+            i8::MIN + 1
         } else {
             diff as i8
         }
@@ -803,6 +811,26 @@ mod test {
         assert_eq!(loaded.hash(), &[0; 32]);
         assert_eq!(loaded.height(), 1);
         assert!(loaded.into_reference().unwrap().is_reference());
+    }
+
+    #[test]
+    fn height_saturates_for_corrupt_child_heights() {
+        let left_heavy_link = Link::Reference {
+            hash: NULL_HASH,
+            aggregate_data: AggregateData::NoAggregateData,
+            child_heights: (255, 0),
+            key: vec![0],
+        };
+        let right_heavy_link = Link::Reference {
+            hash: NULL_HASH,
+            aggregate_data: AggregateData::NoAggregateData,
+            child_heights: (0, 255),
+            key: vec![0],
+        };
+
+        assert_eq!(left_heavy_link.height(), u8::MAX);
+        assert_eq!(left_heavy_link.balance_factor(), i8::MIN + 1);
+        assert_eq!(right_heavy_link.balance_factor(), i8::MAX);
     }
 
     #[test]

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -942,7 +942,7 @@ impl TreeNode {
     /// etc.
     #[inline]
     pub fn height(&self) -> u8 {
-        1 + max(self.child_height(true), self.child_height(false))
+        max(self.child_height(true), self.child_height(false)).saturating_add(1)
     }
 
     /// Returns the balance factor of the root node. This is the difference
@@ -951,13 +951,17 @@ impl TreeNode {
     /// subtree is 2 levels taller than the left subtree.
     #[inline]
     pub const fn balance_factor(&self) -> i8 {
-        // Cast to i8 is safe: child_height() returns at most the tree height,
-        // which is O(log n). Even with 2^127 elements the height would be ~127,
-        // well within i8 range. An AVL tree that could overflow u8 child heights
-        // (>255) is physically impossible.
-        let left_height = self.child_height(true) as i8;
-        let right_height = self.child_height(false) as i8;
-        right_height - left_height
+        // Subtract in i16 to avoid wrapping when corrupted child heights exceed
+        // 127, then clamp to i8 range. For a valid AVL tree the result is in
+        // [-2, 2], but corrupted data could produce larger differences.
+        let diff = self.child_height(false) as i16 - self.child_height(true) as i16;
+        if diff > i8::MAX as i16 {
+            i8::MAX
+        } else if diff < (i8::MIN + 1) as i16 {
+            i8::MIN + 1
+        } else {
+            diff as i8
+        }
     }
 
     /// Attaches the child (if any) to the root node on the given side. Creates
@@ -1525,7 +1529,7 @@ mod test_provable_count_edge_cases;
 #[cfg(test)]
 mod test {
 
-    use super::{commit::NoopCommit, hash::NULL_HASH, AggregateData, TreeNode};
+    use super::{commit::NoopCommit, hash::NULL_HASH, AggregateData, Link, TreeNode};
     use crate::tree::{
         tree_feature_type::TreeFeatureType::SummedMerkNode, TreeFeatureType::BasicMerkNode,
     };
@@ -1723,6 +1727,44 @@ mod test {
         assert_eq!(tree.child_height(true), 0);
         assert_eq!(tree.child_height(false), 1);
         assert_eq!(tree.balance_factor(), 1);
+
+        let tree = TreeNode::from_fields(
+            vec![0],
+            vec![1],
+            NULL_HASH,
+            Some(Link::Reference {
+                hash: NULL_HASH,
+                child_heights: (255, 0),
+                key: vec![2],
+                aggregate_data: AggregateData::NoAggregateData,
+            }),
+            None,
+            BasicMerkNode,
+        )
+        .unwrap();
+        let balance_factor = tree.balance_factor();
+        assert_eq!(tree.child_height(true), u8::MAX);
+        assert_eq!(tree.height(), u8::MAX);
+        assert_eq!(balance_factor, i8::MIN + 1);
+        assert_eq!(balance_factor.abs(), i8::MAX);
+
+        let tree = TreeNode::from_fields(
+            vec![0],
+            vec![1],
+            NULL_HASH,
+            None,
+            Some(Link::Reference {
+                hash: NULL_HASH,
+                child_heights: (255, 0),
+                key: vec![2],
+                aggregate_data: AggregateData::NoAggregateData,
+            }),
+            BasicMerkNode,
+        )
+        .unwrap();
+        assert_eq!(tree.child_height(false), u8::MAX);
+        assert_eq!(tree.height(), u8::MAX);
+        assert_eq!(tree.balance_factor(), i8::MAX);
     }
 
     #[test]


### PR DESCRIPTION
# Fix corrupt height balance clamps

## Summary

- harden `TreeNode::balance_factor()` against corrupt child heights above
  `127`
- clamp balance-factor underflow to `-127` so callers using `.abs()` cannot
  panic on `i8::MIN`
- make `Link::height()` and `TreeNode::height()` saturate for corrupt
  `u8::MAX` child heights
- add regression coverage for corrupt child height `255` on both left and
  right sides

Fixes dashpay/grovedb#712.

## Validation

- `cargo test -p grovedb-merk height_and_balance --lib`
- `cargo test -p grovedb-merk --lib`
- pre-PR code review passed with recommendation: ship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tree structure calculations to prevent overflow when handling corrupted or edge-case data.
  * Enhanced balance factor computation with proper bounds clamping for robustness.

* **Tests**
  * Added unit tests to validate correct behavior with corrupted child-height inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/grovedb/pull/744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->