### PR TITLE
test: speed up commitment-tree Sinsemilla tests in CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,26 @@ num_cpus = "1.17.0"
 axum = { version = "0.8", features = ["macros"] }
 tokio-util = "0.7.17"
 tower-http = { version = "0.6.8", features = ["fs"] }
+
+# Sinsemilla hashing (used by grovedb-commitment-tree) is Pallas-curve
+# arithmetic, which is orders of magnitude slower without optimization.
+# Optimizing just these dependencies keeps debug/test builds of workspace
+# crates fully debuggable while making commitment-tree tests run in seconds
+# instead of minutes. Applies to dev/test profiles only; release is unaffected.
+[profile.dev.package.pasta_curves]
+opt-level = 3
+
+[profile.dev.package.halo2_gadgets]
+opt-level = 3
+
+[profile.dev.package.halo2_proofs]
+opt-level = 3
+
+[profile.dev.package.sinsemilla]
+opt-level = 3
+
+[profile.dev.package.orchard]
+opt-level = 3
+
+[profile.dev.package.incrementalmerkletree]
+opt-level = 3

--- a/grovedb-commitment-tree/src/commitment_frontier/tests.rs
+++ b/grovedb-commitment-tree/src/commitment_frontier/tests.rs
@@ -101,7 +101,6 @@ fn test_serialize_roundtrip() {
 }
 
 #[test]
