### PR TITLE
docs: record adversarially-rejected audit findings (audit-non-issues.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,15 @@ cost_return_on_error!(&mut cost, result);
 4. **Input Validation**: Validate all paths and keys before operations
 5. **Transaction Safety**: Use transactions for multi-step operations
 
+### Auditing This Codebase
+
+Before filing any security or correctness finding, read
+`docs/audit-non-issues.md`. It records findings that were adversarially
+verified and rejected (unreachable arithmetic overflows, by-design behavior,
+verified-unreachable proof/encoding claims) together with the invariant that
+makes each safe. Do not re-file an entry from that list unless you can show
+its "becomes real if" condition now holds.
+
 ## Workspace Structure
 
 ```

--- a/docs/audit-non-issues.md
+++ b/docs/audit-non-issues.md
@@ -1,0 +1,82 @@
+# Audit non-issues: verified unreachable or by-design
+
+This file records findings that security audits have raised (or are likely to
+raise) against GroveDB and that were **adversarially verified and rejected**.
+If you are running an audit — human or automated — check this list before
+filing. Re-filing one of these without new information wastes a triage cycle.
+
+Each entry states the claim, why it is not a real issue, and what would have
+to change for it to become one. If the "becomes real if" condition holds,
+file away — that is a new finding, not a re-report.
+
+## How to use this file in an audit
+
+1. Match your candidate finding against the entries below (grep for the
+   function or file name).
+2. If it matches and the "becomes real if" condition does not hold, drop it.
+3. If you believe the invariant that makes it safe has been broken, file the
+   issue and cite this file — say explicitly which invariant no longer holds.
+
+---
+
+## Unreachable arithmetic overflow (magnitude class)
+
+The recurring pattern: an audit finds unchecked `u32`/`u64` arithmetic on
+byte counts or element counts and reports wraparound. These are not reachable
+because the inputs are derived from **real stored bytes or hash-committed
+counts**, both of which are capped far below the wrap point:
+
+- Key lengths are capped at 255 bytes by every public insert path (direct and
+  batch) — enforced since PR #506.
+- Value/element sizes are capped orders of magnitude below 4 GiB by platform
+  state-transition and document size limits.
+- Tree element counts are accumulated one append at a time and committed into
+  hash-verified `Element` bytes; a verifier reads the count from bytes that
+  are checked against the trusted root **before** any arithmetic runs, so a
+  forged count is rejected as a bad proof, not fed into the math.
+
+Verified-and-rejected instances:
+
+| Issue | Claim | Why unreachable |
+|---|---|---|
+| [#684](https://github.com/dashpay/grovedb/issues/684) (closed) | Unchecked size arithmetic undercounts storage costs | Overflow needs a single ~4 GiB length; cannot exist under key/value caps. Costs are bit-identical for every input that can occur. |
+| [#715](https://github.com/dashpay/grovedb/issues/715) (closed) | `StorageCost::verify` passes after u32 wrap | Same: `added_bytes + replaced_bytes` ≈ 4 GiB required; inputs are real serialized lengths, not attacker-supplied. |
+| [#716](https://github.com/dashpay/grovedb/issues/716) (closed) | Sectioned removal totals wrap u32 | Same: one element's removals would have to exceed 4 GiB of actually-stored bytes. |
+| [#693](https://github.com/dashpay/grovedb/issues/693) (closed) | Bulk-append `2 * leaf_count` overflows near 2^63 | Append side: 2^63 real appends is physically impossible. Verify side: `total_count` comes from hash-verified `Element::BulkAppendTree(count, ...)` bytes — a forged count breaks the parent hash before the arithmetic runs. |
+
+**Becomes real if:** a code path feeds these computations an integer that is
+neither derived from actually-stored bytes nor hash-verified before use
+(e.g. a length decoded from an untrusted proof or network message and used
+in arithmetic before verification).
+
+## Capacity-boundary behavior on impossible tree sizes
+
+| Issue | Claim | Why not real |
+|---|---|---|
+| [#694](https://github.com/dashpay/grovedb/issues/694) (closed) | `CommitmentTree::append_raw` mutates bulk storage before `TreeFull` is returned | (1) `TreeFull` fires at 2^32 leaves — 4.3 billion commitments in one tree. (2) Even at the boundary, the bulk write goes into the op's storage batch, which is committed only if the op succeeds; on error the transaction discards the batch. Rollback is the default, not the caller's job. |
+
+**Becomes real if:** commitment-tree appends stop going through the
+transactional storage-batch flow, or a caller commits a batch after
+observing an append error.
+
+## By-design behavior reported as bugs
+
+| Issue | Claim | Design rationale |
+|---|---|---|
+| [#697](https://github.com/dashpay/grovedb/issues/697) (closed) | Replication reads are not snapshot-isolated | Replication is designed to serve snapshots **from a checkpoint**, not from a live DB. Snapshot isolation is delegated to checkpointing on purpose. Pre-ship state-sync robustness work is tracked in #679/#695/#704/#706. |
+| [#699](https://github.com/dashpay/grovedb/issues/699) (closed) | Checkpoints copy unbounded WALs (`u64::MAX` flush threshold) | Deliberate fast-checkpoint tradeoff: bounded checkpoint latency in exchange for larger checkpoint dirs and WAL replay on open. No data loss either way. Reopen only with a concrete operational repro. |
+| [#711](https://github.com/dashpay/grovedb/issues/711) (closed) | `continue_from_ops` underreports accumulated cost on error paths | Only fires on **rejected** ops and is deterministic — every node computes the identical value, so no divergence and no credit inflation. Wontfix; a tidy-up returning accumulated cost is welcome but not a bug. |
+| `clear_subtree` returns `Result`, not `CostResult` | Costs are "dropped" | Intentional: `clear_subtree` discards costs by design. |
+| `Link::Modified` panics in `hash()` / `aggregate_data()` | Panic reachable | Intentional invariant enforcement: `Link::Modified` must never have these called; the panic is the contract, documented in code comments. |
+
+## Verified-unreachable proof/encoding findings
+
+| Claim | Why not real |
+|---|---|
+| Proof encoding truncates keys ≥ 256 bytes | Unreachable: every public insert path (direct + batch) enforces the 255-byte key limit (PR #506), so oversized keys cannot reach proof encoding. The `debug_assert!` is sufficient. Raw-Merk hardening exists separately (#728). |
+| `feature_type` forgery in `KVValueHashFeatureType` proof nodes | The decoded `_feature_type` is discarded by the verifier; the canonical type/sum/count lives in the hash-verified `Element` bytes. Forged values never reach callers. Documented in `verify.rs` comments and `proof_exploit_tests.rs`. |
+| `saturating_sub` on negative `SumItem` values corrupts `sum_limit` | Correct as written: `sum_limit` tracks the remaining **net sum** budget; +7 and −4 must consume 3, not 11. Absolute-value math would be the bug. |
+
+**Becomes real if:** a new write path bypasses the 255-byte key check, or a
+verifier starts trusting a decoded field instead of the hash-verified
+element bytes.


### PR DESCRIPTION
## What

Adds `docs/audit-non-issues.md`: a durable record of audit findings that were adversarially verified and **rejected**, so future audits (human, Codex, or Claude) check the list before re-filing. CLAUDE.md gains an "Auditing This Codebase" section pointing at it.

## Why

Seven open issues from the 2026-05-20 Codex audit batch were just closed after verification (#693, #694, #697, #699, #711, #715, #716), joining the earlier #684/#685. Without a checked-in record, the next automated audit will rediscover the same unchecked arithmetic and by-design behavior and re-file them.

The file is organized to reject re-reports **without suppressing new findings**: each entry states the claim, the invariant that makes it unreachable (255-byte key cap, platform size caps, hash-verified counts, transactional batch rollback), and an explicit *"becomes real if"* condition — if that condition holds, filing is correct and expected.

## Contents

- **Unreachable arithmetic overflow class** — #684, #715, #716, #693 (inputs are real stored bytes or hash-committed counts, capped far below wrap points)
- **Capacity-boundary behavior** — #694 (2^32 leaves + transactional rollback)
- **By-design behavior** — #697 (replicate from checkpoints), #699 (fast-checkpoint WAL tradeoff), #711 (deterministic undercount on rejected ops only), plus the long-standing `clear_subtree` and `Link::Modified` decisions
- **Verified-unreachable proof/encoding claims** — key-length truncation (#506 cap), `feature_type` forgery (verifier discards it; canonical data is hash-verified), `saturating_sub` on net sum budgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for codebase audits, including where to check before filing security or correctness findings.
  * Added a reference page listing previously reviewed edge cases and when they should be reconsidered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->