### PR TITLE
fix: version-gate add_element_on_transaction (v0=Op::Put, v1=layered)

### DIFF
--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -104,7 +104,11 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
                 insert: 0,
                 insert_on_transaction: 0,
                 insert_without_transaction: 0,
-                add_element_on_transaction: 0,
+                // v1: non-batch insert writes CountSumTree / ProvableCountTree /
+                // ProvableCountSumTree as layered subtrees, consistent with the
+                // batch path. GROVE_V1 / GROVE_V2 keep v0 (Op::Put) to preserve
+                // the protocol-v11 consensus root (testnet block 245,344).
+                add_element_on_transaction: 1,
                 add_element_without_transaction: 0,
                 insert_if_not_exists: 0,
                 insert_if_not_exists_return_existing_element: 0,

--- a/grovedb/src/operations/insert/add_element_on_transaction/mod.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/mod.rs
@@ -1,0 +1,91 @@
+//! `add_element_on_transaction` — versioned dispatch.
+//!
+//! Adds a single element (an empty subtree or a value) into an already-open
+//! parent merk on a transaction. This is the **non-batch** insert path
+//! (`GroveDb::insert` / `insert_if_not_exists`).
+//!
+//! The choice between writing certain tree types as a layered subtree
+//! (`Op::PutLayeredReference`) versus a plain value (`Op::Put`) changes the
+//! parent node's `value_hash` and therefore the grovedb root, so it is
+//! **consensus-critical** and version-gated:
+//!
+//! * **[v0]** — grovedb v4.1.0 behaviour. `CountSumTree` / `ProvableCountTree` /
+//!   `ProvableCountSumTree` are written as a plain value (`Op::Put`). This is the
+//!   behaviour frozen into the live protocol-v11 activation chain (testnet block
+//!   245,344, `transition_to_version_11`). Selected by `GROVE_V1` / `GROVE_V2`.
+//! * **[v1]** — current behaviour. Those three types are written as layered
+//!   subtrees, consistent with the batch insert path (both root hash and fee).
+//!   Selected by `GROVE_V3`+.
+//!
+//! The two implementations are otherwise identical; the only difference is which
+//! match arm those three element types fall into. See [v0] / [v1].
+//!
+//! [v0]: self::v0
+//! [v1]: self::v1
+
+mod v0;
+mod v1;
+
+use grovedb_costs::{CostResult, CostsExt, OperationCost};
+use grovedb_merk::Merk;
+use grovedb_path::SubtreePath;
+use grovedb_storage::{rocksdb_storage::PrefixedRocksDbTransactionContext, StorageBatch};
+use grovedb_version::version::GroveVersion;
+
+use super::InsertOptions;
+use crate::{Element, Error, GroveDb, Transaction};
+
+impl GroveDb {
+    /// Add subtree to another subtree.
+    /// We want to add a new empty merk to another merk at a key
+    /// first make sure other merk exist
+    /// if it exists, then create merk to be inserted, and get root hash
+    /// we only care about root hash of merk to be inserted
+    ///
+    /// Version dispatch (consensus-critical) — see the module documentation.
+    pub(crate) fn add_element_on_transaction<'db, B: AsRef<[u8]>>(
+        &'db self,
+        path: SubtreePath<B>,
+        key: &[u8],
+        element: Element,
+        options: InsertOptions,
+        transaction: &'db Transaction,
+        batch: &'db StorageBatch,
+        grove_version: &GroveVersion,
+    ) -> CostResult<Merk<PrefixedRocksDbTransactionContext<'db>>, Error> {
+        match grove_version
+            .grovedb_versions
+            .operations
+            .insert
+            .add_element_on_transaction
+        {
+            0 => self.add_element_on_transaction_v0(
+                path,
+                key,
+                element,
+                options,
+                transaction,
+                batch,
+                grove_version,
+            ),
+            1 => self.add_element_on_transaction_v1(
+                path,
+                key,
+                element,
+                options,
+                transaction,
+                batch,
+                grove_version,
+            ),
+            version => Err(
+                grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
+                    method: "add_element_on_transaction".to_string(),
+                    known_versions: vec![0, 1],
+                    received: version,
+                }
+                .into(),
+            )
+            .wrap_with_cost(OperationCost::default()),
+        }
+    }
+}