-#[ignore] // ~60s: runs 1000 Sinsemilla appends; use `cargo test -- --ignored`
 fn test_serialize_roundtrip_with_many_leaves() {
     let mut f = CommitmentFrontier::new();
     for i in 0..1000u64 {

--- a/grovedb-commitment-tree/src/commitment_tree/tests.rs
+++ b/grovedb-commitment-tree/src/commitment_tree/tests.rs
@@ -657,7 +657,6 @@ mod storage_tests {
     }
 
     #[test]
-    #[ignore] // ~60s: runs 500 Sinsemilla appends; use `cargo test -- --ignored`
     fn test_roundtrip_with_many_leaves() {
         let ctx = MockDataStorageContext::new();
         let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
@@ -1203,18 +1202,13 @@ mod storage_tests {
             .collect()
     }
 
-    /// Byte-for-byte equivalence: for the same input sequence, `append_many_raw`
-    /// must produce the same `CommitmentFrontier` state and the same
-    /// BulkAppendTree state root as N × `append_raw`. This is the core
-    /// invariant — if it ever fails, batched callers can produce anchors that
-    /// don't match what the per-leaf path would have produced.
-    #[test]
-    fn append_many_raw_byte_for_byte_matches_per_leaf() {
-        // 0 / 1 / 2 / 3 cover edge cases around the very-empty and pre-compaction
-        // shapes; 100 spans the buffer mid-range; 2048 fills exactly one epoch
-        // (with TEST_CHUNK_POWER=1 we hit MANY compactions, exercising the cache
-        // + MMR path); 10_000 spans several epochs at meaningful scale.
-        for n in [0u64, 1, 2, 3, 100, 2048, 10_000] {
+    /// Assert byte-for-byte equivalence between N × `append_raw` and a single
+    /// `append_many_raw` call for the given sizes: same `CommitmentFrontier`
+    /// state and same BulkAppendTree state root. This is the core invariant —
+    /// if it ever fails, batched callers can produce anchors that don't match
+    /// what the per-leaf path would have produced.
+    fn assert_append_many_matches_per_leaf(sizes: &[u64]) {
+        for &n in sizes {
             let entries = make_entries(n);
             let a = build_via_per_leaf_append(&entries);
             let b = build_via_append_many_raw(entries);
@@ -1246,6 +1240,24 @@ mod storage_tests {
             );
             assert_eq!(a.total_count(), n, "tree should hold exactly N={} items", n);
         }
+    }
+
+    /// Fast sizes: 0 / 1 / 2 / 3 cover edge cases around the very-empty and
+    /// pre-compaction shapes; 100 spans the buffer mid-range. The per-leaf
+    /// reference path is O(N) depth-32 Sinsemilla walks, so larger sizes live
+    /// in the `#[ignore]`d companion test below.
+    #[test]
+    fn append_many_raw_byte_for_byte_matches_per_leaf() {
+        assert_append_many_matches_per_leaf(&[0, 1, 2, 3, 100]);
+    }
+
+    /// Large sizes: 2048 fills exactly one epoch (with TEST_CHUNK_POWER=1 we
+    /// hit MANY compactions, exercising the cache + MMR path); 10_000 spans
+    /// several epochs at meaningful scale.
+    #[test]
+    #[ignore] // minutes in debug: ~12k eager Sinsemilla appends; runs in the Slow Tests CI workflow via `cargo test -- --ignored`
+    fn append_many_raw_byte_for_byte_matches_per_leaf_large() {
+        assert_append_many_matches_per_leaf(&[2048, 10_000]);
     }
 
     /// `CommitmentFrontier::append_no_root` is just the carry-chain part of the

--- a/grovedb-commitment-tree/src/commitment_tree/tests.rs
+++ b/grovedb-commitment-tree/src/commitment_tree/tests.rs
@@ -1242,18 +1242,19 @@ mod storage_tests {
         }
     }
 
-    /// Fast sizes: 0 / 1 / 2 / 3 cover edge cases around the very-empty and
-    /// pre-compaction shapes; 100 spans the buffer mid-range. The per-leaf
-    /// reference path is O(N) depth-32 Sinsemilla walks, so larger sizes live
-    /// in the `#[ignore]`d companion test below.
+    /// Fast sizes (with TEST_CHUNK_POWER=1, epoch_size=2): 0 / 1 cover the
+    /// very-empty shapes, 2 fills exactly one epoch, 3 lands one past the
+    /// first epoch boundary, and 100 spans 50 epochs of repeated compaction.
+    /// The per-leaf reference path is O(N) depth-32 Sinsemilla walks, so
+    /// larger sizes live in the `#[ignore]`d companion test below.
     #[test]
     fn append_many_raw_byte_for_byte_matches_per_leaf() {
         assert_append_many_matches_per_leaf(&[0, 1, 2, 3, 100]);
     }
 
-    /// Large sizes: 2048 fills exactly one epoch (with TEST_CHUNK_POWER=1 we
-    /// hit MANY compactions, exercising the cache + MMR path); 10_000 spans
-    /// several epochs at meaningful scale.
+    /// Large sizes (with TEST_CHUNK_POWER=1, epoch_size=2): 2048 spans 1024
+    /// epochs and 10_000 spans 5000, hammering the compaction cache + MMR
+    /// path at meaningful scale.
     #[test]
     #[ignore] // minutes in debug: ~12k eager Sinsemilla appends; runs in the Slow Tests CI workflow via `cargo test -- --ignored`
     fn append_many_raw_byte_for_byte_matches_per_leaf_large() {


### PR DESCRIPTION
## Problem

`commitment_tree::tests::storage_tests::append_many_raw_byte_for_byte_matches_per_leaf` took **4+ minutes** in CI (nextest flagged it SLOW at 60/120/180/240s). Its per-leaf reference path calls `append_raw` once per leaf, and each append does an eager depth-32 Sinsemilla root walk — Pallas-curve arithmetic — for N up to 10,000, in an unoptimized debug build with llvm-cov instrumentation on top.

## Changes

1. **Optimize the curve crates in dev/test builds**: added `[profile.dev.package.*] opt-level = 3` to the workspace `Cargo.toml` for `pasta_curves`, `halo2_gadgets`, `halo2_proofs`, `sinsemilla`, `orchard`, and `incrementalmerkletree`. Workspace crates stay unoptimized and debuggable; release builds are unaffected. This is a ~20–50× speedup for everything touching Sinsemilla.

2. **Split the equivalence test**: N ∈ {0, 1, 2, 3, 100} stays in the default suite (~0.5s); N ∈ {2048, 10,000} moved to `append_many_raw_byte_for_byte_matches_per_leaf_large` marked `#[ignore]` (~46s even with optimized deps). The existing **Slow Tests** workflow already runs `--ignored` tests for this crate on commitment-tree PRs, so the large sizes keep CI coverage — same precedent as the other Sinsemilla-heavy ignored tests.

3. **Un-ignored** `test_roundtrip_with_many_leaves` and `test_serialize_roundtrip_with_many_leaves` (previously `#[ignore]` with "~60s" comments): with the profile change they run in under a second, so they're back in the default suite.

## Result

Full `grovedb-commitment-tree` suite: **4+ minutes → ~4 seconds** (58 passed, 1 ignored → covered by Slow Tests workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled additional commitment frontier and commitment tree round-trip tests in the standard test suite.
  * Added broader coverage for batched append equivalence, while retaining a separate extended test for larger scenarios.

* **Performance**
  * Improved development and test build performance for selected commitment-tree components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->