### PR TITLE
chore(commitment-tree): bump orchard to dashified-0.14.1

### DIFF
--- a/grovedb-commitment-tree/Cargo.toml
+++ b/grovedb-commitment-tree/Cargo.toml
@@ -17,7 +17,7 @@ client = ["shardtree"]
 sqlite = ["client", "rusqlite"]
 
 [dependencies]
-orchard = { git = "https://github.com/dashpay/orchard.git", tag = "dashified-0.14.0", features = ["circuit"] }
+orchard = { git = "https://github.com/dashpay/orchard.git", tag = "dashified-0.14.1", features = ["circuit"] }
 incrementalmerkletree = "0.8"
 shardtree = { version = "0.6", optional = true }
 rusqlite = { version = "0.38", features = ["bundled"], optional = true }


### PR DESCRIPTION
## What

Updates the `orchard` git dependency in `grovedb-commitment-tree` from the `dashified-0.14.0` tag to the new **`dashified-0.14.1`** tag (`38ac9c19a2df7bf3eeadc22ab23053e8fd538828`).

The `dashified-0.14.1` tag was created on the head of dashpay/orchard's `dashified` branch so this bump can be pinned by a named release rather than a raw revision.

## Why it's safe

`dashified-0.14.1` (`38ac9c19`) is a **descendant** of the `dashified-0.14.0` tag commit (`f055573`), verified with `git merge-base --is-ancestor`, so it retains the 0.14.0 circuit soundness fix that #758 migrated to — this moves forward, not sideways. The orchard crate version stays `0.14.0` internally (the tag name is just the dashified release marker). The five commits between the tags are non-breaking:

- `fix:` make PCZT trial decryption generic over `MemoSize`
- `feat:` enforce `MemoSize` invariants at compile time + `DashMemo` coverage
- `perf:` build note plaintexts in a stack buffer instead of a heap `Vec`
- `cleanup:` single source of truth for the AEAD tag size in the txid hasher
- `cleanup:` extract the compact ciphertext prefix in one place

`Cargo.lock` is gitignored in this repo, so the `tag` in `Cargo.toml` is the source of truth; it resolves to `38ac9c19`.

## Testing

- `cargo build -p grovedb-commitment-tree --features server,client,sqlite` — clean against the tag.
- Commitment-tree crate suite (all features): **110 passed, 0 failed** (2 ignored).
- `grovedb` commitment-tree integration tests: **50 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->