### PR TITLE
feat(commitment-tree): re-export ProofSizeEnforcement + ActionFromPartsError

### DIFF
--- a/grovedb-commitment-tree/src/lib.rs
+++ b/grovedb-commitment-tree/src/lib.rs
@@ -106,6 +106,8 @@ pub use orchard::builder::{Builder, BundleType};
 pub use orchard::bundle::BatchValidator;
 // Bundle/Action types
 pub use orchard::bundle::{Authorized, Flags};
+// Bundle reconstruction: proof-size policy for `Bundle::try_from_parts`
+pub use orchard::bundle::ProofSizeEnforcement;
 // Proof creation/verification (requires orchard "circuit" feature)
 pub use orchard::circuit::{ProvingKey, VerifyingKey};
 // Key management
@@ -135,7 +137,8 @@ pub use orchard::{
     zcash_note_encryption::{
         try_compact_note_decryption, try_note_decryption, Domain, EphemeralKeyBytes, ShieldedOutput,
     },
-    Action, Address as PaymentAddress, Bundle, Note, Proof, NOTE_COMMITMENT_TREE_DEPTH,
+    Action, ActionFromPartsError, Address as PaymentAddress, Bundle, Note, Proof,
+    NOTE_COMMITMENT_TREE_DEPTH,
 };
 #[cfg(feature = "sqlite")]
 pub use rusqlite;


### PR DESCRIPTION
## What

Re-export two orchard symbols from `grovedb-commitment-tree` that were missed:

- `orchard::bundle::ProofSizeEnforcement`
- `orchard::ActionFromPartsError`

## Why

`grovedb-commitment-tree` already re-exports the full orchard verification API used by downstream consumers — `Action`, `Bundle`, `Authorized`, `Flags`, `BatchValidator`, `ExtractedNoteCommitment`, `Nullifier`, `TransmittedNoteCiphertext`, `VerifyingKey`, etc. — so consumers can reconstruct and verify Orchard bundles without depending on `orchard` directly.

Under orchard 0.14, reconstructing a `Bundle<Authorized>` from serialized parts requires two more symbols this crate doesn't yet re-export:

- `ProofSizeEnforcement` — the required argument of `Bundle::try_from_parts`, the only public constructor for `Bundle<Authorized>` (the old generic `Bundle::from_parts` is gone in 0.14).
- `ActionFromPartsError` — the error `Action::from_parts` now returns (was `Option` in 0.13), needed to distinguish the `IdentityRk` vs `InvalidEpk` rejection causes.

Without these, a consumer (Dash Platform's shielded-proof verifier in `rs-drive-abci`) has to add a *direct* `orchard` dependency just to name them, duplicating the dependency the commitment tree already owns. Re-exporting them lets the verifier go entirely through `grovedb-commitment-tree`.

## Change

Two `pub use` lines added next to the existing `orchard::bundle` / `orchard::{...}` re-exports. No behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended public API to re-export additional Orchard types: `ProofSizeEnforcement` and `ActionFromPartsError`, expanding available functionality for library users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->