### PR TITLE
ci: only deploy book from develop to match github-pages environment policy

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -3,9 +3,7 @@ name: Deploy Book
 on:
   push:
     branches:
-      - master
       - develop
-      - 'v[0-9]*.[0-9]*-dev'
     paths:
       - 'docs/book/**'
       - '.github/workflows/book.yml'
@@ -64,7 +62,8 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    # The github-pages environment only permits deployments from develop
+    if: github.ref == 'refs/heads/develop' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: build
     runs-on: ubuntu-24.04
     environment:


### PR DESCRIPTION
## Problem

The [github-pages deployment on June 30](https://github.com/dashpay/grovedb/actions/runs/28431907655) failed with:

> Branch "master" is not allowed to deploy to github-pages due to environment protection rules.

The `github-pages` environment's custom branch policy only allows deployments from `develop`, but `book.yml` triggered deploys on pushes to `master`, `develop`, and `v*-dev` branches — so any book-affecting push to `master` was guaranteed to fail the deploy job.

## Fix

Make the workflow match the environment configuration:

- Restrict the `push` trigger to `develop` only.
- Gate the deploy job on `github.ref == 'refs/heads/develop'` so a manual `workflow_dispatch` from another branch builds the book but doesn't attempt a deploy that the environment would reject.

PR builds are unaffected — they still build the book (without deploying) as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build and deployment triggers to run only for the `develop` branch.
  * Restricted GitHub Pages deployments to manual runs or pushes to `develop`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->