--- a/grovedb/src/operations/insert/add_element_on_transaction/v0.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/v0.rs
@@ -1,0 +1,240 @@
+//! `add_element_on_transaction` — **v0** (grovedb v4.1.0, `GROVE_V1` / `GROVE_V2`).
+//!
+//! CONSENSUS-CRITICAL. `CountSumTree` / `ProvableCountTree` /
+//! `ProvableCountSumTree` are inserted via the **plain-value path** (`Op::Put`,
+//! the `Item` arm below), NOT as layered subtrees. grovedb <= v4.1.0 routed
+//! them through `_ => element.insert()` (`Op::Put`), and that is the behaviour
+//! frozen into the live protocol-v11 activation chain — e.g. testnet block
+//! 245,344's `transition_to_version_11`, which inserts an
+//! `empty_provable_count_sum_tree` (CLEAR_ADDRESS_POOL) and an
+//! `empty_count_sum_tree` (ADDRESS_BALANCES) through this non-batch path.
+//!
+//! Routing those three types through the layered-subtree arm (as [`super::v1`]
+//! does for `GROVE_V3`+) changes the parent node's `value_hash` from
+//! `value_hash(serialized)` to `combine_hash(value_hash(serialized), NULL_HASH)`,
+//! which changes the grovedb root and breaks consensus when v11 is replayed.
+//!
+//! v0 therefore differs from [`super::v1`] ONLY in the placement of those three
+//! match arms: here they join the `Op::Put` arm; there they join the layered
+//! arm. Everything else is identical. (The v12-only `ProvableSumTree` /
+//! `ProvableCountProvableSumTree` keep the layered behaviour in both — they were
+//! never created via this path on the v11 chain.)
+
+use grovedb_costs::{
+    cost_return_on_error, cost_return_on_error_into, cost_return_on_error_no_add, CostResult,
+    CostsExt, OperationCost,
+};
+use grovedb_element::reference_path::path_from_reference_path_type;
+use grovedb_merk::{
+    element::{costs::ElementCostExtensions, insert::ElementInsertToStorageExtensions, ElementExt},
+    tree::NULL_HASH,
+    Merk,
+};
+use grovedb_path::SubtreePath;
+use grovedb_storage::{rocksdb_storage::PrefixedRocksDbTransactionContext, StorageBatch};
+use grovedb_version::version::GroveVersion;
+
+use super::super::InsertOptions;
+use crate::{Element, Error, GroveDb, Transaction};
+
+impl GroveDb {
+    /// `add_element_on_transaction` v0 — see the module documentation.
+    pub(crate) fn add_element_on_transaction_v0<'db, B: AsRef<[u8]>>(
+        &'db self,
+        path: SubtreePath<B>,
+        key: &[u8],
+        element: Element,
+        options: InsertOptions,
+        transaction: &'db Transaction,
+        batch: &'db StorageBatch,
+        grove_version: &GroveVersion,
+    ) -> CostResult<Merk<PrefixedRocksDbTransactionContext<'db>>, Error> {
+        let mut cost = OperationCost::default();
+
+        let mut subtree_to_insert_into = cost_return_on_error!(
+            &mut cost,
+            self.open_transactional_merk_at_path(
+                path.clone(),
+                transaction,
+                Some(batch),
+                grove_version
+            )
+        );
+        // if we don't allow a tree override then we should check
+
+        if options.checks_for_override() {
+            let maybe_element_bytes = cost_return_on_error!(
+                &mut cost,
+                subtree_to_insert_into
+                    .get(
+                        key,
+                        true,
+                        Some(&Element::value_defined_cost_for_serialized_value),
+                        grove_version,
+                    )
+                    .map_err(|e| Error::CorruptedData(e.to_string()))
+            );
+            if let Some(element_bytes) = maybe_element_bytes {
+                if options.validate_insertion_does_not_override {
+                    return Err(Error::OverrideNotAllowed(
+                        "insertion not allowed to override",
+                    ))
+                    .wrap_with_cost(cost);
+                }
+                if options.validate_insertion_does_not_override_tree {
+                    let element = cost_return_on_error_no_add!(
+                        cost,
+                        Element::deserialize(element_bytes.as_slice(), grove_version).map_err(
+                            |_| {
+                                Error::CorruptedData(String::from("unable to deserialize element"))
+                            }
+                        )
+                    );
+                    if element.is_any_tree() {
+                        return Err(Error::OverrideNotAllowed(
+                            "insertion not allowed to override tree",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                }
+            }
+        }
+
+        // Dispatch via the underlying element so a NonCounted wrapper takes
+        // the same path as its inner element. The actual `element.insert*`
+        // calls operate on the outer wrapper, which is what we want — the
+        // serialized wrapper bytes go to storage.
+        match element.underlying() {
+            // `ReferenceWithSumItem` shares the reference resolution + proof
+            // shape with `Reference`. The merk feature_type derived from the
+            // element's `sum_value_or_default()` already routes the sum into
+            // any sum-bearing parent; the call site is otherwise identical.
+            Element::Reference(reference_path, ..)
+            | Element::ReferenceWithSumItem(reference_path, ..) => {
+                let path = path.to_vec(); // TODO: need for support for references in path library
+                let reference_path = cost_return_on_error_into!(
+                    &mut cost,
+                    path_from_reference_path_type(reference_path.clone(), &path, Some(key))
+                        .wrap_with_cost(OperationCost::default())
+                );
+
+                let referenced_item = cost_return_on_error!(
+                    &mut cost,
+                    self.follow_reference(
+                        reference_path.as_slice().into(),
+                        false,
+                        Some(transaction),
+                        grove_version
+                    )
+                );
+
+                let referenced_element_value_hash = cost_return_on_error_into!(
+                    &mut cost,
+                    referenced_item.value_hash(grove_version)
+                );
+
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_reference(
+                        &mut subtree_to_insert_into,
+                        key,
+                        referenced_element_value_hash,
+                        Some(options.as_merk_options()),
+                        grove_version,
+                    )
+                );
+            }
+            // CONSENSUS-CRITICAL: `CountSumTree` / `ProvableCountTree` /
+            // `ProvableCountSumTree` are NOT in this layered arm in v0 — they
+            // take the `Op::Put` arm below to match grovedb v4.1.0 / the live
+            // protocol-v11 root. See the module docs.
+            Element::Tree(value, _)
+            | Element::SumTree(value, ..)
+            | Element::BigSumTree(value, ..)
+            | Element::CountTree(value, ..)
+            | Element::ProvableSumTree(value, ..)
+            | Element::ProvableCountProvableSumTree(value, ..) => {
+                if value.is_some() {
+                    return Err(Error::InvalidCodeExecution(
+                        "a tree should be empty at the moment of insertion when not using batches",
+                    ))
+                    .wrap_with_cost(cost);
+                } else {
+                    cost_return_on_error_into!(
+                        &mut cost,
+                        element.insert_subtree(
+                            &mut subtree_to_insert_into,
+                            key,
+                            NULL_HASH,
+                            Some(options.as_merk_options()),
+                            grove_version
+                        )
+                    );
+                }
+            }
+            // CommitmentTree uses BulkAppendTree internally; the initial child
+            // hash must include the empty sinsemilla root so V1 proof
+            // verification works even before the first append.
+            Element::CommitmentTree(..) => {
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_subtree(
+                        &mut subtree_to_insert_into,
+                        key,
+                        grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT,
+                        Some(options.as_merk_options()),
+                        grove_version
+                    )
+                );
+            }
+            // MmrTree, BulkAppendTree, DenseAppendOnlyFixedSizeTree: initial
+            // insert uses NULL_HASH since these trees start empty.
+            Element::MmrTree(..)
+            | Element::BulkAppendTree(..)
+            | Element::DenseAppendOnlyFixedSizeTree(..) => {
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_subtree(
+                        &mut subtree_to_insert_into,
+                        key,
+                        NULL_HASH,
+                        Some(options.as_merk_options()),
+                        grove_version
+                    )
+                );
+            }
+            // `CountSumTree` / `ProvableCountTree` / `ProvableCountSumTree` are
+            // inserted via `Op::Put` here (NOT the layered-subtree arm above) to
+            // preserve the grovedb v4.1.0 / protocol-v11 consensus root — see the
+            // module docs.
+            Element::Item(..)
+            | Element::SumItem(..)
+            | Element::ItemWithSumItem(..)
+            | Element::CountSumTree(..)
+            | Element::ProvableCountTree(..)
+            | Element::ProvableCountSumTree(..) => {
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert(
+                        &mut subtree_to_insert_into,
+                        key,
+                        Some(options.as_merk_options()),
+                        grove_version
+                    )
+                );
+            }
+            // `underlying()` only unwraps one level; nested wrappers are
+            // forbidden by the constructor and (de)serializer, but the public
+            // insert path can still receive a hand-built nested wrapper —
+            // return a typed error rather than panic.
+            Element::NonCounted(_) | Element::NotSummed(_) | Element::NotCountedOrSummed(_) => {
+                return Err(Error::InvalidInput(
+                    "nested element wrappers are not allowed",
+                ))
+                .wrap_with_cost(cost);
+            }
+        }
+
+        Ok(subtree_to_insert_into).wrap_with_cost(cost)
+    }
+}

