### PR TITLE
feat(commitment-tree): re-export OrchardNoteEncryption + ValueCommitTrapdoor

### DIFF
--- a/grovedb-commitment-tree/src/lib.rs
+++ b/grovedb-commitment-tree/src/lib.rs
@@ -127,14 +127,17 @@ pub use orchard::note::TransmittedNoteCiphertext;
 // Orchard tree types
 pub use orchard::note::{ExtractedNoteCommitment, Nullifier};
 // Note encryption / trial decryption
-pub use orchard::note_encryption::{CompactAction, OrchardDomain};
+// `OrchardNoteEncryption` lets downstream crates construct real encrypted
+// Orchard outputs (e.g. for OVK-recovery round-trip tests) without taking a
+// direct dependency on the orchard fork.
+pub use orchard::note_encryption::{CompactAction, OrchardDomain, OrchardNoteEncryption};
 // Byte wrapper and trait for constructing note ciphertexts
 pub use orchard::zcash_note_encryption::note_bytes::{NoteBytes, NoteBytesData};
 pub use orchard::{
     note::Rho,
     primitives::redpallas,
     tree::{Anchor, MerkleHashOrchard, MerklePath},
-    value::{NoteValue, ValueCommitment},
+    value::{NoteValue, ValueCommitTrapdoor, ValueCommitment},
     zcash_note_encryption::{
         try_compact_note_decryption, try_note_decryption, Domain, EphemeralKeyBytes, ShieldedOutput,
     },


### PR DESCRIPTION
## Summary

Re-exports two more `orchard` types from `grovedb-commitment-tree` so that
downstream crates (Platform) don't need a separate **test-only direct
dependency** on the `dashpay/orchard` fork:

- `note_encryption::OrchardNoteEncryption`
- `value::ValueCommitTrapdoor`

`value::{ValueCommitment, NoteValue}` were already re-exported, so this just
completes the set needed to construct a real encrypted Orchard output (the
`OVK`-recovery round-trip test in Platform).

## Why

Platform currently carries a test-only direct dep matching the same git
tag / feature set so Cargo unifies onto a single `orchard` instance:

```toml
orchard = { git = "https://github.com/dashpay/orchard.git", tag = "dashified-0.14.0", features = ["circuit"] }
```

It needs `OrchardNoteEncryption` + `value::{ValueCommitment, ValueCommitTrapdoor, NoteValue}`
to build a real encrypted Orchard output — none of which were fully
re-exported. With this change Platform can drop that extra dependency and
import everything from `grovedb_commitment_tree`.

## Notes

- Purely additive `pub use` re-exports; no behavior change.
- Both `orchard::note_encryption` and `orchard::value` are `pub mod`s, and all
  re-exported items are public in the `dashified-0.14.0` fork.
- `cargo build -p grovedb-commitment-tree` passes (the crate has
  `#![deny(missing_docs)]`, so the build also confirms the re-exports don't
  trip the docs lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)