### PR TITLE
chore: bump workspace crate versions to 5.0.0

### DIFF
--- a/costs/Cargo.toml
+++ b/costs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-costs"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2024"
 license = "MIT"
 description = "Costs extension crate for GroveDB"

--- a/grovedb-bulk-append-tree/Cargo.toml
+++ b/grovedb-bulk-append-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-bulk-append-tree"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["Samuel Westrich <sam@dash.org>"]
 edition = "2024"
 license = "MIT"
@@ -20,11 +20,11 @@ storage = [
 mem_store = ["grovedb-merkle-mountain-range/mem_store"]
 
 [dependencies]
-grovedb-merkle-mountain-range = { version = "4.0.0", path = "../grovedb-merkle-mountain-range", default-features = false }
-grovedb-dense-fixed-sized-merkle-tree = { version = "4.0.0", path = "../grovedb-dense-fixed-sized-merkle-tree", default-features = false }
-grovedb-query = { version = "4.0.0", path = "../grovedb-query" }
-grovedb-costs = { version = "4.0.0", path = "../costs" }
-grovedb-storage = { version = "4.0.0", path = "../storage", optional = true }
+grovedb-merkle-mountain-range = { version = "5.0.0", path = "../grovedb-merkle-mountain-range", default-features = false }
+grovedb-dense-fixed-sized-merkle-tree = { version = "5.0.0", path = "../grovedb-dense-fixed-sized-merkle-tree", default-features = false }
+grovedb-query = { version = "5.0.0", path = "../grovedb-query" }
+grovedb-costs = { version = "5.0.0", path = "../costs" }
+grovedb-storage = { version = "5.0.0", path = "../storage", optional = true }
 blake3 = { workspace = true }
 bincode = { workspace = true, features = ["derive"] }
 hex = { workspace = true }

--- a/grovedb-commitment-tree/Cargo.toml
+++ b/grovedb-commitment-tree/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb-commitment-tree"
 description = "Orchard-style commitment tree integration for GroveDB"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["Samuel Westrich <sam@dash.org>"]
 edition = "2024"
 license = "MIT"
@@ -21,9 +21,9 @@ orchard = { git = "https://github.com/dashpay/orchard.git", tag = "dashified-0.1
 incrementalmerkletree = "0.8"
 shardtree = { version = "0.6", optional = true }
 rusqlite = { version = "0.38", features = ["bundled"], optional = true }
-grovedb-costs = { version = "4.0.0", path = "../costs" }
-grovedb-storage = { version = "4.0.0", path = "../storage", optional = true }
-grovedb-bulk-append-tree = { version = "4.0.0", path = "../grovedb-bulk-append-tree", default-features = false }
+grovedb-costs = { version = "5.0.0", path = "../costs" }
+grovedb-storage = { version = "5.0.0", path = "../storage", optional = true }
+grovedb-bulk-append-tree = { version = "5.0.0", path = "../grovedb-bulk-append-tree", default-features = false }
 blake3 = { workspace = true }
 thiserror = { workspace = true }
 
@@ -33,8 +33,8 @@ criterion = { workspace = true }
 rand = { workspace = true }
 rand_core = "0.6"
 # For the `seeding` benchmark: a real RocksDB-backed storage context.
-grovedb-storage = { version = "4.0.0", path = "../storage", features = ["rocksdb_storage"] }
-grovedb-path = { version = "4.0.0", path = "../path" }
+grovedb-storage = { version = "5.0.0", path = "../storage", features = ["rocksdb_storage"] }
+grovedb-path = { version = "5.0.0", path = "../path" }
 
 [[bench]]
 name = "verification"

--- a/grovedb-dense-fixed-sized-merkle-tree/Cargo.toml
+++ b/grovedb-dense-fixed-sized-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-dense-fixed-sized-merkle-tree"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["Samuel Westrich <sam@dash.org>"]
 edition = "2024"
 license = "MIT"
@@ -16,6 +16,6 @@ storage = ["grovedb-storage"]
 blake3 = { workspace = true }
 bincode = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-grovedb-costs = { version = "4.0.0", path = "../costs" }
-grovedb-query = { version = "4.0.0", path = "../grovedb-query" }
-grovedb-storage = { version = "4.0.0", path = "../storage", optional = true }
+grovedb-costs = { version = "5.0.0", path = "../costs" }
+grovedb-query = { version = "5.0.0", path = "../grovedb-query" }
+grovedb-storage = { version = "5.0.0", path = "../storage", optional = true }

--- a/grovedb-element/Cargo.toml
+++ b/grovedb-element/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb-element"
 description = "The storage element crate for grovedb"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["Samuel Westrich <sam@dash.org>"]
 edition = "2024"
 license = "MIT"
@@ -17,9 +17,9 @@ serde = { workspace = true, optional = true }
 hex = { workspace = true }
 integer-encoding = { workspace = true }
 thiserror = { workspace = true }
-grovedb-version = { version = "4.0.0", path = "../grovedb-version" }
-grovedb-visualize = { version = "4.0.0", path = "../visualize", optional = true }
-grovedb-path = { version = "4.0.0", path = "../path" }
+grovedb-version = { version = "5.0.0", path = "../grovedb-version" }
+grovedb-visualize = { version = "5.0.0", path = "../visualize", optional = true }
+grovedb-path = { version = "5.0.0", path = "../path" }
 
 [features]
 default = ["verify", "constructor"]

--- a/grovedb-epoch-based-storage-flags/Cargo.toml
+++ b/grovedb-epoch-based-storage-flags/Cargo.toml
@@ -2,13 +2,13 @@
 name = "grovedb-epoch-based-storage-flags"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Epoch based storage flags for GroveDB"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/dashpay/grovedb"
 
 [dependencies]
-grovedb-costs = { version = "4.0.0", path = "../costs" }
+grovedb-costs = { version = "5.0.0", path = "../costs" }
 
 hex = { workspace = true }
 integer-encoding = { workspace = true }

--- a/grovedb-merkle-mountain-range/Cargo.toml
+++ b/grovedb-merkle-mountain-range/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-merkle-mountain-range"
-version = "4.0.0"
+version = "5.0.0"
 authors = [
     "Samuel Westrich <sam@dash.org>",
     "Nervos Core Dev <dev@nervos.org>",
@@ -20,8 +20,8 @@ mem_store = []
 [dependencies]
 blake3 = { workspace = true }
 bincode = { workspace = true, features = ["derive"] }
-grovedb-costs = { version = "4.0.0", path = "../costs" }
-grovedb-storage = { version = "4.0.0", path = "../storage", optional = true }
+grovedb-costs = { version = "5.0.0", path = "../costs" }
+grovedb-storage = { version = "5.0.0", path = "../storage", optional = true }
 
 [dev-dependencies]
 faster-hex = "0.10.0"

--- a/grovedb-query/Cargo.toml
+++ b/grovedb-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-query"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2024"
 license = "MIT"
 description = "Query primitives for GroveDB"
@@ -19,8 +19,8 @@ byteorder = { workspace = true }
 integer-encoding = { workspace = true }
 
 # Feature-gated deps for merk integration
-grovedb-costs = { version = "4.0.0", path = "../costs", optional = true }
-grovedb-storage = { version = "4.0.0", path = "../storage", optional = true }
+grovedb-costs = { version = "5.0.0", path = "../costs", optional = true }
+grovedb-storage = { version = "5.0.0", path = "../storage", optional = true }
 
 
 

--- a/grovedb-version/Cargo.toml
+++ b/grovedb-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "grovedb-version"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Versioning library for Platform"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/dashpay/grovedb"

--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb"
 description = "Fully featured database using balanced hierarchical authenticated data structures"
-version = "4.0.0"
+version = "5.0.0"
 authors = [
     "Samuel Westrich <sam@dash.org>",
     "Wisdom Ogwu <wisdom@dash.org>",
@@ -15,19 +15,19 @@ readme = "../README.md"
 documentation = "https://docs.rs/grovedb"
 
 [dependencies]
-grovedb-costs = { version = "4.0.0", path = "../costs", optional = true }
-grovedbg-types = { version = "4.0.0", path = "../grovedbg-types", optional = true }
-grovedb-merk = { version = "4.0.0", path = "../merk", optional = true, default-features = false }
-grovedb-path = { version = "4.0.0", path = "../path" }
-grovedb-storage = { version = "4.0.0", path = "../storage", optional = true }
-grovedb-version = { version = "4.0.0", path = "../grovedb-version" }
-grovedb-visualize = { version = "4.0.0", path = "../visualize", optional = true }
-grovedb-element = { version = "4.0.0", path = "../grovedb-element" }
-grovedb-commitment-tree = { version = "4.0.0", path = "../grovedb-commitment-tree", optional = true }
-grovedb-merkle-mountain-range = { version = "4.0.0", path = "../grovedb-merkle-mountain-range", optional = true, default-features = false }
-grovedb-bulk-append-tree = { version = "4.0.0", path = "../grovedb-bulk-append-tree", optional = true, default-features = false }
-grovedb-dense-fixed-sized-merkle-tree = { version = "4.0.0", path = "../grovedb-dense-fixed-sized-merkle-tree", optional = true, default-features = false }
-grovedb-query = { version = "4.0.0", path = "../grovedb-query" }
+grovedb-costs = { version = "5.0.0", path = "../costs", optional = true }
+grovedbg-types = { version = "5.0.0", path = "../grovedbg-types", optional = true }
+grovedb-merk = { version = "5.0.0", path = "../merk", optional = true, default-features = false }
+grovedb-path = { version = "5.0.0", path = "../path" }
+grovedb-storage = { version = "5.0.0", path = "../storage", optional = true }
+grovedb-version = { version = "5.0.0", path = "../grovedb-version" }
+grovedb-visualize = { version = "5.0.0", path = "../visualize", optional = true }
+grovedb-element = { version = "5.0.0", path = "../grovedb-element" }
+grovedb-commitment-tree = { version = "5.0.0", path = "../grovedb-commitment-tree", optional = true }
+grovedb-merkle-mountain-range = { version = "5.0.0", path = "../grovedb-merkle-mountain-range", optional = true, default-features = false }
+grovedb-bulk-append-tree = { version = "5.0.0", path = "../grovedb-bulk-append-tree", optional = true, default-features = false }
+grovedb-dense-fixed-sized-merkle-tree = { version = "5.0.0", path = "../grovedb-dense-fixed-sized-merkle-tree", optional = true, default-features = false }
+grovedb-query = { version = "5.0.0", path = "../grovedb-query" }
 
 axum = { workspace = true, optional = true }
 bincode = { workspace = true }
@@ -50,7 +50,7 @@ zip-extensions = { version = "0.13.0", optional = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-grovedb-epoch-based-storage-flags = { version = "4.0.0", path = "../grovedb-epoch-based-storage-flags" }
+grovedb-epoch-based-storage-flags = { version = "5.0.0", path = "../grovedb-epoch-based-storage-flags" }
 
 criterion = { workspace = true }
 hex = { workspace = true }

--- a/grovedbg-types/Cargo.toml
+++ b/grovedbg-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedbg-types"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2024"
 description = "Common type definitions for data exchange over GroveDBG protocol"
 authors = ["Evgeny Fomin <evgeny.fomin@dash.org>"]

--- a/merk/Cargo.toml
+++ b/merk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb-merk"
 description = "Merkle key/value store adapted for GroveDB"
-version = "4.0.0"
+version = "5.0.0"
 authors = [
         "Samuel Westrich <sam@dash.org>",
         "Wisdom Ogwu <wisdom@dash.org>",
@@ -16,13 +16,13 @@ readme = "README.md"
 documentation = "https://docs.rs/grovedb-merk"
 
 [dependencies]
-grovedb-costs = { version = "4.0.0", path = "../costs" }
-grovedb-path = { version = "4.0.0", path = "../path" }
-grovedb-storage = { version = "4.0.0", path = "../storage", optional = true }
-grovedb-version = { version = "4.0.0", path = "../grovedb-version" }
-grovedb-visualize = { version = "4.0.0", path = "../visualize" }
-grovedb-element = { version = "4.0.0", path = "../grovedb-element" }
-grovedb-query = { version = "4.0.0", path = "../grovedb-query" }
+grovedb-costs = { version = "5.0.0", path = "../costs" }
+grovedb-path = { version = "5.0.0", path = "../path" }
+grovedb-storage = { version = "5.0.0", path = "../storage", optional = true }
+grovedb-version = { version = "5.0.0", path = "../grovedb-version" }
+grovedb-visualize = { version = "5.0.0", path = "../visualize" }
+grovedb-element = { version = "5.0.0", path = "../grovedb-element" }
+grovedb-query = { version = "5.0.0", path = "../grovedb-query" }
 
 bincode = { workspace = true }
 bincode_derive = { workspace = true }

--- a/path/Cargo.toml
+++ b/path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-path"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2024"
 license = "MIT"
 description = "Path extension crate for GroveDB"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-storage"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2024"
 license = "MIT"
 description = "Storage extension crate for GroveDB"
@@ -9,9 +9,9 @@ documentation = "https://docs.rs/grovedb-storage"
 repository = "https://github.com/dashpay/grovedb"
 
 [dependencies]
-grovedb-costs = { version = "4.0.0", path = "../costs" }
-grovedb-path = { version = "4.0.0", path = "../path" }
-grovedb-visualize = { version = "4.0.0", path = "../visualize" }
+grovedb-costs = { version = "5.0.0", path = "../costs" }
+grovedb-path = { version = "5.0.0", path = "../path" }
+grovedb-visualize = { version = "5.0.0", path = "../visualize" }
 
 blake3 = { workspace = true, optional = true }
 hex = { workspace = true }

--- a/visualize/Cargo.toml
+++ b/visualize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-visualize"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2024"
 license = "MIT"
 description = "Debug prints extension crate for GroveDB"


### PR DESCRIPTION
Bumps all workspace crates from 4.0.0 to 5.0.0, including all intra-workspace dependency version requirements.

- All 15 publishable crates updated (grovedb, merk, storage, costs, path, visualize, grovedb-version, grovedb-element, grovedb-query, grovedbg-types, grovedb-epoch-based-storage-flags, grovedb-merkle-mountain-range, grovedb-dense-fixed-sized-merkle-tree, grovedb-bulk-append-tree, grovedb-commitment-tree)
- `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 5.0.0 with coordinated package updates across all internal modules to maintain consistency and dependency alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->