--- a/grovedb/src/operations/insert/add_element_on_transaction/v1.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/v1.rs
@@ -1,0 +1,227 @@
+//! `add_element_on_transaction` — **v1** (current behaviour, `GROVE_V3`+).
+//!
+//! `CountSumTree` / `ProvableCountTree` / `ProvableCountSumTree` are inserted as
+//! **layered subtrees** (`Op::PutLayeredReference`), the same way the batch
+//! insert path writes them. This makes the parent node's `value_hash` =
+//! `combine_hash(value_hash(serialized), child_root_hash)` and the storage cost
+//! the fixed layered tree cost — i.e. the non-batch path agrees with the batch
+//! path on both the root hash and the fee.
+//!
+//! This differs from [`super::v0`] (grovedb v4.1.0 / `GROVE_V1` / `GROVE_V2`)
+//! ONLY in the match arm for those three element types, where v0 uses the
+//! plain-value `Op::Put` path instead. See the module docs in
+//! [`super`][`mod@super`] for the consensus rationale.
+
+use grovedb_costs::{
+    cost_return_on_error, cost_return_on_error_into, cost_return_on_error_no_add, CostResult,
+    CostsExt, OperationCost,
+};
+use grovedb_element::reference_path::path_from_reference_path_type;
+use grovedb_merk::{
+    element::{costs::ElementCostExtensions, insert::ElementInsertToStorageExtensions, ElementExt},
+    tree::NULL_HASH,
+    Merk,
+};
+use grovedb_path::SubtreePath;
+use grovedb_storage::{rocksdb_storage::PrefixedRocksDbTransactionContext, StorageBatch};
+use grovedb_version::version::GroveVersion;
+
+use super::super::InsertOptions;
+use crate::{Element, Error, GroveDb, Transaction};
+
+impl GroveDb {
+    /// `add_element_on_transaction` v1 — see the module documentation.
+    pub(crate) fn add_element_on_transaction_v1<'db, B: AsRef<[u8]>>(
+        &'db self,
+        path: SubtreePath<B>,
+        key: &[u8],
+        element: Element,
+        options: InsertOptions,
+        transaction: &'db Transaction,
+        batch: &'db StorageBatch,
+        grove_version: &GroveVersion,
+    ) -> CostResult<Merk<PrefixedRocksDbTransactionContext<'db>>, Error> {
+        let mut cost = OperationCost::default();
+
+        let mut subtree_to_insert_into = cost_return_on_error!(
+            &mut cost,
+            self.open_transactional_merk_at_path(
+                path.clone(),
+                transaction,
+                Some(batch),
+                grove_version
+            )
+        );
+        // if we don't allow a tree override then we should check
+
+        if options.checks_for_override() {
+            let maybe_element_bytes = cost_return_on_error!(
+                &mut cost,
+                subtree_to_insert_into
+                    .get(
+                        key,
+                        true,
+                        Some(&Element::value_defined_cost_for_serialized_value),
+                        grove_version,
+                    )
+                    .map_err(|e| Error::CorruptedData(e.to_string()))
+            );
+            if let Some(element_bytes) = maybe_element_bytes {
+                if options.validate_insertion_does_not_override {
+                    return Err(Error::OverrideNotAllowed(
+                        "insertion not allowed to override",
+                    ))
+                    .wrap_with_cost(cost);
+                }
+                if options.validate_insertion_does_not_override_tree {
+                    let element = cost_return_on_error_no_add!(
+                        cost,
+                        Element::deserialize(element_bytes.as_slice(), grove_version).map_err(
+                            |_| {
+                                Error::CorruptedData(String::from("unable to deserialize element"))
+                            }
+                        )
+                    );
+                    if element.is_any_tree() {
+                        return Err(Error::OverrideNotAllowed(
+                            "insertion not allowed to override tree",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                }
+            }
+        }
+
+        // Dispatch via the underlying element so a NonCounted wrapper takes
+        // the same path as its inner element. The actual `element.insert*`
+        // calls operate on the outer wrapper, which is what we want — the
+        // serialized wrapper bytes go to storage.
+        match element.underlying() {
+            // `ReferenceWithSumItem` shares the reference resolution + proof
+            // shape with `Reference`. The merk feature_type derived from the
+            // element's `sum_value_or_default()` already routes the sum into
+            // any sum-bearing parent; the call site is otherwise identical.
+            Element::Reference(reference_path, ..)
+            | Element::ReferenceWithSumItem(reference_path, ..) => {
+                let path = path.to_vec(); // TODO: need for support for references in path library
+                let reference_path = cost_return_on_error_into!(
+                    &mut cost,
+                    path_from_reference_path_type(reference_path.clone(), &path, Some(key))
+                        .wrap_with_cost(OperationCost::default())
+                );
+
+                let referenced_item = cost_return_on_error!(
+                    &mut cost,
+                    self.follow_reference(
+                        reference_path.as_slice().into(),
+                        false,
+                        Some(transaction),
+                        grove_version
+                    )
+                );
+
+                let referenced_element_value_hash = cost_return_on_error_into!(
+                    &mut cost,
+                    referenced_item.value_hash(grove_version)
+                );
+
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_reference(
+                        &mut subtree_to_insert_into,
+                        key,
+                        referenced_element_value_hash,
+                        Some(options.as_merk_options()),
+                        grove_version,
+                    )
+                );
+            }
+            // v1: all tree types — including `CountSumTree` / `ProvableCountTree`
+            // / `ProvableCountSumTree` — are written as layered subtrees. This is
+            // the behaviour selected by `GROVE_V3`+; for `GROVE_V1` / `GROVE_V2`
+            // those three types take the plain-value `Op::Put` arm in
+            // [`super::v0`] instead, to preserve the protocol-v11 consensus root.
+            Element::Tree(value, _)
+            | Element::SumTree(value, ..)
+            | Element::BigSumTree(value, ..)
+            | Element::CountTree(value, ..)
+            | Element::CountSumTree(value, ..)
+            | Element::ProvableCountTree(value, ..)
+            | Element::ProvableCountSumTree(value, ..)
+            | Element::ProvableSumTree(value, ..)
+            | Element::ProvableCountProvableSumTree(value, ..) => {
+                if value.is_some() {
+                    return Err(Error::InvalidCodeExecution(
+                        "a tree should be empty at the moment of insertion when not using batches",
+                    ))
+                    .wrap_with_cost(cost);
+                } else {
+                    cost_return_on_error_into!(
+                        &mut cost,
+                        element.insert_subtree(
+                            &mut subtree_to_insert_into,
+                            key,
+                            NULL_HASH,
+                            Some(options.as_merk_options()),
+                            grove_version
+                        )
+                    );
+                }
+            }
+            // CommitmentTree uses BulkAppendTree internally; the initial child
+            // hash must include the empty sinsemilla root so V1 proof
+            // verification works even before the first append.
+            Element::CommitmentTree(..) => {
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_subtree(
+                        &mut subtree_to_insert_into,
+                        key,
+                        grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT,
+                        Some(options.as_merk_options()),
+                        grove_version
+                    )
+                );
+            }
+            // MmrTree, BulkAppendTree, DenseAppendOnlyFixedSizeTree: initial
+            // insert uses NULL_HASH since these trees start empty.
+            Element::MmrTree(..)
+            | Element::BulkAppendTree(..)
+            | Element::DenseAppendOnlyFixedSizeTree(..) => {
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_subtree(
+                        &mut subtree_to_insert_into,
+                        key,
+                        NULL_HASH,
+                        Some(options.as_merk_options()),
+                        grove_version
+                    )
+                );
+            }
+            Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert(
+                        &mut subtree_to_insert_into,
+                        key,
+                        Some(options.as_merk_options()),
+                        grove_version
+                    )
+                );
+            }
+            // `underlying()` only unwraps one level; nested wrappers are
+            // forbidden by the constructor and (de)serializer, but the public
+            // insert path can still receive a hand-built nested wrapper —
+            // return a typed error rather than panic.
+            Element::NonCounted(_) | Element::NotSummed(_) | Element::NotCountedOrSummed(_) => {
+                return Err(Error::InvalidInput(
+                    "nested element wrappers are not allowed",
+                ))
+                .wrap_with_cost(cost);
+            }
+        }
+
+        Ok(subtree_to_insert_into).wrap_with_cost(cost)
+    }
+}

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -2,21 +2,17 @@
 
 use std::{collections::HashMap, option::Option::None};
 
