### PR TITLE
deps(commitment-tree): migrate orchard to 0.14.0 (circuit soundness fix)

### DIFF
--- a/grovedb-commitment-tree/Cargo.toml
+++ b/grovedb-commitment-tree/Cargo.toml
@@ -17,7 +17,7 @@ client = ["shardtree"]
 sqlite = ["client", "rusqlite"]
 
 [dependencies]
-orchard = { git = "https://github.com/dashpay/orchard.git", rev = "898258d76aab2822249492aede59a02d49278fff", features = ["circuit"] }
+orchard = { git = "https://github.com/dashpay/orchard.git", tag = "dashified-0.14.0", features = ["circuit"] }
 incrementalmerkletree = "0.8"
 shardtree = { version = "0.6", optional = true }
 rusqlite = { version = "0.38", features = ["bundled"], optional = true }


### PR DESCRIPTION
Closes #756.

## What

Pins `orchard` in [`grovedb-commitment-tree/Cargo.toml`](https://github.com/dashpay/grovedb/blob/claude/eager-shirley-f0d2e7/grovedb-commitment-tree/Cargo.toml) to the `dashified-0.14.0` tag, replacing the previous 0.13.1-based `rev` pin:

```diff
-orchard = { git = "https://github.com/dashpay/orchard.git", rev = "898258d76aab2822249492aede59a02d49278fff", features = ["circuit"] }
+orchard = { git = "https://github.com/dashpay/orchard.git", tag = "dashified-0.14.0", features = ["circuit"] }
```

The tag dereferences to commit `f0555739` — **orchard 0.14.0** + the Dash `MemoSize` commits, pulling in **halo2_gadgets 0.5.0**. `Cargo.lock` is gitignored in this workspace, so this is the sole tracked change.

## Why (security)

orchard `< 0.14.0` / halo2_gadgets `< 0.5.0` contain a disclosed **soundness bug in the Orchard zero-knowledge circuit**: variable-base scalar multiplication (`ecc::chip::mul`) never constrained the incomplete double-and-add loop's per-iteration base to the real base, so a prover could compute `[a]·base + [b]·B'` instead of `[scalar]·base` — potentially enabling double-spends within an Orchard pool. The fix changes the circuit and therefore requires a **new verifying key**.

0.14.0 also adds proof-size bounding for bundles from untrusted parts (**GHSA-2x4w-pxqw-58v9**) and an `epk` validity check in `Action::from_parts`.

This crate enables the `circuit` feature and uses `builder::Builder`, `bundle::{Authorized, Flags, BatchValidator}`, and `circuit::{ProvingKey, VerifyingKey}`, so it is directly exposed.

## Why no code/API changes were needed

- The 0.14.0 breaking changes — `Action::from_parts` → `Result`, removal of `Bundle::from_parts` (→ `try_from_parts` + `ProofSizeEnforcement`), `OrchardCircuitVersion` threading — are **not used directly** anywhere in this crate or its benches.
- The verification bench's `Builder::new` / `build` / `create_proof` / `apply_signatures` / `BatchValidator` signatures are unchanged. `Builder::new` and `ProvingKey::build` / `VerifyingKey::build` all default to the **secure `FixedPostNu6_2`** circuit, so proofs are built and verified against the fixed VK automatically.
- **Nothing to regenerate**: the crate commits no proving/verifying keys, VK fingerprints, or serialized proof/test vectors. The verification bench builds keys+proofs at runtime; the seeding bench uses random data.
- **MSRV**: workspace toolchain is `stable`; orchard's 1.85.1 MSRV is satisfied.
- **No crate version bump** — `grovedb-commitment-tree` has never shipped to production.

## Verification

- `cargo build -p grovedb-commitment-tree --all-features` (lib + benches) ✓
- `cargo test -p grovedb-commitment-tree --all-features` → **108 passed, 0 failed**, 2 ignored ✓
- `cargo clippy -p grovedb-commitment-tree --all-features --all-targets` → no warnings ✓
- `cargo fmt -p grovedb-commitment-tree -- --check` → clean ✓
- Final build + test-link re-resolved against the remote source `git+https://github.com/dashpay/orchard.git?tag=dashified-0.14.0#f0555739` ✓

## Coordination (follow-up, not in this PR)

`dashpay/platform` and `dashpay/dash-evo-tool` also depend on the `dashpay/orchard` fork — they should pin the **same** `dashified-0.14.0` tag so versions stay consistent across the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency to a specific version tag for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->