### PR TITLE
ci: build all targets, and fix two benches that no longer compile

### DIFF
--- a/.github/workflows/grovedb.yml
+++ b/.github/workflows/grovedb.yml
@@ -121,6 +121,15 @@ jobs:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: sccache
         run: cargo clippy --workspace --all-features -- -D warnings
+      # Benches and other non-lib targets are not built by the clippy or test
+      # steps, so a rename can leave a registered bench target uncompilable
+      # without any job noticing. Type-check every target (no -D warnings
+      # here — this step is about compile breakage, not lints).
+      - name: Check all targets build
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
+        run: cargo check --workspace --all-features --all-targets
       - name: Check verify feature
         env:
           SCCACHE_GHA_ENABLED: "true"

--- a/grovedb-merkle-mountain-range/benches/mmr_benchmark.rs
+++ b/grovedb-merkle-mountain-range/benches/mmr_benchmark.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 
 use criterion::{BenchmarkId, Criterion};
 use grovedb_merkle_mountain_range::{MMRStoreReadOps, MemStore, MmrNode, MMR};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 
 /// Create an MmrNode leaf from an integer (for benchmarking).
 fn leaf_from_u32(i: u32) -> MmrNode {

--- a/merk/benches/branch_queries.rs
+++ b/merk/benches/branch_queries.rs
@@ -233,7 +233,21 @@ fn get_key_from_node(node: &Node) -> Option<Vec<u8>> {
         Node::KVRefValueHash(key, ..) => Some(key.clone()),
         Node::KVCount(key, ..) => Some(key.clone()),
         Node::KVRefValueHashCount(key, ..) => Some(key.clone()),
-        Node::Hash(_) | Node::KVHash(_) | Node::KVHashCount(..) | Node::HashWithCount(..) => None,
+        Node::KVSum(key, ..) => Some(key.clone()),
+        Node::KVRefValueHashSum(key, ..) => Some(key.clone()),
+        Node::KVCountSum(key, ..) => Some(key.clone()),
+        Node::KVRefValueHashCountSum(key, ..) => Some(key.clone()),
+        Node::KVDigestSum(key, ..) => Some(key.clone()),
+        Node::KVDigestCountSum(key, ..) => Some(key.clone()),
+        // Hash-only nodes carry no key.
+        Node::Hash(_)
+        | Node::KVHash(_)
+        | Node::KVHashCount(..)
+        | Node::HashWithCount(..)
+        | Node::KVHashSum(..)
+        | Node::HashWithSum(..)
+        | Node::KVHashCountSum(..)
+        | Node::HashWithCountAndSum(..) => None,
     }
 }
 


### PR DESCRIPTION
## Problem

No CI job builds bench targets. The test job builds lib/test targets; the clippy job runs `--workspace --all-features` without `--all-targets`. A registered bench can therefore stop compiling and stay broken indefinitely with every check green.

Two benches on `develop` are currently in exactly that state:

| Bench | Breakage |
|---|---|
| `grovedb-merkle-mountain-range/benches/mmr_benchmark.rs` | imports `rand::seq::SliceRandom` for `choose`, which moved to the `IndexedRandom` trait in rand 0.9 |
| `merk/benches/branch_queries.rs` | exhaustive `match` on `Node` missing seven variants added since it was written |

Reproduce on `develop`:

```bash
cargo check --workspace --all-features --all-targets
```

## Fix

Repairs both benches and adds a `cargo check --workspace --all-features --all-targets` step to the lint job so it cannot regress silently.

Deliberately **no `-D warnings`** on the new step — it exists to catch compile breakage, and lints are already enforced by the adjacent clippy step. Keeping it warning-tolerant means it won't start failing on unrelated lint drift in bench code.

## Notes

Split out of #657, which surfaced both breakages (it renamed a function and left its own bench uncompilable, which nothing caught). That PR should not carry unrelated CI and bench repairs, and these fix `develop` today rather than depending on the feature landing.

Verified: `cargo check --workspace --all-features --all-targets` is clean with this change and fails without the bench repairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved proof analysis to correctly identify keys across additional aggregated and sum-based node types.
  - Reduced incorrect key extraction from hash-only proof nodes.

- **Tests**
  - Added a comprehensive workspace compilation check covering all features and build targets, helping detect compilation issues earlier.

- **Chores**
  - Updated benchmark randomness utilities for compatibility with the current Rust ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->