### PR TITLE
feat(commitment-tree): re-export try_output_recovery_with_ovk + OutgoingCipherKey

### DIFF
--- a/grovedb-commitment-tree/src/lib.rs
+++ b/grovedb-commitment-tree/src/lib.rs
@@ -138,10 +138,19 @@ pub use orchard::{
     primitives::redpallas,
     tree::{Anchor, MerkleHashOrchard, MerklePath},
     value::{NoteValue, ValueCommitTrapdoor, ValueCommitment},
+    // `try_output_recovery_with_ovk` (+ the `OutgoingCipherKey` it derives) lets the
+    // sender recover an outgoing note from an Orchard action using the outgoing viewing
+    // key, without a direct dependency on the orchard fork.
     zcash_note_encryption::{
-        try_compact_note_decryption, try_note_decryption, Domain, EphemeralKeyBytes, ShieldedOutput,
+        try_compact_note_decryption, try_note_decryption, try_output_recovery_with_ovk, Domain,
+        EphemeralKeyBytes, OutgoingCipherKey, ShieldedOutput,
     },
-    Action, ActionFromPartsError, Address as PaymentAddress, Bundle, Note, Proof,
+    Action,
+    ActionFromPartsError,
+    Address as PaymentAddress,
+    Bundle,
+    Note,
+    Proof,
     NOTE_COMMITMENT_TREE_DEPTH,
 };
 #[cfg(feature = "sqlite")]


### PR DESCRIPTION
## What

Re-export `try_output_recovery_with_ovk` and `OutgoingCipherKey` from `orchard::zcash_note_encryption` in `grovedb-commitment-tree`.

## Why

The rs-sdk's `try_recover_outgoing_note` recovers an outgoing Orchard note from an action using the **outgoing viewing key (OVK)**. That path needs `zcash_note_encryption::try_output_recovery_with_ovk` (and the `OutgoingCipherKey` it derives). Everything else its signature touches — `OrchardDomain`, `OutgoingViewingKey`, `ShieldedOutput`, `ValueCommitment` — is already re-exported here.

These two were the last orchard items the SDK pulled directly, forcing it to keep a **non-test** direct dependency on the dashpay orchard fork. Re-exporting them lets the SDK drop that dep and import everything from `grovedb-commitment-tree`, so Cargo unifies onto the single orchard instance.

This continues the re-export pattern from #760, #762.

## SDK follow-up (separate, not in this PR)

Once this lands and the pin is bumped, the SDK can switch its import to `grovedb_commitment_tree::{try_output_recovery_with_ovk, OutgoingCipherKey}` and remove the direct orchard dependency.

## Notes

- `grovedb-commitment-tree` builds cleanly (`cargo build -p grovedb-commitment-tree`).
- No behavior change — re-exports only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code organization and formatting of module exports.

**Note:** No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->