-use grovedb_costs::{
-    cost_return_on_error, cost_return_on_error_into, cost_return_on_error_no_add, CostResult,
-    CostsExt, OperationCost,
-};
-use grovedb_element::reference_path::path_from_reference_path_type;
-use grovedb_merk::{
-    element::{costs::ElementCostExtensions, insert::ElementInsertToStorageExtensions, ElementExt},
-    tree::NULL_HASH,
-    Merk, MerkOptions,
-};
+use grovedb_costs::{cost_return_on_error, CostResult, CostsExt, OperationCost};
+use grovedb_merk::{Merk, MerkOptions};
 use grovedb_path::SubtreePath;
 use grovedb_storage::{rocksdb_storage::PrefixedRocksDbTransactionContext, Storage, StorageBatch};
 use grovedb_version::{check_grovedb_v0_with_cost, version::GroveVersion};
 
 use crate::{util::TxRef, Element, Error, GroveDb, Transaction, TransactionArg};
+
+/// Versioned dispatch for `add_element_on_transaction` (the non-batch insert
+/// path). Consensus-critical — see the module docs.
+mod add_element_on_transaction;
 
 #[derive(Clone)]
 /// Insert options
@@ -164,209 +160,6 @@ impl GroveDb {
         );
 
         Ok(()).wrap_with_cost(cost)
