### PR TITLE
fix(storage): flush all column families in RocksDbStorage::flush()

### DIFF
--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -42,8 +42,8 @@ use lazy_static::lazy_static;
 #[cfg(feature = "unsafe-dump-load")]
 use rocksdb::IngestExternalFileOptions;
 use rocksdb::{
-    checkpoint::Checkpoint, ColumnFamily, ColumnFamilyDescriptor, OptimisticTransactionDB,
-    Transaction, WriteBatchWithTransaction, DEFAULT_COLUMN_FAMILY_NAME,
+    checkpoint::Checkpoint, ColumnFamily, ColumnFamilyDescriptor, FlushOptions,
+    OptimisticTransactionDB, Transaction, WriteBatchWithTransaction, DEFAULT_COLUMN_FAMILY_NAME,
 };
 
 use super::{PrefixedRocksDbImmediateStorageContext, PrefixedRocksDbTransactionContext};
@@ -611,7 +611,19 @@ impl<'db> Storage<'db> for RocksDbStorage {
     }
 
     fn flush(&self) -> Result<(), Error> {
-        self.db.flush().map_err(RocksDBError)
+        // Flush all column families: `set_atomic_flush(true)` requires it, and a
+        // default-only flush leaves the roots/meta/aux memtables unpersisted.
+        self.db
+            .flush_cfs_opt(
+                &[
+                    cf_default(&self.db),
+                    cf_aux(&self.db),
+                    cf_roots(&self.db),
+                    cf_meta(&self.db),
+                ],
+                &FlushOptions::default(),
+            )
+            .map_err(RocksDBError)
     }
 
     fn get_transactional_storage_context<'b, B>(
@@ -714,6 +726,13 @@ fn cf_meta(storage: &Db) -> &ColumnFamily {
         .expect("meta column family must exist")
 }
 
+/// Get the default column family
+fn cf_default(storage: &Db) -> &ColumnFamily {
+    storage
+        .cf_handle(DEFAULT_COLUMN_FAMILY_NAME)
+        .expect("default column family must exist")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -722,6 +741,38 @@ mod tests {
         RawIterator, Storage, StorageContext,
     };
     use grovedb_path::SubtreePath;
+
+    #[test]
+    fn flush_persists_all_column_families() {
+        let storage = TempStorage::new();
+        let db = &storage.db;
+
+        // Populate every column family.
+        db.put_cf(cf_default(db), b"kd", b"vd")
+            .expect("default put");
+        db.put_cf(cf_aux(db), b"ka", b"va").expect("aux put");
+        db.put_cf(cf_roots(db), b"kr", b"vr").expect("roots put");
+        db.put_cf(cf_meta(db), b"km", b"vm").expect("meta put");
+
+        storage.flush().expect("flush");
+
+        // Every CF's active memtable must now be empty (data flushed to SST).
+        for (name, cf) in [
+            (DEFAULT_COLUMN_FAMILY_NAME, cf_default(db)),
+            (AUX_CF_NAME, cf_aux(db)),
+            (ROOTS_CF_NAME, cf_roots(db)),
+            (META_CF_NAME, cf_meta(db)),
+        ] {
+            let entries = db
+                .property_int_value_cf(cf, "rocksdb.num-entries-active-mem-table")
+                .expect("memtable property read")
+                .expect("memtable property present");
+            assert_eq!(
+                entries, 0,
+                "column family '{name}' was not flushed: {entries} entries still in the memtable",
+            );
+        }
+    }
 
     #[test]
     fn test_build_prefix() {


### PR DESCRIPTION
## Problem

`RocksDbStorage::flush()` flushes only the **`default`** column family:

```rust
fn flush(&self) -> Result<(), Error> {
    self.db.flush().map_err(RocksDBError)
}
```

But the storage spreads its data across four CFs — `default`, `aux`, `roots`, `meta` — opened with `set_atomic_flush(true)`. So `flush()` leaves `aux`/`roots`/`meta` sitting in volatile memtables, and any caller that relies on it for durability before a non-clean shutdown (`SIGTERM`/`SIGKILL`, where the `Drop`-time close never runs) silently loses recently-committed data.

Under `atomic_flush`, RocksDB expects every CF to be flushed together anyway — so today's single-CF flush is effectively a no-op for durability.

## Fix

Flush all four column families atomically via `flush_cfs_opt`, consistent with `set_atomic_flush(true)`.

## Test

Adds `flush_persists_all_column_families`: writes into all four CFs, calls `flush()`, and asserts each CF's active memtable is empty (data moved to SST). It **fails** on the old `flush()` (`column family 'aux' was not flushed: 1 entries still in the memtable`) and **passes** with this change.

```
cargo test -p grovedb-storage --features rocksdb_storage flush_persists_all_column_families
```

## Why this stayed latent

The single-CF flush has been here since #13 (2022), so it's worth noting why it hasn't bitten before. `flush()` only matters for durability when it's the last write before an unclean stop. Drive — grovedb's main consumer — calls it from `Drop`, where RocksDB's own teardown persists every CF anyway, and an unclean kill is backstopped by Tenderdash replaying the missing blocks. The consumer that surfaced this (Willow indexer node) is the first to lean on `flush()` as a real crash barrier — called on `SIGTERM`, with no consensus layer behind it to regenerate lost state — which is the one condition under which the partial flush actually drops committed data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a storage persistence issue where certain data types could remain in volatile memory instead of being properly written to disk during flush operations, improving overall data reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
