### PR TITLE
perf: gate grovedbg build deps behind grovedbg feature

### DIFF
--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -113,6 +113,9 @@ verify = [
 estimated_costs = ["full"]
 zk_client = ["grovedb-commitment-tree", "grovedb-commitment-tree/client"]
 grovedbg = [
+    "dep:hex-literal",
+    "dep:reqwest",
+    "dep:sha2",
     "grovedbg-types",
     "tokio",
     "tokio-util",
@@ -136,6 +139,6 @@ grovedbg = [
 unsafe-dump-load = ["grovedb-storage/unsafe-dump-load"]
 
 [build-dependencies]
-hex-literal = "1.1.0"
-reqwest = { version = "0.13", features = ["blocking"] }
-sha2 = "0.10.8"
+hex-literal = { version = "1.1.0", optional = true }
+reqwest = { version = "0.13", features = ["blocking"], optional = true }
+sha2 = { version = "0.10.8", optional = true }


### PR DESCRIPTION
While profiling platform build times I noticed that some dependencies from this crate where stalling the entire pipeline. With this change the grovedb repo compile time in debug mode goes from 2m30s to 1m30s, something similar should happen for release build. In platform the speedup is similar. This also removes 7 dependencies from the compile pipeline in this repo


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build dependencies by making three packages optional, ensuring they are only included when the `grovedbg` feature is explicitly enabled, reducing unnecessary package overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->