-    }
-
-    /// Add subtree to another subtree.
-    /// We want to add a new empty merk to another merk at a key
-    /// first make sure other merk exist
-    /// if it exists, then create merk to be inserted, and get root hash
-    /// we only care about root hash of merk to be inserted
-    fn add_element_on_transaction<'db, B: AsRef<[u8]>>(
-        &'db self,
-        path: SubtreePath<B>,
-        key: &[u8],
-        element: Element,
-        options: InsertOptions,
-        transaction: &'db Transaction,
-        batch: &'db StorageBatch,
-        grove_version: &GroveVersion,
-    ) -> CostResult<Merk<PrefixedRocksDbTransactionContext<'db>>, Error> {
-        check_grovedb_v0_with_cost!(
-            "add_element_on_transaction",
-            grove_version
-                .grovedb_versions
-                .operations
-                .insert
-                .add_element_on_transaction
-        );
-
-        let mut cost = OperationCost::default();
-
-        let mut subtree_to_insert_into = cost_return_on_error!(
-            &mut cost,
-            self.open_transactional_merk_at_path(
-                path.clone(),
-                transaction,
-                Some(batch),
-                grove_version
-            )
-        );
-        // if we don't allow a tree override then we should check
-
-        if options.checks_for_override() {
-            let maybe_element_bytes = cost_return_on_error!(
-                &mut cost,
-                subtree_to_insert_into
-                    .get(
-                        key,
-                        true,
-                        Some(&Element::value_defined_cost_for_serialized_value),
-                        grove_version,
-                    )
-                    .map_err(|e| Error::CorruptedData(e.to_string()))
-            );
-            if let Some(element_bytes) = maybe_element_bytes {
-                if options.validate_insertion_does_not_override {
-                    return Err(Error::OverrideNotAllowed(
-                        "insertion not allowed to override",
-                    ))
-                    .wrap_with_cost(cost);
-                }
-                if options.validate_insertion_does_not_override_tree {
-                    let element = cost_return_on_error_no_add!(
-                        cost,
-                        Element::deserialize(element_bytes.as_slice(), grove_version).map_err(
-                            |_| {
-                                Error::CorruptedData(String::from("unable to deserialize element"))
-                            }
-                        )
-                    );
-                    if element.is_any_tree() {
-                        return Err(Error::OverrideNotAllowed(
-                            "insertion not allowed to override tree",
-                        ))
-                        .wrap_with_cost(cost);
-                    }
-                }
-            }
-        }
-
-        // Dispatch via the underlying element so a NonCounted wrapper takes
-        // the same path as its inner element. The actual `element.insert*`
-        // calls operate on the outer wrapper, which is what we want — the
-        // serialized wrapper bytes go to storage.
-        match element.underlying() {
-            // `ReferenceWithSumItem` shares the reference resolution + proof
-            // shape with `Reference`. The merk feature_type derived from the
-            // element's `sum_value_or_default()` already routes the sum into
-            // any sum-bearing parent; the call site is otherwise identical.
-            Element::Reference(reference_path, ..)
-            | Element::ReferenceWithSumItem(reference_path, ..) => {
-                let path = path.to_vec(); // TODO: need for support for references in path library
-                let reference_path = cost_return_on_error_into!(
-                    &mut cost,
-                    path_from_reference_path_type(reference_path.clone(), &path, Some(key))
-                        .wrap_with_cost(OperationCost::default())
-                );
-
-                let referenced_item = cost_return_on_error!(
-                    &mut cost,
-                    self.follow_reference(
-                        reference_path.as_slice().into(),
-                        false,
-                        Some(transaction),
-                        grove_version
-                    )
-                );
-
-                let referenced_element_value_hash = cost_return_on_error_into!(
-                    &mut cost,
-                    referenced_item.value_hash(grove_version)
-                );
-
-                cost_return_on_error_into!(
-                    &mut cost,
-                    element.insert_reference(
-                        &mut subtree_to_insert_into,
-                        key,
-                        referenced_element_value_hash,
-                        Some(options.as_merk_options()),
-                        grove_version,
-                    )
-                );
-            }
-            Element::Tree(value, _)
-            | Element::SumTree(value, ..)
-            | Element::BigSumTree(value, ..)
-            | Element::CountTree(value, ..)
-            | Element::CountSumTree(value, ..)
-            | Element::ProvableCountTree(value, ..)
-            | Element::ProvableCountSumTree(value, ..)
-            | Element::ProvableSumTree(value, ..)
-            | Element::ProvableCountProvableSumTree(value, ..) => {
-                if value.is_some() {
-                    return Err(Error::InvalidCodeExecution(
-                        "a tree should be empty at the moment of insertion when not using batches",
-                    ))
-                    .wrap_with_cost(cost);
-                } else {
-                    cost_return_on_error_into!(
-                        &mut cost,
-                        element.insert_subtree(
-                            &mut subtree_to_insert_into,
-                            key,
-                            NULL_HASH,
-                            Some(options.as_merk_options()),
-                            grove_version
-                        )
-                    );
-                }
-            }
-            // CommitmentTree uses BulkAppendTree internally; the initial child
-            // hash must include the empty sinsemilla root so V1 proof
-            // verification works even before the first append.
-            Element::CommitmentTree(..) => {
-                cost_return_on_error_into!(
-                    &mut cost,
-                    element.insert_subtree(
-                        &mut subtree_to_insert_into,
-                        key,
-                        grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT,
-                        Some(options.as_merk_options()),
-                        grove_version
-                    )
-                );
-            }
-            // MmrTree, BulkAppendTree, DenseAppendOnlyFixedSizeTree: initial
-            // insert uses NULL_HASH since these trees start empty.
-            Element::MmrTree(..)
-            | Element::BulkAppendTree(..)
-            | Element::DenseAppendOnlyFixedSizeTree(..) => {
-                cost_return_on_error_into!(
-                    &mut cost,
-                    element.insert_subtree(
-                        &mut subtree_to_insert_into,
-                        key,
-                        NULL_HASH,
-                        Some(options.as_merk_options()),
-                        grove_version
-                    )
-                );
-            }
-            Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
-                cost_return_on_error_into!(
-                    &mut cost,
-                    element.insert(
-                        &mut subtree_to_insert_into,
-                        key,
-                        Some(options.as_merk_options()),
-                        grove_version
-                    )
-                );
-            }
-            // `underlying()` only unwraps one level; nested wrappers are
-            // forbidden by the constructor and (de)serializer, but the public
-            // insert path can still receive a hand-built nested wrapper —
-            // return a typed error rather than panic.
-            Element::NonCounted(_) | Element::NotSummed(_) | Element::NotCountedOrSummed(_) => {
-                return Err(Error::InvalidInput(
-                    "nested element wrappers are not allowed",
-                ))
-                .wrap_with_cost(cost);
-            }
-        }
-
-        Ok(subtree_to_insert_into).wrap_with_cost(cost)
     }
 
     /// Insert if not exists
