### PR TITLE
fix(indexed-tree): close security invariant gaps

### DIFF
--- a/grovedb-element/src/indexed/sort_keys.rs
+++ b/grovedb-element/src/indexed/sort_keys.rs
@@ -63,10 +63,10 @@ pub fn decode_sum_sort_key(bytes: &[u8; 8]) -> i64 {
 ///   magnitude beyond any realistic `i64` aggregation. Saturation is
 ///   therefore a defensive last line of defense; in practice the operation
 ///   never saturates.
-/// - Integer division floors toward negative infinity for negative
-///   results because the operands have the same sign after the
-///   saturating multiplication; for positive results division is
-///   ordinary truncation toward zero, equivalent to floor.
+/// - Euclidean division is used explicitly so negative fractional results
+///   round toward negative infinity. Rust's `/` operator truncates signed
+///   integers toward zero and would place negative averages one fixed-point
+///   bucket too high.
 #[inline]
 pub fn compute_avg_fixed_point(sum: i64, count: u64) -> i128 {
     if count == 0 {
@@ -74,7 +74,9 @@ pub fn compute_avg_fixed_point(sum: i64, count: u64) -> i128 {
     }
     let sum_i128 = sum as i128;
     let count_i128 = count as i128;
-    sum_i128.saturating_mul(AVG_FIXED_POINT_SCALE) / count_i128
+    sum_i128
+        .saturating_mul(AVG_FIXED_POINT_SCALE)
+        .div_euclid(count_i128)
 }
 
 /// `i128` big-endian with the sign bit flipped (bit 127). Lexicographic
@@ -286,5 +288,18 @@ mod tests {
         // i128::MAX ≈ 1.7e38), so the multiplication does NOT saturate.
         let expected = (max_sum as i128) * AVG_FIXED_POINT_SCALE;
         assert_eq!(v, expected);
+    }
+
+    #[test]
+    fn negative_average_uses_floor_bucket() {
+        let expected_floor = (-AVG_FIXED_POINT_SCALE).div_euclid(3);
+        let computed = compute_avg_fixed_point(-1, 3);
+
+        assert_eq!(computed, expected_floor);
+        assert_eq!(
+            encode_avg_sort_key(computed),
+            encode_avg_sort_key(expected_floor),
+            "negative fractional averages must remain in the mathematical floor bucket"
+        );
     }
 }

--- a/grovedb/src/batch/indexed_tree.rs
+++ b/grovedb/src/batch/indexed_tree.rs
@@ -11,8 +11,7 @@
 //! - [`apply_cidx_secondary_mirror_post_apply`] runs after the primary
 //!   merk's `apply_with_specialized_costs` returns. It re-reads each
 //!   captured key's new count, builds a deterministic delta list, and
-//!   applies the corresponding `mirror_to_secondary_for_batch` calls
-//!   on the cidx secondary merk, returning the secondary's post-mirror
+//!   applies one atomic Merk batch to the cidx secondary, returning its post-mirror
 //!   `(root_hash, root_key)` for the bubble-up code to fold into the
 //!   parent's H1-A composition.
 //! - [`reject_freshly_inserted_cidx_with_descendants`] is the preflight
@@ -23,10 +22,10 @@
 //!   parent merk that hasn't been flushed yet.
 //! - [`inspect_cidx_overwrite`] runs inside the per-op loop when
 //!   tree-override protection is OFF and the op could overwrite an
-//!   existing element. It classifies the overwrite against the
-//!   safe-subset rules (cidx → non-cidx OR cidx → empty cidx are
-//!   allowed and scheduled for cleanup; cidx → non-empty cidx is
-//!   rejected as ambiguous; descendants-in-same-batch are rejected
+//!   existing element. It classifies every indexed-tree variant against
+//!   the safe-subset rules (indexed → non-indexed OR indexed → empty
+//!   indexed are allowed and scheduled for cleanup; indexed → non-empty
+//!   indexed is rejected as ambiguous; descendants-in-same-batch are rejected
 //!   because the post-apply cleanup would silently clear them).
 //!
 //! Kept out of `mod.rs` to keep that file focused on the generic batch
@@ -39,7 +38,15 @@ use std::collections::BTreeMap;
 use grovedb_costs::{
     cost_return_on_error, cost_return_on_error_no_add, CostResult, CostsExt, OperationCost,
 };
-use grovedb_merk::{element::costs::ElementCostExtensions, CryptoHash, Merk};
+use grovedb_element::indexed::IndexAxis;
+use grovedb_merk::{
+    element::{
+        costs::ElementCostExtensions, delete::ElementDeleteFromStorageExtensions,
+        insert::ElementInsertToStorageExtensions, tree_type::ElementTreeTypeExtensions,
+    },
+    tree_type::TreeType,
+    BatchEntry, CryptoHash, Merk,
+};
 use grovedb_storage::StorageContext;
 use grovedb_version::version::GroveVersion;
 
@@ -128,23 +135,11 @@ pub(crate) fn capture_cidx_pre_state<'db, S: StorageContext<'db>>(
 /// `(root_hash, root_key)` for the caller to fold into the parent's
 /// H1-A `combine_hash_three` composition.
 ///
-/// **Determinism note:** the input `pre` is a `BTreeMap`, so its
-/// iteration is already deterministic (key-sorted). The deltas are
-/// still re-sorted *pure deletes first, then by key* before being
-/// applied: empirical reproduction showed that when an INSERT delta
-/// runs BEFORE a DELETE delta on the same secondary merk, the delete
-/// sometimes fails to actually remove the entry — leaving stale
-/// secondary state. The underlying merk-level bug
-/// (delete-after-insert on a count-bearing Merk) needs separate
-/// investigation; this sort enforces a known-good order in the
-/// meantime. (We previously used a `HashMap` here, which made the
-/// ordering bug surface non-deterministically across runs.)
-///
-/// Classification: a delta `(_, Some(_), None)` is a pure delete
-/// (key removed from primary). For each individual delta,
-/// `mirror_to_secondary_for_batch` does a delete-then-insert ON ONE
-/// KEY which is fine; the order issue only surfaces ACROSS deltas of
-/// different keys.
+/// **Determinism and atomic-transition note:** the input `pre` is a
+/// `BTreeMap`, so iteration is key-sorted. All secondary deletes and inserts
+/// are assembled into one sorted Merk batch. Applying them as separate Merk
+/// mutations can retain a stale row after multiple same-level count changes;
+/// one atomic batch gives the secondary a single pre/post transition.
 pub(crate) fn apply_cidx_secondary_mirror_post_apply<'db, S: StorageContext<'db>>(
     primary_merk: &Merk<S>,
     pre: BTreeMap<Vec<u8>, Option<u64>>,
@@ -183,24 +178,80 @@ pub(crate) fn apply_cidx_secondary_mirror_post_apply<'db, S: StorageContext<'db>
         deltas.push((key, old_count, new_count));
     }
 
-    deltas.sort_by(|a, b| {
-        let a_is_pure_delete = a.1.is_some() && a.2.is_none();
-        let b_is_pure_delete = b.1.is_some() && b.2.is_none();
-        match b_is_pure_delete.cmp(&a_is_pure_delete) {
-            std::cmp::Ordering::Equal => a.0.cmp(&b.0),
-            other => other,
+    let secondary_tree_type = TreeType::ProvableCountTree;
+    let mut secondary_batch: Vec<BatchEntry<Vec<u8>>> = Vec::with_capacity(deltas.len() * 2);
+    for (key, old_count, new_count) in &deltas {
+        if old_count == new_count {
+            continue;
         }
-    });
-    for (key, old_count, new_count) in deltas {
+        if let Some(old_count) = old_count {
+            let old_secondary_key = crate::operations::indexed_tree::make_axis_secondary_key(
+                IndexAxis::Count,
+                *old_count,
+                0,
+                key,
+            );
+            cost_return_on_error!(
+                &mut cost,
+                Element::delete_into_batch_operations(
+                    old_secondary_key,
+                    false,
+                    secondary_tree_type,
+                    &mut secondary_batch,
+                    grove_version,
+                )
+                .map_err(Error::MerkError)
+            );
+        }
+        if let Some(new_count) = new_count {
+            let new_secondary_key = crate::operations::indexed_tree::make_axis_secondary_key(
+                IndexAxis::Count,
+                *new_count,
+                0,
+                key,
+            );
+            let entry = Element::new_item(Vec::new());
+            let feature_type = cost_return_on_error_no_add!(
+                cost,
+                entry
+                    .get_feature_type(secondary_tree_type)
+                    .map_err(Error::MerkError)
+            );
+            cost_return_on_error!(
+                &mut cost,
+                entry
+                    .insert_into_batch_operations(
+                        new_secondary_key,
+                        &mut secondary_batch,
+                        feature_type,
+                        grove_version,
+                    )
+                    .map_err(Error::MerkError)
+            );
+        }
+    }
+    secondary_batch.sort_by(|a, b| a.0.cmp(&b.0));
+    if !secondary_batch.is_empty() {
         cost_return_on_error!(
             &mut cost,
-            crate::operations::indexed_tree::mirror_to_secondary_for_batch(
-                secondary_merk,
-                key.as_slice(),
-                old_count,
-                new_count,
-                grove_version,
-            )
+            secondary_merk
+                .apply_with_specialized_costs::<_, Vec<u8>>(
+                    &secondary_batch,
+                    &[],
+                    None,
+                    &|key, value| {
+                        Element::specialized_costs_for_key_value(
+                            key,
+                            value,
+                            secondary_tree_type.inner_node_type(),
+                            grove_version,
+                        )
+                        .map_err(|e| grovedb_merk::Error::ClientCorruptionError(e.to_string()))
+                    },
+                    Some(&Element::value_defined_cost_for_serialized_value),
+                    grove_version,
+                )
+                .map_err(Error::MerkError)
         );
     }
     let (sec_hash, sec_root_key, _) = cost_return_on_error!(
@@ -290,16 +341,16 @@ pub(crate) fn reject_freshly_inserted_cidx_with_descendants(
 
 /// Classify an `op_could_overwrite` insert at `path / key_info` against
 /// the existing primary-merk entry, when tree-override protection is
-/// **OFF** for this batch. Allows the cidx safe-subset overwrites and
+/// **OFF** for this batch. Allows indexed-tree safe-subset overwrites and
 /// rejects the ambiguous ones:
 ///
 /// |  existing              |  new                       |  outcome                      |
 /// |------------------------|----------------------------|-------------------------------|
 /// |  none                  |  *                         |  `Ok(None)`                   |
-/// |  non-cidx              |  *                         |  `Ok(None)`                   |
-/// |  cidx                  |  non-cidx                  |  `Ok(Some(cidx_path))`        |
-/// |  cidx                  |  empty cidx                |  `Ok(Some(cidx_path))`        |
-/// |  cidx                  |  non-empty cidx            |  `Err(NotSupported)`          |
+/// |  non-indexed           |  *                         |  `Ok(None)`                   |
+/// |  indexed              |  non-indexed               |  `Ok(Some(indexed_path))`     |
+/// |  indexed              |  empty indexed             |  `Ok(Some(indexed_path))`     |
+/// |  indexed              |  non-empty indexed         |  `Err(NotSupported)`          |
 ///
 /// When `Ok(Some(cidx_path))` is returned, the caller should push
 /// `cidx_path` onto its `cidx_overwrite_cleanup_paths` list so the
@@ -355,36 +406,41 @@ pub(crate) fn inspect_cidx_overwrite<'db, S: StorageContext<'db>>(
         })
     );
 
-    let existing_is_cidx = matches!(
-        existing_element.underlying(),
-        Element::ProvableCountIndexedTree(..)
-    );
-    if !existing_is_cidx {
+    if !existing_element.is_indexed_tree() {
         return Ok(None).wrap_with_cost(cost);
     }
 
-    // Classify the new element.
-    let (new_is_cidx, new_is_empty_cidx) = match new_element.underlying() {
-        Element::ProvableCountIndexedTree(p, s, c, _) => {
-            (true, p.is_none() && s.is_none() && *c == 0)
+    // Classify the complete indexed family. Empty PCPSIT elements retain a
+    // canonical non-empty axes list, but every axis root key must be None.
+    let new_indexed_empty = match new_element.underlying() {
+        Element::ProvableSumIndexedTree(p, s, sum, _) => {
+            Some(p.is_none() && s.is_none() && *sum == 0)
         }
-        _ => (false, false),
+        Element::ProvableCountIndexedTree(p, s, c, _) => {
+            Some(p.is_none() && s.is_none() && *c == 0)
+        }
+        Element::ProvableCountProvableSumIndexedTree(p, c, sum, axes, _) => Some(
+            p.is_none()
+                && *c == 0
+                && *sum == 0
+                && axes.iter().all(|(_, root_key)| root_key.is_none()),
+        ),
+        _ => None,
     };
-    if new_is_cidx && !new_is_empty_cidx {
+    if matches!(new_indexed_empty, Some(false)) {
         return Err(Error::NotSupported(
-            "overwriting an existing CountIndexedTree / ProvableCountIndexedTree with a \
-             NON-EMPTY cidx via the batch path is not supported (storage-pointer semantics \
+            "overwriting an existing indexed tree with a NON-EMPTY indexed tree via the \
+             batch path is not supported (storage-pointer semantics \
              are ambiguous: the new element's root_keys would refer to data while the \
-             post-apply cleanup also clears it). Empty the cidx via \
-             delete_from_count_indexed_tree, DeleteTree it via batch, and re-create with \
+             post-apply cleanup also clears it). DeleteTree the old indexed tree and re-create \
              the new state in a follow-up batch"
                 .to_string(),
         ))
         .wrap_with_cost(cost);
     }
 
-    // Safe subset: cidx → non-cidx OR cidx → empty cidx. Schedule the
-    // OLD cidx's storage namespaces for cleanup. The cidx's path is
+    // Safe subset: indexed → non-indexed OR indexed → empty indexed.
+    // Schedule the OLD indexed tree's storage namespaces for cleanup. Its path is
     // `path + key_info`.
     let mut cidx_path = path.to_vec();
     cidx_path.push(key_info.get_key_clone());

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -123,6 +123,35 @@ pub enum SubelementsDeletionBehavior {
     Skip,
 }
 
+/// Treat the tree type carried by `DeleteTree` as a checked claim, not as
+/// storage-ownership authority. Cleanup namespaces must be selected from the
+/// element that is actually stored at the target key.
+fn validate_delete_tree_type<'db, S: StorageContext<'db>>(
+    parent_storage: &S,
+    key: &[u8],
+    declared_tree_type: TreeType,
+    grove_version: &GroveVersion,
+) -> CostResult<TreeType, Error> {
+    let mut cost = OperationCost::default();
+    let stored_element = cost_return_on_error!(
+        &mut cost,
+        Element::get_from_storage(parent_storage, key, grove_version).map_err(Error::MerkError)
+    );
+    let Some(actual_tree_type) = stored_element.tree_type() else {
+        return Err(Error::InvalidBatchOperation(
+            "DeleteTree target exists but is not a tree element",
+        ))
+        .wrap_with_cost(cost);
+    };
+    if actual_tree_type != declared_tree_type {
+        return Err(Error::InvalidBatchOperation(
+            "DeleteTree declared tree type does not match the stored element",
+        ))
+        .wrap_with_cost(cost);
+    }
+    Ok(actual_tree_type).wrap_with_cost(cost)
+}
+
 /// Metadata for non-Merk tree types, carrying tree-type-specific state
 /// through the batch system.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -2327,7 +2356,7 @@ where
                                 .wrap_with_cost(cost);
                             }
                         }
-                    } else if op_could_overwrite && !matches!(&element, Element::Reference(..)) {
+                    } else if op_could_overwrite {
                         // Tree-override protection is OFF; let the
                         // cidx helper classify the overwrite (safe
                         // subset → schedule cleanup, ambiguous → err,
@@ -4776,6 +4805,27 @@ impl GroveDb {
                 let mut child_path = op.path.to_path();
                 child_path.push(key.as_slice().to_vec());
 
+                let parent_path_vec = op.path.to_path();
+                let parent_path: SubtreePath<Vec<u8>> = parent_path_vec.as_slice().into();
+                let parent_storage = self
+                    .db
+                    .get_transactional_storage_context(
+                        parent_path,
+                        Some(&storage_batch),
+                        tx.as_ref(),
+                    )
+                    .unwrap_add_cost(&mut cost);
+                let actual_tree_type = cost_return_on_error!(
+                    &mut cost,
+                    validate_delete_tree_type(
+                        &parent_storage,
+                        key.as_slice(),
+                        *tree_type,
+                        grove_version,
+                    )
+                );
+                let tree_type = &actual_tree_type;
+
                 // Per-op emptiness check based on the SubelementsDeletionBehavior policy.
                 match subelements_deletion_behavior {
                     SubelementsDeletionBehavior::DontCheckWithNoCleanup => {
@@ -5294,6 +5344,27 @@ impl GroveDb {
             {
                 let mut child_path = op.path.to_path();
                 child_path.push(key.as_slice().to_vec());
+
+                let parent_path_vec = op.path.to_path();
+                let parent_path: SubtreePath<Vec<u8>> = parent_path_vec.as_slice().into();
+                let parent_storage = self
+                    .db
+                    .get_transactional_storage_context(
+                        parent_path,
+                        Some(&storage_batch),
+                        tx.as_ref(),
+                    )
+                    .unwrap_add_cost(&mut cost);
+                let actual_tree_type = cost_return_on_error!(
+                    &mut cost,
+                    validate_delete_tree_type(
+                        &parent_storage,
+                        key.as_slice(),
+                        *tree_type,
+                        grove_version,
+                    )
+                );
+                let tree_type = &actual_tree_type;
 
                 match subelements_deletion_behavior {
                     SubelementsDeletionBehavior::DontCheckWithNoCleanup => {

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -319,6 +319,105 @@ type OpenedMerkForReplication<'tx> = (
     TreeType,
 );
 
+/// Verify that an indexed tree's secondary projection is exactly derivable
+/// from its primary entries. Root-hash binding alone only proves that both
+/// Merks are internally authenticated; it does not prove their relationship.
+#[cfg(feature = "minimal")]
+fn verify_indexed_axis_relation<'db, P, S>(
+    primary_merk: &Merk<P>,
+    secondary_merk: &Merk<S>,
+    axis: grovedb_element::indexed::IndexAxis,
+    indexed_path: &[Vec<u8>],
+    primary_root_hash: CryptoHash,
+    all_query: &Query,
+    issues: &mut VerificationIssues,
+    grove_version: &GroveVersion,
+) -> Result<(), Error>
+where
+    P: StorageContext<'db>,
+    S: StorageContext<'db>,
+{
+    let mut expected: HashMap<Vec<u8>, (Vec<u8>, Element)> = HashMap::new();
+    let mut primary_iter = KVIterator::new(primary_merk.storage.raw_iter(), all_query).unwrap();
+    while let Some((primary_key, primary_value)) = primary_iter.next_kv().unwrap() {
+        let primary_element = Element::raw_decode(&primary_value, grove_version)?;
+        let (count, sum) = primary_element.count_sum_value_or_default();
+        let secondary_key = crate::operations::indexed_tree::make_axis_secondary_key(
+            axis,
+            count,
+            sum,
+            &primary_key,
+        );
+        let secondary_element = match axis {
+            grovedb_element::indexed::IndexAxis::Count => Element::new_item(Vec::new()),
+            grovedb_element::indexed::IndexAxis::Sum => Element::new_sum_item(sum),
+            grovedb_element::indexed::IndexAxis::Avg => {
+                Element::new_item_with_sum_item(Vec::new(), sum)
+            }
+        };
+        expected.insert(secondary_key, (primary_key, secondary_element));
+    }
+    drop(primary_iter);
+
+    let mut secondary_iter = KVIterator::new(secondary_merk.storage.raw_iter(), all_query).unwrap();
+    while let Some((secondary_key, actual_value)) = secondary_iter.next_kv().unwrap() {
+        let actual_element = Element::raw_decode(&actual_value, grove_version)?;
+        match expected.remove(&secondary_key) {
+            Some((primary_key, expected_element)) if expected_element != actual_element => {
+                let expected_value = expected_element.serialize(grove_version)?;
+                let actual_value = actual_element.serialize(grove_version)?;
+                let mut issue_path = indexed_path.to_vec();
+                issue_path.push(b"__indexed_secondary_value_mismatch__".to_vec());
+                issue_path.push(vec![axis.tag()]);
+                issue_path.push(primary_key);
+                issues.insert(
+                    issue_path,
+                    (
+                        primary_root_hash,
+                        value_hash(&expected_value).unwrap(),
+                        value_hash(&actual_value).unwrap(),
+                    ),
+                );
+            }
+            Some(_) => {}
+            None => {
+                let actual_value = actual_element.serialize(grove_version)?;
+                let mut issue_path = indexed_path.to_vec();
+                issue_path.push(b"__indexed_secondary_orphan__".to_vec());
+                issue_path.push(vec![axis.tag()]);
+                issue_path.push(secondary_key);
+                issues.insert(
+                    issue_path,
+                    (
+                        primary_root_hash,
+                        [0u8; 32],
+                        value_hash(&actual_value).unwrap(),
+                    ),
+                );
+            }
+        }
+    }
+    drop(secondary_iter);
+
+    for (_secondary_key, (primary_key, expected_element)) in expected {
+        let expected_value = expected_element.serialize(grove_version)?;
+        let mut issue_path = indexed_path.to_vec();
+        issue_path.push(b"__indexed_primary_orphan__".to_vec());
+        issue_path.push(vec![axis.tag()]);
+        issue_path.push(primary_key);
+        issues.insert(
+            issue_path,
+            (
+                primary_root_hash,
+                value_hash(&expected_value).unwrap(),
+                [0u8; 32],
+            ),
+        );
+    }
+
+    Ok(())
+}
+
 #[cfg(feature = "minimal")]
 impl GroveDb {
     /// Opens a given path
@@ -2109,6 +2208,22 @@ impl GroveDb {
                         grove_version,
                     )?;
 
+                    // Also validate the axis payload. The content walk above
+                    // catches missing, duplicate, orphaned, and mis-bucketed
+                    // rows; this relation check additionally proves that the
+                    // secondary element stored at the right key is the one
+                    // canonically derived from the primary element.
+                    verify_indexed_axis_relation(
+                        &primary_merk,
+                        &secondary_merk,
+                        grovedb_element::indexed::IndexAxis::Sum,
+                        &new_path.to_vec(),
+                        primary_root_hash,
+                        &all_query,
+                        &mut issues,
+                        grove_version,
+                    )?;
+
                     issues.extend(self.verify_merk_and_submerks_in_transaction(
                         primary_merk,
                         &new_path_ref,
@@ -2178,6 +2293,16 @@ impl GroveDb {
                                 grove_version,
                             )
                             .unwrap()?;
+                        verify_indexed_axis_relation(
+                            &primary_merk,
+                            &secondary_merk,
+                            axis,
+                            &new_path.to_vec(),
+                            primary_root_hash,
+                            &all_query,
+                            &mut issues,
+                            grove_version,
+                        )?;
                         axis_hashes.push((*tag, secondary_merk.root_hash().unwrap()));
                         // Per-axis content walk while this axis's secondary
                         // is open (see `verify_indexed_axis_content`).

--- a/grovedb/src/operations/indexed_tree.rs
+++ b/grovedb/src/operations/indexed_tree.rs
@@ -815,7 +815,6 @@ impl GroveDb {
             | Element::ProvableCountSumTree(..)
             | Element::ProvableSumTree(..)
             | Element::ProvableCountProvableSumTree(..)
-            | Element::CommitmentTree(..)
             | Element::MmrTree(..)
             | Element::BulkAppendTree(..)
             | Element::DenseAppendOnlyFixedSizeTree(..) => {
@@ -827,6 +826,19 @@ impl GroveDb {
                         grovedb_merk::tree::NULL_HASH,
                         None,
                         grove_version
+                    )
+                    .map_err(Error::MerkError)
+                );
+            }
+            Element::CommitmentTree(..) => {
+                cost_return_on_error!(
+                    &mut cost,
+                    item.insert_subtree(
+                        &mut primary_merk,
+                        item_key,
+                        grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT,
+                        None,
+                        grove_version,
                     )
                     .map_err(Error::MerkError)
                 );
@@ -2444,10 +2456,10 @@ impl GroveDb {
     /// stored element bytes (primary_root_key, secondary_root_key,
     /// sum_value) via the H1-A three-input value hash.
     ///
-    /// `path` is the path to the PSIT element (its primary Merk's
-    /// path). The child element must be sum-bearing (see
-    /// [`Element::is_sum_bearing_child`]); otherwise an
-    /// `InvalidInputError` is returned.
+    /// `path` is the path to the PSIT element (its primary Merk's path). The
+    /// child element must carry an `i64` sum (see
+    /// [`Element::is_sum_bearing_child`]); `BigSumTree` is excluded because
+    /// its aggregate is `i128`. Unsupported children return `InvalidInput`.
     pub fn insert_into_provable_sum_indexed_tree<'b, B, P>(
         &self,
         path: P,
@@ -2511,6 +2523,17 @@ impl GroveDb {
             return Err(Error::InvalidInput(
                 "ProvableSumIndexedTree only accepts sum-bearing children (SumItem, \
                  ItemWithSumItem, ReferenceWithSumItem, or any sum-bearing tree variant)",
+            ))
+            .wrap_with_cost(cost);
+        }
+
+        // PSIT is an i64 sum index. BigSumTree carries an i128 aggregate and
+        // `sum_value_or_default` intentionally has no narrowing conversion;
+        // accepting it here would silently mirror zero into authenticated
+        // state. A future i128 index requires a distinct typed/versioned axis.
+        if matches!(item.underlying(), Element::BigSumTree(..)) {
+            return Err(Error::InvalidInput(
+                "ProvableSumIndexedTree does not accept BigSumTree children; its sum axis is i64",
             ))
             .wrap_with_cost(cost);
         }
@@ -2631,10 +2654,10 @@ impl GroveDb {
                     )
                 );
             }
-            // Sum-bearing trees: write with NULL_HASH (empty subtree
-            // assumption); same restriction as the PCIT path.
+            // i64 sum-bearing trees: write with NULL_HASH (empty subtree
+            // assumption); same restriction as the PCIT path. BigSumTree is
+            // rejected before this dispatch because it has an i128 aggregate.
             Element::SumTree(..)
-            | Element::BigSumTree(..)
             | Element::CountSumTree(..)
             | Element::ProvableCountSumTree(..)
             | Element::ProvableSumTree(..)
@@ -3675,49 +3698,13 @@ pub(crate) fn mirror_indexed_axis_to_secondary<'db, S: StorageContext<'db>>(
     Ok(()).wrap_with_cost(cost)
 }
 
-/// Apply the secondary-mirror update for a primary mutation in the
-/// generic batch path. Handles all four cases (insert / update / delete
-/// / no-op) by combining `old_count` and `new_count` Options:
-/// - `(None, None)`: no-op (key was absent before and after).
-/// - `(None, Some(c))`: insert at count `c`.
-/// - `(Some(c), None)`: delete the secondary entry at count `c`.
-/// - `(Some(o), Some(n))`: update — delete entry at `o` and insert at `n`
-///   (skips both if `o == n`).
-///
-/// This is the [`IndexAxis::Count`] special case of
-/// [`mirror_indexed_axis_to_secondary`]: the Count-axis key and payload
-/// ignore the sum entirely, so the sum values threaded below never affect
-/// the produced bytes and each Option pair maps to the same delete/insert
-/// as the explicit table above. (For the Count axis the pcpsit fast-path
-/// payload check is always `Item(empty) == Item(empty)`, so it reduces to
-/// the former `old_count == new_count` no-op.)
-pub(crate) fn mirror_to_secondary_for_batch<'db, S: StorageContext<'db>>(
-    secondary: &mut Merk<S>,
-    item_key: &[u8],
-    old_count: Option<u64>,
-    new_count: Option<u64>,
-    grove_version: &GroveVersion,
-) -> CostResult<(), Error> {
-    mirror_indexed_axis_to_secondary(
-        secondary,
-        IndexAxis::Count,
-        item_key,
-        old_count,
-        old_count.map(|_| 0i64),
-        new_count,
-        new_count.map(|_| 0i64),
-        grove_version,
-    )
-}
-
 /// Apply the secondary-mirror update for a primary insert/update.
 ///
 /// `old_count` is `None` for a fresh insert, `Some(c)` for an update.
 ///
 /// The [`IndexAxis::Count`], always-present-`new_count` special case of
-/// [`mirror_indexed_axis_to_secondary`] — see
-/// [`mirror_to_secondary_for_batch`] for why the threaded sum values are
-/// irrelevant on the Count axis.
+/// [`mirror_indexed_axis_to_secondary`]. The Count-axis key and payload
+/// ignore the threaded sum values.
 pub(crate) fn mirror_to_secondary<'db, S: StorageContext<'db>>(
     secondary: &mut Merk<S>,
     item_key: &[u8],

--- a/grovedb/src/tests/direct_insert_indexed_tests.rs
+++ b/grovedb/src/tests/direct_insert_indexed_tests.rs
@@ -1143,4 +1143,40 @@ mod tests {
             .unwrap();
         assert!(matches!(result, Err(Error::InvalidInput(_))));
     }
+
+    #[test]
+    fn non_counted_indexed_child_rejected_in_provable_count_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"pct",
+            Element::empty_provable_count_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create parent");
+
+        let wrapped = Element::new_non_counted(Element::empty_provable_count_indexed_tree())
+            .expect("valid wrapper");
+        let result = db
+            .insert(
+                [TEST_LEAF, b"pct"].as_ref(),
+                b"cidx",
+                wrapped,
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(matches!(result, Err(Error::InvalidInput(_))));
+        assert!(
+            db.get([TEST_LEAF, b"pct"].as_ref(), b"cidx", None, grove_version)
+                .unwrap()
+                .is_err(),
+            "a rejected child must not be persisted"
+        );
+    }
 }

--- a/grovedb/src/tests/indexed_tree_security_regression_tests.rs
+++ b/grovedb/src/tests/indexed_tree_security_regression_tests.rs
@@ -1,0 +1,402 @@
+//! Cross-cutting security regressions for specialized indexed-tree insertion.
+
+use grovedb_element::{indexed::IndexAxis, reference_path::ReferencePathType};
+use grovedb_merk::tree_type::TreeType;
+use grovedb_version::version::GroveVersion;
+use tempfile::TempDir;
+
+use crate::{
+    batch::{QualifiedGroveDbOp, SubelementsDeletionBehavior},
+    tests::{common::EMPTY_PATH, make_test_grovedb, TEST_LEAF},
+    Element, Error, GroveDb,
+};
+
+fn assert_verify_passes(db: &GroveDb, grove_version: &GroveVersion) {
+    let issues = db
+        .verify_grovedb(None, true, true, grove_version)
+        .expect("integrity traversal");
+    assert!(issues.is_empty(), "integrity issues: {issues:?}");
+}
+
+#[test]
+fn commitment_tree_under_pcit_uses_specialized_empty_root() {
+    let grove_version = GroveVersion::latest();
+    let tmp = TempDir::new().expect("temporary database");
+    {
+        let db = GroveDb::open(tmp.path()).expect("open database");
+        db.insert(
+            EMPTY_PATH,
+            b"pcit",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create PCIT");
+        db.insert_into_count_indexed_tree(
+            [b"pcit".as_slice()].as_ref(),
+            b"commitment",
+            Element::empty_commitment_tree(10).expect("valid CommitmentTree"),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert CommitmentTree");
+
+        let issues = db
+            .verify_grovedb(None, false, true, grove_version)
+            .expect("integrity traversal");
+        assert!(
+            issues.is_empty(),
+            "specialized child binding drifted: {issues:?}"
+        );
+    }
+    GroveDb::open_with_cidx_integrity_check(tmp.path(), grove_version)
+        .expect("checked reopen accepts specialized child binding");
+}
+
+#[test]
+fn psit_rejects_big_sum_tree_at_i64_boundary() {
+    let grove_version = GroveVersion::latest();
+    let tmp = TempDir::new().expect("temporary database");
+    let db = GroveDb::open(tmp.path()).expect("open database");
+    db.insert(
+        EMPTY_PATH,
+        b"psit",
+        Element::empty_provable_sum_indexed_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("create PSIT");
+
+    let result = db
+        .insert_into_provable_sum_indexed_tree(
+            [b"psit".as_slice()].as_ref(),
+            b"big",
+            Element::new_big_sum_tree_with_flags_and_sum_value(None, 42, None),
+            None,
+            grove_version,
+        )
+        .unwrap();
+    assert!(matches!(result, Err(crate::Error::InvalidInput(_))));
+
+    db.insert_into_provable_sum_indexed_tree(
+        [b"psit".as_slice()].as_ref(),
+        b"sum",
+        Element::new_sum_tree_with_flags_and_sum_value(None, 42, None),
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("i64 SumTree control");
+    assert_eq!(
+        db.indexed_sum_top_k([b"psit".as_slice()].as_ref(), 10, true, None, grove_version,)
+            .unwrap()
+            .unwrap(),
+        vec![(42, b"sum".to_vec())]
+    );
+}
+
+#[test]
+fn delete_tree_rejects_declared_type_mismatch() {
+    let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        [TEST_LEAF].as_ref(),
+        b"cidx",
+        Element::empty_provable_count_indexed_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("create PCIT");
+    db.insert_into_count_indexed_tree(
+        [TEST_LEAF, b"cidx"].as_ref(),
+        b"row",
+        Element::new_item(b"value".to_vec()),
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("populate PCIT");
+
+    let result = db
+        .apply_batch(
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec()],
+                b"cidx".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap();
+    assert!(matches!(result, Err(Error::InvalidBatchOperation(_))));
+    assert_eq!(
+        db.indexed_count_top_k([TEST_LEAF, b"cidx"].as_ref(), 10, true, None, grove_version,)
+            .unwrap()
+            .unwrap(),
+        vec![(1, b"row".to_vec())]
+    );
+    assert_verify_passes(&db, grove_version);
+}
+
+#[test]
+fn batch_overwrite_cleans_psit_and_pcpsit_namespaces() {
+    let grove_version = GroveVersion::latest();
+
+    let psit = make_test_grovedb(grove_version);
+    psit.insert(
+        [TEST_LEAF].as_ref(),
+        b"indexed",
+        Element::empty_provable_sum_indexed_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("create PSIT");
+    psit.insert_into_provable_sum_indexed_tree(
+        [TEST_LEAF, b"indexed"].as_ref(),
+        b"stale",
+        Element::new_sum_item(42),
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("populate PSIT");
+    for replacement in [
+        Element::new_item(b"replacement".to_vec()),
+        Element::empty_provable_sum_indexed_tree(),
+    ] {
+        psit.apply_batch(
+            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec()],
+                b"indexed".to_vec(),
+                replacement,
+            )],
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("overwrite PSIT");
+    }
+    assert!(psit
+        .indexed_sum_top_k(
+            [TEST_LEAF, b"indexed"].as_ref(),
+            10,
+            true,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .unwrap()
+        .is_empty());
+    assert_verify_passes(&psit, grove_version);
+
+    let pcpsit = make_test_grovedb(grove_version);
+    let axes = vec![(IndexAxis::Count.tag(), None), (IndexAxis::Sum.tag(), None)];
+    pcpsit
+        .insert(
+            [TEST_LEAF].as_ref(),
+            b"indexed",
+            Element::empty_provable_count_provable_sum_indexed_tree(axes.clone()).unwrap(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create PCPSIT");
+    pcpsit
+        .insert_into_provable_count_provable_sum_indexed_tree(
+            [TEST_LEAF, b"indexed"].as_ref(),
+            b"stale",
+            Element::new_item_with_sum_item(b"value".to_vec(), 42),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("populate PCPSIT");
+    for replacement in [
+        Element::new_item(b"replacement".to_vec()),
+        Element::empty_provable_count_provable_sum_indexed_tree(axes).unwrap(),
+    ] {
+        pcpsit
+            .apply_batch(
+                vec![QualifiedGroveDbOp::insert_or_replace_op(
+                    vec![TEST_LEAF.to_vec()],
+                    b"indexed".to_vec(),
+                    replacement,
+                )],
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("overwrite PCPSIT");
+    }
+    assert!(pcpsit
+        .indexed_count_top_k(
+            [TEST_LEAF, b"indexed"].as_ref(),
+            10,
+            true,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .unwrap()
+        .is_empty());
+    assert!(pcpsit
+        .indexed_sum_top_k(
+            [TEST_LEAF, b"indexed"].as_ref(),
+            10,
+            true,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .unwrap()
+        .is_empty());
+    assert_verify_passes(&pcpsit, grove_version);
+}
+
+#[test]
+fn bare_reference_overwrite_cleans_indexed_storage() {
+    let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        [TEST_LEAF].as_ref(),
+        b"target",
+        Element::new_item(b"target".to_vec()),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("target");
+    db.insert(
+        [TEST_LEAF].as_ref(),
+        b"cidx",
+        Element::empty_provable_count_indexed_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("create PCIT");
+    db.insert_into_count_indexed_tree(
+        [TEST_LEAF, b"cidx"].as_ref(),
+        b"stale",
+        Element::new_item(b"value".to_vec()),
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("populate PCIT");
+
+    db.apply_batch(
+        vec![QualifiedGroveDbOp::insert_or_replace_op(
+            vec![TEST_LEAF.to_vec()],
+            b"cidx".to_vec(),
+            Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                TEST_LEAF.to_vec(),
+                b"target".to_vec(),
+            ])),
+        )],
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("bare reference overwrite");
+    db.insert(
+        [TEST_LEAF].as_ref(),
+        b"cidx",
+        Element::empty_provable_count_indexed_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("recreate PCIT");
+    assert!(db
+        .indexed_count_top_k([TEST_LEAF, b"cidx"].as_ref(), 10, true, None, grove_version,)
+        .unwrap()
+        .unwrap()
+        .is_empty());
+    assert_verify_passes(&db, grove_version);
+}
+
+#[test]
+fn batch_count_changes_remove_all_old_secondary_rows_first() {
+    let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        [TEST_LEAF].as_ref(),
+        b"cidx",
+        Element::empty_provable_count_indexed_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("create PCIT");
+    for child in [b"a".as_slice(), b"b".as_slice()] {
+        db.insert_into_count_indexed_tree(
+            [TEST_LEAF, b"cidx"].as_ref(),
+            child,
+            Element::empty_count_tree(),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create child");
+        db.insert(
+            [TEST_LEAF, b"cidx", child].as_ref(),
+            b"seed",
+            Element::new_item(b"value".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("seed child");
+    }
+    db.apply_batch(
+        [b"a".as_slice(), b"b".as_slice()]
+            .into_iter()
+            .map(|child| {
+                QualifiedGroveDbOp::insert_or_replace_op(
+                    vec![TEST_LEAF.to_vec(), b"cidx".to_vec(), child.to_vec()],
+                    b"next".to_vec(),
+                    Element::new_item(b"value".to_vec()),
+                )
+            })
+            .collect(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("update both children");
+    assert_eq!(
+        db.indexed_count_top_k(
+            [TEST_LEAF, b"cidx"].as_ref(),
+            10,
+            false,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .unwrap(),
+        vec![(2, b"a".to_vec()), (2, b"b".to_vec())]
+    );
+    assert_verify_passes(&db, grove_version);
+}

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -47,6 +47,7 @@ mod estimated_costs_worst_case_tests;
 mod get_cost_estimator_tests;
 mod grove_query_result_tests;
 mod indexed_axis_proof_tests;
+mod indexed_tree_security_regression_tests;
 mod is_empty_tree_tests;
 mod misc_coverage_tests;
 mod mmr_tree_tests;

--- a/grovedb/src/tests/provable_count_indexed_tree_tests.rs
+++ b/grovedb/src/tests/provable_count_indexed_tree_tests.rs
@@ -472,7 +472,7 @@ mod tests {
 
     #[test]
     fn pcit_batch_overwrite_existing_pcit_with_non_empty_pcit_is_rejected() {
-        // cidx → non-empty cidx must be rejected by
+        // indexed → non-empty indexed must be rejected by
         // `inspect_cidx_overwrite` (storage-pointer ambiguity: the new
         // root keys would refer to on-disk data that post-apply
         // cleanup of the OLD cidx also clears).
@@ -499,7 +499,7 @@ mod tests {
             .unwrap();
         match result {
             Err(Error::NotSupported(msg)) => assert!(
-                msg.contains("NON-EMPTY cidx") || msg.contains("cidx"),
+                msg.contains("NON-EMPTY indexed tree"),
                 "expected NotSupported, got: {msg}"
             ),
             other => panic!("expected NotSupported, got {:?}", other),

--- a/grovedb/src/tests/provable_sum_indexed_tree_tests.rs
+++ b/grovedb/src/tests/provable_sum_indexed_tree_tests.rs
@@ -6,8 +6,8 @@
 //! - Delete (existing + missing) + verify.
 //! - Child-type rejection: non-sum-bearing items (`Item`, plain
 //!   `Reference`, plain `Tree`).
-//! - Child-type acceptance: SumItem, ItemWithSumItem, empty sum-bearing
-//!   trees (SumTree, BigSumTree, CountSumTree, …).
+//! - Child-type acceptance: SumItem, ItemWithSumItem, and empty i64
+//!   sum-bearing trees (SumTree, CountSumTree, …); BigSumTree is rejected.
 //! - Error paths: wrong tree-type target, root-path inserts/deletes,
 //!   non-empty PSIT direct child rejection, oversized item key.
 //! - Tree-overwrite cleanup via batch.

--- a/grovedb/src/tests/verify_grovedb_indexed_tests.rs
+++ b/grovedb/src/tests/verify_grovedb_indexed_tests.rs
@@ -17,6 +17,7 @@ mod tests {
     use grovedb_version::version::GroveVersion;
 
     use crate::{
+        operations::insert::InsertOptions,
         tests::{make_test_grovedb, TEST_LEAF},
         Element,
     };
@@ -1258,6 +1259,53 @@ mod tests {
         k
     }
 
+    fn delete_psit_secondary_row_and_get_root_key(
+        db: &crate::GroveDb,
+        psit_primary_path: &[&[u8]],
+        secondary_root_key: Option<Vec<u8>>,
+        secondary_key: &[u8],
+        grove_version: &GroveVersion,
+    ) -> Option<Vec<u8>> {
+        let tx = db.start_transaction();
+        let batch = StorageBatch::new();
+        let path_vec: Vec<&[u8]> = psit_primary_path.to_vec();
+        let path: SubtreePath<&[u8]> = path_vec.as_slice().into();
+        let new_root_key = {
+            let mut secondary_merk = db
+                .open_indexed_secondary_at_path(
+                    path,
+                    IndexAxis::Sum,
+                    secondary_root_key,
+                    &tx,
+                    Some(&batch),
+                    grove_version,
+                )
+                .unwrap()
+                .expect("open PSIT secondary");
+            Element::delete(
+                &mut secondary_merk,
+                secondary_key,
+                None,
+                false,
+                TreeType::ProvableSumTree,
+                grove_version,
+            )
+            .unwrap()
+            .expect("delete secondary row");
+            secondary_merk
+                .root_hash_key_and_aggregate_data()
+                .unwrap()
+                .expect("read secondary root")
+                .1
+        };
+        db.db
+            .commit_multi_context_batch(batch, Some(&tx))
+            .unwrap()
+            .expect("commit mutated secondary");
+        tx.commit().expect("commit transaction");
+        new_root_key
+    }
+
     #[test]
     fn verify_grovedb_psit_detects_secondary_drift() {
         // PSIT mirror is via i64-keyed secondary. Delete the secondary
@@ -1307,6 +1355,75 @@ mod tests {
             .verify_grovedb(None, true, true, grove_version)
             .expect("verify");
         assert!(!issues.is_empty(), "expected H1-A drift detection");
+    }
+
+    #[test]
+    fn verify_grovedb_psit_detects_coherently_rebound_relational_drift() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"psit",
+            Element::empty_provable_sum_indexed_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create PSIT");
+        for (key, sum) in [(b"a".as_slice(), 10), (b"b".as_slice(), 20)] {
+            db.insert_into_provable_sum_indexed_tree(
+                [TEST_LEAF, b"psit"].as_ref(),
+                key,
+                Element::new_sum_item(sum),
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("populate PSIT");
+        }
+        let parent = db
+            .get([TEST_LEAF].as_ref(), b"psit", None, grove_version)
+            .unwrap()
+            .expect("read PSIT parent");
+        let (primary_root, secondary_root, sum, flags) = match parent {
+            Element::ProvableSumIndexedTree(primary, secondary, sum, flags) => {
+                (primary, secondary, sum, flags)
+            }
+            other => panic!("expected PSIT, got {other:?}"),
+        };
+        let new_secondary_root = delete_psit_secondary_row_and_get_root_key(
+            &db,
+            &[TEST_LEAF, b"psit"],
+            secondary_root,
+            &psit_secondary_key(10, b"a"),
+            grove_version,
+        );
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"psit",
+            Element::ProvableSumIndexedTree(primary_root, new_secondary_root, sum, flags),
+            Some(InsertOptions {
+                validate_insertion_does_not_override: false,
+                validate_insertion_does_not_override_tree: false,
+                base_root_storage_is_free: true,
+            }),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("rebind authenticated secondary root");
+
+        let issues = db
+            .verify_grovedb(None, false, true, grove_version)
+            .expect("verify coherently rebound PSIT");
+        assert!(
+            issues.keys().any(|path| path
+                .iter()
+                .any(|segment| segment.as_slice() == b"__indexed_primary_orphan__")),
+            "relational verifier missed a primary row absent from the rebound secondary: {issues:?}"
+        );
     }
 
     // -----------------------------------------------------------------

--- a/merk/src/element/insert.rs
+++ b/merk/src/element/insert.rs
@@ -745,9 +745,9 @@ impl ElementInsertToStorageExtensions for Element {
             .wrap_with_cost(Default::default());
         }
 
-        if self.is_non_counted() && !merk.tree_type.is_count_bearing() {
+        if self.is_non_counted() && !merk.tree_type.accepts_non_counted_children() {
             return Err(Error::InvalidInputError(
-                "non-counted elements may only be inserted into count-bearing trees",
+                "non-counted elements may only be inserted into non-provable count-bearing trees",
             ))
             .wrap_with_cost(Default::default());
         }
@@ -831,20 +831,18 @@ impl ElementInsertToStorageExtensions for Element {
             .wrap_with_cost(Default::default());
         }
 
-        // Mirror the non-counted destination guard from the direct
-        // `insert_count_indexed_subtree` path (L696-700): a NonCounted-
-        // wrapped cidx may only be inserted into a count-bearing
-        // parent. The direct path checks `merk.tree_type.is_count_bearing()`;
-        // the batch variant only has the per-node `feature_type` so we
-        // use `feature_type.count().is_some()` as the equivalent
-        // count-bearing predicate (a node is count-bearing iff its
-        // feature type carries a count). Without this check, callers
-        // could queue a `NonCounted(CountIndexedTree)` op with a
-        // non-count-bearing feature type, bypassing the invariant the
-        // direct API enforces.
-        if self.is_non_counted() && feature_type.count().is_none() {
+        // The batch builder has the parent's feature type instead of its
+        // TreeType. Only the non-provable CountTree/CountSumTree feature
+        // variants accept NonCounted children; the Provable* variants commit
+        // their count and must reject the wrapper just like the direct path.
+        if self.is_non_counted()
+            && !matches!(
+                feature_type,
+                TreeFeatureType::CountedMerkNode(_) | TreeFeatureType::CountedSummedMerkNode(..)
+            )
+        {
             return Err(Error::InvalidInputError(
-                "non-counted elements may only be inserted into count-bearing trees",
+                "non-counted elements may only be inserted into non-provable count-bearing trees",
             ))
             .wrap_with_cost(Default::default());
         }
@@ -1455,9 +1453,9 @@ mod tests {
 
     #[test]
     fn insert_count_indexed_subtree_rejects_non_counted_wrapper_into_normal_tree() {
-        // Coverage for L696-700 — non-counted wrapper elements may
-        // only be inserted into count-bearing trees. A NonCounted-
-        // wrapped cidx into a NormalTree merk must be rejected.
+        // Non-counted wrapper elements may only be inserted into
+        // non-provable count-bearing trees. A NonCounted-wrapped cidx into a
+        // NormalTree merk must be rejected.
         use crate::tree::hash::NULL_HASH;
 
         let grove_version = GroveVersion::latest();
@@ -1481,10 +1479,7 @@ mod tests {
         match result {
             Err(Error::InvalidInputError(msg)) => {
                 assert!(
-                    msg.contains(
-                        "non-counted elements may only be inserted into \
-                                  count-bearing trees"
-                    ),
+                    msg.contains("non-provable count-bearing trees"),
                     "expected non-counted-wrong-tree error, got: {msg}"
                 );
             }
@@ -1539,17 +1534,48 @@ mod tests {
     }
 
     #[test]
+    fn insert_count_indexed_subtree_rejects_non_counted_in_provable_count_parents() {
+        use crate::tree::hash::NULL_HASH;
+
+        let grove_version = GroveVersion::latest();
+        for parent_type in [
+            TreeType::ProvableCountTree,
+            TreeType::ProvableCountSumTree,
+            TreeType::ProvableCountProvableSumTree,
+            TreeType::ProvableCountIndexedTree,
+            TreeType::ProvableCountProvableSumIndexedTree,
+        ] {
+            assert!(!parent_type.accepts_non_counted_children());
+            let mut merk = TempMerk::new_with_tree_type(grove_version, parent_type);
+            let wrapped = Element::new_non_counted(Element::empty_provable_count_indexed_tree())
+                .expect("valid wrapper");
+            let result = wrapped
+                .insert_count_indexed_subtree(
+                    &mut merk,
+                    b"nested",
+                    NULL_HASH,
+                    NULL_HASH,
+                    None,
+                    grove_version,
+                )
+                .unwrap();
+            assert!(
+                matches!(result, Err(Error::InvalidInputError(_))),
+                "forbidden indexed child was accepted by {parent_type:?}: {result:?}"
+            );
+        }
+    }
+
+    #[test]
     fn insert_count_indexed_subtree_into_batch_operations_rejects_non_counted_wrapper_with_non_count_bearing_feature_type(
     ) {
         // Coverage for the new non-counted-destination guard (CodeRabbit
         // finding on 2026-05-11 review). The direct
         // insert_count_indexed_subtree path already enforces:
         //   `NonCounted(...) + non-count-bearing merk → InvalidInput`
-        // The batch variant must enforce the equivalent invariant
-        // using its only available signal (`feature_type`): a node is
-        // count-bearing iff `feature_type.count().is_some()`. Without
-        // this check, callers could queue a NonCounted(cidx) op with
-        // BasicMerkNode and bypass the guard.
+        // The batch variant must enforce the equivalent invariant using its
+        // available `feature_type`: only the non-provable CountedMerkNode and
+        // CountedSummedMerkNode variants accept the wrapper.
         use crate::tree::hash::NULL_HASH;
         use crate::TreeFeatureType::BasicMerkNode;
 
@@ -1576,10 +1602,7 @@ mod tests {
         match result {
             Err(Error::InvalidInputError(msg)) => {
                 assert!(
-                    msg.contains(
-                        "non-counted elements may only be inserted into \
-                                  count-bearing trees"
-                    ),
+                    msg.contains("non-provable count-bearing trees"),
                     "expected non-counted-wrong-destination error, got: {msg}"
                 );
             }
@@ -1594,8 +1617,8 @@ mod tests {
             "rejected op must not push to batch_operations vec"
         );
 
-        // Sanity: same wrapped element with a count-bearing feature
-        // type SUCCEEDS (the guard only fires on non-count-bearing).
+        // Sanity: the same wrapped element with a non-provable count-bearing
+        // feature succeeds.
         let result_ok = wrapped
             .insert_count_indexed_subtree_into_batch_operations(
                 key,
@@ -1612,6 +1635,30 @@ mod tests {
             "non-counted cidx into count-bearing tree must be accepted, got: {:?}",
             result_ok
         );
+
+        for feature_type in [
+            crate::TreeFeatureType::ProvableCountedMerkNode(0),
+            crate::TreeFeatureType::ProvableCountedSummedMerkNode(0, 0),
+            crate::TreeFeatureType::ProvableCountedAndProvableSummedMerkNode(0, 0),
+        ] {
+            let mut rejected_ops: Vec<BatchEntry<&[u8]>> = Vec::new();
+            let result = wrapped
+                .insert_count_indexed_subtree_into_batch_operations(
+                    key,
+                    NULL_HASH,
+                    NULL_HASH,
+                    false,
+                    &mut rejected_ops,
+                    feature_type,
+                    grove_version,
+                )
+                .unwrap();
+            assert!(
+                matches!(result, Err(Error::InvalidInputError(_))),
+                "provable count feature accepted NonCounted child: {feature_type:?}"
+            );
+            assert!(rejected_ops.is_empty());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- closes all nine validated indexed-tree findings from the Codex Security review of #657
- validates stored tree authority and makes secondary-index maintenance atomic
- adds relational verification and corrects specialized child-policy and numeric-boundary handling

## Root causes and fixes

- Batch authority and cleanup: validate caller-supplied tree types against stored elements, cover every indexed-tree variant and bare references, and apply count-index secondary changes atomically.
- Verification: verify PSIT and PCPSIT secondary keys, row membership, and payload relationships rather than only comparing aggregate roots.
- Specialized operations: use Euclidean division for negative averages, bind commitment-tree children to the empty commitment state root, reject `BigSumTree` at the signed 64-bit boundary, and enforce `NonCounted` parent policy for specialized indexed subtrees.

## Validation

- `cargo test -p grovedb indexed_tree` — 239 passed
- `cargo test -p grovedb-merk insert_count_indexed_subtree` — 6 passed
- `cargo test -p grovedb-element indexed::sort_keys` — 12 passed
- focused regression tests for the cross-cutting security cases — 6 passed
- `cargo clippy -p grovedb-element -p grovedb-merk -p grovedb -- -D warnings`
- `cargo fmt --all -- --check`

Rebased and conflict-tested against feature commit `47cff3ad`. This remains a security-hardening follow-up to #657 and intentionally targets its feature branch.
