### PR TITLE
fix(commitment-tree): iterate checkpoints in ascending order in SqliteShardStore

### DIFF
--- a/grovedb-commitment-tree/src/client/sqlite_client_tests.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_client_tests.rs
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_witness_survives_checkpoint_pruning() {
-        // Regression test: sql_list_checkpoints used to iterate DESC, which
+        // Regression test: checkpoint listing used to iterate DESC, which
         // violates the ShardStore contract (ascending checkpoint ID order).
         // shardtree's prune_excess_checkpoints assumes oldest-first, so the
         // wrong order made it delete the newest checkpoints and clear the

--- a/grovedb-commitment-tree/src/client/sqlite_client_tests.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_client_tests.rs
@@ -6,7 +6,9 @@ mod tests {
     use orchard::tree::Anchor;
     use rusqlite::Connection;
 
-    use crate::{test_utils::test_leaf, ClientPersistentCommitmentTree};
+    use crate::{
+        test_utils::test_leaf, ClientMemoryCommitmentTree, ClientPersistentCommitmentTree,
+    };
 
     fn memory_tree() -> ClientPersistentCommitmentTree {
         let conn = Connection::open_in_memory().expect("open in-memory sqlite");
@@ -181,6 +183,66 @@ mod tests {
         assert!(
             msg.contains("invalid Pallas field element"),
             "error should mention field element: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_witness_survives_checkpoint_pruning() {
+        // Regression test: sql_list_checkpoints used to iterate DESC, which
+        // violates the ShardStore contract (ascending checkpoint ID order).
+        // shardtree's prune_excess_checkpoints assumes oldest-first, so the
+        // wrong order made it delete the newest checkpoints and clear the
+        // retention flags on leaves that surviving checkpoints still need,
+        // destroying witness data once max_checkpoints was exceeded. Drive
+        // both stores through enough checkpoints to force pruning and assert
+        // they stay in lockstep.
+        const MAX_CHECKPOINTS: usize = 2;
+
+        let conn = Connection::open_in_memory().expect("open in-memory sqlite");
+        let mut sqlite_tree =
+            ClientPersistentCommitmentTree::open(conn, MAX_CHECKPOINTS).expect("open sqlite tree");
+        let mut memory_tree = ClientMemoryCommitmentTree::new(MAX_CHECKPOINTS);
+
+        // A marked note early in the tree, whose witness must survive.
+        sqlite_tree
+            .append(test_leaf(0), Retention::Marked)
+            .expect("append marked");
+        memory_tree
+            .append(test_leaf(0), Retention::Marked)
+            .expect("append marked");
+
+        // Enough checkpoints to trigger pruning several times over.
+        for i in 1..=6u32 {
+            sqlite_tree
+                .append(test_leaf(i as u64), Retention::Ephemeral)
+                .expect("append");
+            memory_tree
+                .append(test_leaf(i as u64), Retention::Ephemeral)
+                .expect("append");
+            assert!(sqlite_tree.checkpoint(i).expect("sqlite checkpoint"));
+            assert!(memory_tree.checkpoint(i).expect("memory checkpoint"));
+        }
+
+        assert_eq!(
+            sqlite_tree.anchor().expect("sqlite anchor"),
+            memory_tree.anchor().expect("memory anchor"),
+            "anchors should match after pruning"
+        );
+
+        let sqlite_witness = sqlite_tree
+            .witness(Position::from(0), 0)
+            .expect("sqlite witness")
+            .expect("sqlite witness should exist for marked leaf after pruning");
+        let memory_witness = memory_tree
+            .witness(Position::from(0), 0)
+            .expect("memory witness")
+            .expect("memory witness should exist for marked leaf after pruning");
+
+        assert_eq!(sqlite_witness.position(), memory_witness.position());
+        assert_eq!(
+            sqlite_witness.auth_path(),
+            memory_witness.auth_path(),
+            "witness auth paths should match after pruning"
         );
     }
 

--- a/grovedb-commitment-tree/src/client/sqlite_store/mod.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_store/mod.rs
@@ -215,7 +215,7 @@ impl ShardStore for SqliteShardStore {
     where
         F: FnMut(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>,
     {
-        let entries = self.with_conn(|conn| sql_list_checkpoints(conn, limit))?;
+        let entries = self.with_conn(|conn| sql_list_checkpoints_ascending(conn, limit))?;
         for (id, checkpoint) in &entries {
             callback(id, checkpoint)?;
         }
@@ -226,7 +226,7 @@ impl ShardStore for SqliteShardStore {
     where
         F: FnMut(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>,
     {
-        let entries = self.with_conn(|conn| sql_list_checkpoints(conn, limit))?;
+        let entries = self.with_conn(|conn| sql_list_checkpoints_ascending(conn, limit))?;
         for (id, checkpoint) in &entries {
             callback(id, checkpoint)?;
         }

--- a/grovedb-commitment-tree/src/client/sqlite_store/sql_helpers.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_store/sql_helpers.rs
@@ -274,9 +274,15 @@ pub(crate) fn sql_list_checkpoints(
     conn: &Connection,
     limit: usize,
 ) -> Result<Vec<(u32, Checkpoint)>, SqliteShardStoreError> {
+    // Ascending order is required: the `ShardStore::with_checkpoints` /
+    // `for_each_checkpoint` contract iterates in checkpoint ID order
+    // (oldest first), and shardtree's checkpoint pruning relies on it to
+    // decide which checkpoints to delete and which leaf retention flags to
+    // preserve. (`sql_get_checkpoint_at_depth` is the opposite: depth 0 is
+    // the most recent checkpoint, so it orders DESC.)
     let mut stmt = conn.prepare(
         "SELECT checkpoint_id, position FROM commitment_tree_checkpoints ORDER BY checkpoint_id \
-         DESC LIMIT ?1",
+         ASC LIMIT ?1",
     )?;
     let rows: Vec<(u32, Option<i64>)> = stmt
         .query_map(params![limit as i64], |row| Ok((row.get(0)?, row.get(1)?)))?

--- a/grovedb-commitment-tree/src/client/sqlite_store/sql_helpers.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_store/sql_helpers.rs
@@ -270,16 +270,19 @@ pub(crate) fn sql_get_checkpoint(
     }
 }
 
-pub(crate) fn sql_list_checkpoints(
+/// Lists the first `limit` checkpoints in ascending checkpoint ID order
+/// (oldest first).
+///
+/// The order is load-bearing and encoded in the name: the
+/// `ShardStore::with_checkpoints` / `for_each_checkpoint` contract requires
+/// iteration in checkpoint ID order, and shardtree's checkpoint pruning
+/// relies on oldest-first to decide which checkpoints to delete and which
+/// leaf retention flags to preserve. (`sql_get_checkpoint_at_depth` is the
+/// opposite — depth 0 is the most recent checkpoint, so it orders DESC.)
+pub(crate) fn sql_list_checkpoints_ascending(
     conn: &Connection,
     limit: usize,
 ) -> Result<Vec<(u32, Checkpoint)>, SqliteShardStoreError> {
-    // Ascending order is required: the `ShardStore::with_checkpoints` /
-    // `for_each_checkpoint` contract iterates in checkpoint ID order
-    // (oldest first), and shardtree's checkpoint pruning relies on it to
-    // decide which checkpoints to delete and which leaf retention flags to
-    // preserve. (`sql_get_checkpoint_at_depth` is the opposite: depth 0 is
-    // the most recent checkpoint, so it orders DESC.)
     let mut stmt = conn.prepare(
         "SELECT checkpoint_id, position FROM commitment_tree_checkpoints ORDER BY checkpoint_id \
          ASC LIMIT ?1",

--- a/grovedb-commitment-tree/src/client/sqlite_store_tests.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_store_tests.rs
@@ -435,6 +435,9 @@ mod tests {
                 .expect("add");
         }
 
+        // The ShardStore contract requires iteration in ascending checkpoint
+        // ID order (oldest first); shardtree's checkpoint pruning depends on
+        // it.
         let mut ids = Vec::new();
         store
             .for_each_checkpoint(3, |id, _| {
@@ -442,7 +445,7 @@ mod tests {
                 Ok(())
             })
             .expect("for_each");
-        assert_eq!(ids, vec![5, 4, 3]);
+        assert_eq!(ids, vec![1, 2, 3]);
     }
 
     #[test]
@@ -454,6 +457,8 @@ mod tests {
                 .expect("add");
         }
 
+        // Ascending checkpoint ID order, same contract as
+        // `for_each_checkpoint`.
         let mut ids = Vec::new();
         store
             .with_checkpoints(2, |id, _| {
@@ -461,7 +466,7 @@ mod tests {
                 Ok(())
             })
             .expect("with_checkpoints");
-        assert_eq!(ids, vec![5, 4]);
+        assert_eq!(ids, vec![1, 2]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`sql_list_checkpoints` ordered checkpoints `DESC`, but the shardtree `ShardStore` contract requires `with_checkpoints` / `for_each_checkpoint` to iterate **in checkpoint ID order** (oldest first), as the reference `MemoryShardStore` does via its `BTreeMap`.

This matters because shardtree's `prune_excess_checkpoints` runs on every `checkpoint()` call once `max_checkpoints` is exceeded, and its algorithm assumes oldest-first iteration: the first `remove_count` checkpoints it sees are deleted, and the later (retained) ones rescue the `CHECKPOINT`/`MARKED` leaf retention flags that must survive. Fed newest-first, it:

1. deleted the **newest** checkpoints instead of the oldest, and
2. ran the flag-preservation logic backwards, clearing retention flags on leaves that surviving checkpoints still referenced.

The result is permanent loss of Merkle nodes needed for spend-witness generation in `ClientPersistentCommitmentTree` (SQLite-backed wallets). Client-only: the server-side frontier/anchor path has no checkpoints, and the in-memory client tree was unaffected. No soundness impact — a witness from a corrupted tree fails anchor verification; the impact is availability (wallet must rescan to rebuild its tree).

The existing tests never triggered pruning (`max_checkpoints = 100`, ≤2 checkpoints added) and two store-level assertions codified the descending order.

## Fix

- `sql_list_checkpoints` now orders `ASC`, with a comment explaining the contract. `sql_get_checkpoint_at_depth` intentionally keeps `DESC` — depth 0 = most recent checkpoint is correct there.
- Updated the two store-level test assertions to expect ascending order.
- Added `test_witness_survives_checkpoint_pruning`: drives SQLite and memory trees in lockstep with `max_checkpoints = 2` through 6 checkpoints (forcing several pruning rounds), then asserts the SQLite tree still produces a witness for an early marked leaf, byte-identical (position + auth path) to the memory tree's, with matching anchors. Verified this test fails against the previous `DESC` ordering.

## Testing

- Full `grovedb-commitment-tree` suite with `--features server,client,sqlite`: 111 passed, 0 failed.
- Regression test confirmed red on the old ordering, green on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkpoint iteration to return entries in the expected oldest-first order.
  * Improved pruning behavior so witnesses for earlier marked leaves remain available after checkpoints are cleaned up.
  * Aligned checkpoint-related behavior across storage backends, helping results stay consistent between persistent and in-memory modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->