@@ -541,6 +334,85 @@ mod tests {
         tests::{common::EMPTY_PATH, make_empty_grovedb, make_test_grovedb, TEST_LEAF},
         Element, Error,
     };
+
+    /// Consensus version gate for `add_element_on_transaction` (the non-batch
+    /// insert path). `CountSumTree` / `ProvableCountTree` / `ProvableCountSumTree`
+    /// are written via the plain-value path (`Op::Put`) under **v0**
+    /// (`GROVE_V1` / `GROVE_V2` — the behaviour frozen into the live protocol-v11
+    /// activation chain, testnet block 245,344) and as **layered subtrees**
+    /// under **v1** (`GROVE_V3`+, consistent with the batch insert path).
+    ///
+    /// The two ops compute a different parent `value_hash`
+    /// (`value_hash(serialized)` vs `combine_hash(value_hash(serialized),
+    /// NULL_HASH)`), hence a different grovedb root. This test pins both roots
+    /// and asserts they differ, so the dispatch cannot silently collapse to a
+    /// single behaviour — which would either break v11 replay (if v0 became
+    /// layered) or revert the v3 change (if v1 became `Op::Put`).
+    ///
+    /// `empty_sum_tree` at `[56]` is the control: it is in the layered arm in
+    /// both versions, so it never changed.
+    #[test]
+    fn add_element_on_transaction_version_gate_provable_count_sum_tree_root() {
+        use grovedb_version::version::v1::GROVE_V1;
+
+        // Replays the `transition_to_version_11` shape: an `empty_sum_tree`
+        // (control) then an `empty_provable_count_sum_tree` (the regressed op).
+        let root = |gv: &GroveVersion| {
+            let db = make_empty_grovedb();
+            db.insert(
+                EMPTY_PATH,
+                &[56u8],
+                Element::empty_sum_tree(),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("insert sum_tree at [56]");
+            db.insert(
+                [[56u8].as_slice()].as_ref(),
+                b"c",
+                Element::empty_provable_count_sum_tree(),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("insert provable_count_sum_tree at [56,'c']");
+            db.root_hash(None, gv).unwrap().unwrap()
+        };
+
+        let root_v0 = root(&GROVE_V1); // Op::Put — protocol-v11 consensus root
+        let root_v1 = root(GroveVersion::latest()); // GROVE_V3 — layered
+
+        eprintln!("root_v0 (Op::Put / protocol-v11) = {root_v0:?}");
+        eprintln!("root_v1 (layered / GROVE_V3)     = {root_v1:?}");
+
+        assert_ne!(
+            root_v0, root_v1,
+            "version gate must change the ProvableCountSumTree root: v0 (Op::Put) \
+             vs v1 (layered)"
+        );
+
+        // v0 golden — the `Op::Put` root. Identical to PR #757's pinned root
+        // (its `GOLDEN_2`), i.e. the grovedb v4.1.0 / protocol-v11 root that the
+        // live activation chain (testnet block 245,344) committed. Locking it
+        // here makes the GROVE_V1 / GROVE_V2 dispatch un-regressable.
+        const GOLDEN_V0: [u8; 32] = [
+            35, 99, 15, 178, 25, 57, 206, 47, 187, 195, 100, 28, 97, 85, 113, 230, 135, 22, 34,
+            126, 72, 125, 158, 90, 116, 94, 214, 136, 96, 195, 235, 46,
+        ];
+        // v1 golden — the layered root produced under GROVE_V3.
+        const GOLDEN_V1: [u8; 32] = [
+            210, 14, 74, 67, 205, 240, 43, 174, 50, 154, 162, 90, 237, 45, 168, 42, 64, 155, 78,
+            123, 102, 237, 213, 101, 63, 227, 24, 105, 16, 215, 194, 54,
+        ];
+        assert_eq!(
+            root_v0, GOLDEN_V0,
+            "v0 root drifted — the protocol-v11 (Op::Put) consensus root MUST NOT change"
+        );
+        assert_eq!(root_v1, GOLDEN_V1, "v1 (layered / GROVE_V3) root drifted");
+    }
 
     #[test]
     fn test_non_root_insert_item_without_transaction() {

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -414,6 +414,150 @@ mod tests {
         assert_eq!(root_v1, GOLDEN_V1, "v1 (layered / GROVE_V3) root drifted");
     }
 
+    /// Drives every match arm of `add_element_on_transaction` through the
+    /// non-batch insert path for a given grove version: the layered-tree arm
+    /// (all tree types), the commitment-tree arm, the append-tree arm
+    /// (MMR / bulk-append / dense), the item arm, the reference arm, plus the
+    /// override guards and the empty-tree-only (`value.is_some()`) guard. Run
+    /// under both a v0 version (`GROVE_V1`) and a v1 version (`GROVE_V3`) so
+    /// both frozen snapshots (`v0.rs` / `v1.rs`) are exercised.
+    fn exercise_all_add_element_arms(gv: &GroveVersion) {
+        use crate::reference_path::ReferencePathType;
+
+        let db = make_empty_grovedb();
+        let ins = |key: &[u8], el: Element| {
+            db.insert(EMPTY_PATH, key, el, None, None, gv)
+                .unwrap()
+                .unwrap_or_else(|e| panic!("insert {}: {e:?}", String::from_utf8_lossy(key)));
+        };
+
+        // Layered-tree arm — every tree type round-trips on the non-batch path.
+        ins(b"tree", Element::empty_tree());
+        ins(b"sum", Element::empty_sum_tree());
+        ins(b"bigsum", Element::empty_big_sum_tree());
+        ins(b"count", Element::empty_count_tree());
+        ins(b"countsum", Element::empty_count_sum_tree());
+        ins(b"pcount", Element::empty_provable_count_tree());
+        ins(b"pcountsum", Element::empty_provable_count_sum_tree());
+        ins(b"psum", Element::empty_provable_sum_tree());
+        ins(b"pcps", Element::empty_provable_count_provable_sum_tree());
+
+        // Append-tree arm.
+        ins(b"mmr", Element::empty_mmr_tree());
+        ins(
+            b"bulk",
+            Element::empty_bulk_append_tree(10).expect("valid chunk_power"),
+        );
+        ins(b"dense", Element::empty_dense_tree(4));
+
+        // Commitment-tree arm (its own non-NULL initial child hash).
+        ins(
+            b"commit",
+            Element::empty_commitment_tree(10).expect("valid chunk_power"),
+        );
+
+        // Item arm.
+        ins(b"item", Element::new_item(b"v".to_vec()));
+        // Sum item must live in a sum-bearing tree.
+        db.insert(
+            [b"sum".as_slice()].as_ref(),
+            b"si",
+            Element::new_sum_item(7),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("sum_item into sum tree");
+
+        // Reference arm.
+        ins(
+            b"ref",
+            Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                b"item".to_vec()
+            ])),
+        );
+
+        // Override guard (tree): default options forbid overriding a tree.
+        let tree_override = db
+            .insert(EMPTY_PATH, b"tree", Element::empty_tree(), None, None, gv)
+            .unwrap();
+        assert!(
+            matches!(tree_override, Err(Error::OverrideNotAllowed(_))),
+            "overriding a tree must be rejected, got {tree_override:?}"
+        );
+
+        // Override guard (plain value): explicit option forbids any override.
+        let item_override = db
+            .insert(
+                EMPTY_PATH,
+                b"item",
+                Element::new_item(b"v2".to_vec()),
+                Some(InsertOptions {
+                    validate_insertion_does_not_override: true,
+                    validate_insertion_does_not_override_tree: true,
+                    base_root_storage_is_free: true,
+                }),
+                None,
+                gv,
+            )
+            .unwrap();
+        assert!(
+            matches!(item_override, Err(Error::OverrideNotAllowed(_))),
+            "overriding an item with validate_insertion_does_not_override must be rejected, got \
+             {item_override:?}"
+        );
+
+        // Empty-tree-only guard: a tree element carrying a root key is rejected
+        // on the non-batch path (trees must be empty at insertion time here).
+        let with_root_key = db
+            .insert(
+                EMPTY_PATH,
+                b"hasroot",
+                Element::Tree(Some(vec![1u8]), None),
+                None,
+                None,
+                gv,
+            )
+            .unwrap();
+        assert!(
+            matches!(with_root_key, Err(Error::InvalidCodeExecution(_))),
+            "a non-empty tree must be rejected on the non-batch insert path, got {with_root_key:?}"
+        );
+    }
+
+    /// Coverage for the v0 (`Op::Put`) snapshot — `GROVE_V1`.
+    #[test]
+    fn add_element_on_transaction_v0_covers_all_arms() {
+        use grovedb_version::version::v1::GROVE_V1;
+        exercise_all_add_element_arms(&GROVE_V1);
+    }
+
+    /// Coverage for the v1 (layered) snapshot — `GROVE_V3` (latest).
+    #[test]
+    fn add_element_on_transaction_v1_covers_all_arms() {
+        exercise_all_add_element_arms(GroveVersion::latest());
+    }
+
+    /// The dispatcher rejects an unknown `add_element_on_transaction` version
+    /// slot rather than silently picking a behaviour.
+    #[test]
+    fn add_element_on_transaction_rejects_unknown_version() {
+        let mut bad = GroveVersion::latest().clone();
+        bad.grovedb_versions
+            .operations
+            .insert
+            .add_element_on_transaction = 2;
+        let db = make_empty_grovedb();
+        let err = db
+            .insert(EMPTY_PATH, b"x", Element::empty_tree(), None, None, &bad)
+            .unwrap();
+        assert!(
+            matches!(err, Err(Error::VersionError(_))),
+            "unknown add_element_on_transaction version must error, got {err:?}"
+        );
+    }
+
     #[test]
     fn test_non_root_insert_item_without_transaction() {
         let grove_version = GroveVersion::latest();


### PR DESCRIPTION
## What

Splits the non-batch insert helper `GroveDb::add_element_on_transaction` into a **versioned dispatch** (Platform-style: dispatcher + frozen `v0`/`v1` snapshots, each in its own file under `grovedb/src/operations/insert/add_element_on_transaction/`):

| GroveVersion | `add_element_on_transaction` slot | behaviour for `CountSumTree` / `ProvableCountTree` / `ProvableCountSumTree` |
|---|---|---|
| `GROVE_V1`, `GROVE_V2` | `0` → **v0** | plain value (`Op::Put`) — matches grovedb v4.1.0 / the live protocol-v11 chain |
| `GROVE_V3` | `1` → **v1** | layered subtree (`Op::PutLayeredReference`) — current behaviour, consistent with the batch path |

Only `GROVE_V3`'s slot is bumped `0 → 1`; `v1`/`v2` stay `0`.

## Why — protocol-v11 consensus

`add_element_on_transaction` decides whether an element is written as a layered subtree (`Op::PutLayeredReference`) or a plain value (`Op::Put`). The two ops compute a different parent-node `value_hash`:

```
Op::Put                : value_hash = value_hash(serialized)
Op::PutLayeredReference: value_hash = combine_hash(value_hash(serialized), child_root_hash)
                                    = combine_hash(value_hash(serialized), NULL_HASH)   // empty tree
```

In grovedb **v4.1.0**, `CountSumTree` / `ProvableCountTree` / `ProvableCountSumTree` fell through `_ => element.insert()` → **`Op::Put`**. **#752** (subtree dump/restore primitives) broadened the tree arm to include them → **`Op::PutLayeredReference`**, changing the parent node hash and therefore the grovedb root.

These types are created on the **protocol-v11 activation** (`transition_to_version_11` inserts an `empty_provable_count_sum_tree` and an `empty_count_sum_tree` via this non-batch path — testnet block 245,344), so the broadened dispatch makes a v11 node compute a **different app-hash than the v4.1.0-era binaries that produced the canonical chain** — a consensus divergence on replay.

## Why versioned instead of an unconditional revert (cf. #757)

#757 reverts the three types to `Op::Put` for all versions. This PR instead **preserves both behaviours** and gates them, so:

- `GROVE_V1` / `GROVE_V2` replay the protocol-v11 chain correctly (`Op::Put`), and
- `GROVE_V3`+ keep the layered behaviour, which makes the **non-batch path agree with the batch path** on both root hash and fee (the batch path has always written these three types as layered, via `insert_subtree_into_batch_operations` + `LayeredValueDefinedCost`). That removes the long-standing batch/non-batch divergence going forward instead of freezing it.

`v0`/`v1` are full frozen snapshots; they differ **only** in which match arm those three element types fall into. `v0` is intentionally "current body with those three arms moved to `Op::Put`" rather than a literal v4.1.0 copy, so it still handles the newer element types (`ProvableSumTree`, `CommitmentTree`, the append-trees, `NonCounted` wrappers) that v4.1.0 predates, while reproducing the v4.1.0 consensus root exactly for every type that existed then.

## Test

`add_element_on_transaction_version_gate_provable_count_sum_tree_root` replays the `transition_to_version_11` shape (`empty_sum_tree` control at `[56]`, then `empty_provable_count_sum_tree` at `[56,'c']`) under both versions and pins both roots:

- **v0 root is byte-identical to PR #757's pinned protocol-v11 golden** — i.e. `GROVE_V1 → v0 → Op::Put` reproduces the exact canonical root.
- **v1 (layered, `GROVE_V3`) root differs**, and the gate is asserted to switch behaviour so it cannot silently collapse.

## Verification

- `cargo build -p grovedb` — clean, no warnings
- `cargo clippy -p grovedb --lib` — clean
- `cargo test -p grovedb --lib` — **1853 passed, 0 failed, 1 ignored**

## Reviewer notes

- `latest() = GROVE_V3 = v1 = layered`, which is today's behaviour, so all `latest()`-based tests are unaffected. The behaviour change is limited to `GROVE_V1` / `GROVE_V2`, which now correctly use `Op::Put` for these three types (the regressed layered behaviour was never on the canonical chain for those versions).
- The v12-only `ProvableSumTree` / `ProvableCountProvableSumTree` keep the layered behaviour in both v0 and v1 — they were never created via this path on the v11 chain.
- Branch is rebased on #758 (the `orchard` 0.14.0 pin) so it builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced versioning infrastructure for database insert operations with improved protocol-specific handling to ensure consistent behavior across all supported grove database versions.

* **Tests**
  * Added comprehensive regression tests validating version-specific protocol behaviors for insert operations, including consensus root hash verification to prevent regressions across grove versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->