### PR TITLE
ci: generate lockfile before cargo audit

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -145,4 +145,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-audit
+      - name: Generate lockfile for audit
+        run: cargo generate-lockfile
       - run: cargo audit


### PR DESCRIPTION
# Generate lockfile before cargo audit

## Summary

- Generate a workspace `Cargo.lock` in the GroveDB security audit job before
  running `cargo audit`.
- Keep the generated lockfile ephemeral so the repository can continue ignoring
  `Cargo.lock` while CI audits an explicit dependency graph.

Fixes dashpay/grovedb#720.

## Validation

- `cargo generate-lockfile`
- `git diff --check`
- Code review gate: ship
  - Base: `upstream/develop`
  - Head: `origin/ci-generate-lockfile-before-audit`
- `cargo audit` not run locally: `cargo-audit` is not installed in this
  environment; CI installs it with `taiki-e/install-action@cargo-audit`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security audit process by ensuring dependency lockfile is generated and up-to-date before running security checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/grovedb/pull/753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->