### PR TITLE
test: cover provable count sum discriminant

### DIFF
--- a/grovedb-element/src/element_type.rs
+++ b/grovedb-element/src/element_type.rs
@@ -1810,16 +1810,22 @@ mod tests {
                 ElementType::ProvableSumTree,
                 "ProvableSumTree",
             ),
+            // discriminant 20
+            (
+                Element::ProvableCountProvableSumTree(None, 0, 0, None),
+                ElementType::ProvableCountProvableSumTree,
+                "ProvableCountProvableSumTree",
+            ),
         ];
 
-        // Verify we're testing all 17 base discriminants: 0..=14, 18, 19.
+        // Verify we're testing all 18 base discriminants: 0..=14, 18, 19, 20.
         // (15 = NonCounted wrapper byte, 16 = NotSummed wrapper byte,
         // 17 = NotCountedOrSummed wrapper byte — none has a base
         // ElementType variant.)
         assert_eq!(
             test_cases.len(),
-            17,
-            "Expected 17 base Element variants in test, got {}",
+            18,
+            "Expected 18 base Element variants in test, got {}",
             test_cases.len()
         );
 


### PR DESCRIPTION
# Test Element Discriminant Coverage

## Issue being fixed or feature implemented

Fixes dashpay/grovedb#718.

The Element serialization discriminant drift test covered base discriminants
`0..=14`, `18`, and `19`, but omitted `ProvableCountProvableSumTree` at
discriminant `20`.

## What was done

- Added `Element::ProvableCountProvableSumTree` to
  `test_element_serialization_discriminants_match_element_type`.
- Updated the pinned base-variant count from 17 to 18.

## How Has This Been Tested

See validation below.

## Validation

- `cargo test -p grovedb-element test_element_serialization_discriminants_match_element_type`
- Pre-PR code review gate: `ship`

Environment: local macOS arm64 workspace.

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

## For repository code-owners and collaborators only

- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for element serialization by adding support for a new provable tree variant and updating related assertions to validate proper type handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/grovedb/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->