### PR TITLE
fix: verify-only access to indexed-axis proofs + bind subset lower layers

### DIFF
--- a/grovedb/src/operations/proof/indexed_axis/axis_api.rs
+++ b/grovedb/src/operations/proof/indexed_axis/axis_api.rs
@@ -3,13 +3,18 @@
 //!
 //! Each wrapper pins the [`IndexAxis`] and forwards; no logic lives here.
 
+#[cfg(feature = "minimal")]
 use grovedb_costs::CostResult;
 use grovedb_element::indexed::IndexAxis;
 use grovedb_merk::proofs::Query as MerkQuery;
+#[cfg(feature = "minimal")]
 use grovedb_path::SubtreePath;
+#[cfg(feature = "minimal")]
 use grovedb_version::version::GroveVersion;
 
-use crate::{Error, GroveDb, TransactionArg};
+#[cfg(feature = "minimal")]
+use crate::TransactionArg;
+use crate::{Error, GroveDb};
 
 use super::{IndexedAxisAggregateResult, IndexedAxisPaginatedResult, IndexedAxisQueryResult};
 
@@ -18,6 +23,7 @@ impl GroveDb {
 
     /// Prove the top-`k` entries of the count axis. Thin wrapper over
     /// [`Self::prove_indexed_axis_top_k`] with `axis = Count`.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_count_top_k<'b, B, P>(
         &self,
         path: P,
@@ -41,6 +47,7 @@ impl GroveDb {
     }
 
     /// Prove an offset-paginated top-`k` window on the count axis.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_count_top_k_paginated<'b, B, P>(
         &self,
         path: P,
@@ -66,6 +73,7 @@ impl GroveDb {
     }
 
     /// Prove an arbitrary query against the count-axis secondary.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_count_query<'b, B, P>(
         &self,
         path: P,
@@ -90,6 +98,7 @@ impl GroveDb {
 
     /// Prove the aggregate count of entries whose `count_value` is in
     /// `[lo_count, hi_count]`.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_count_range_aggregate<'b, B, P>(
         &self,
         path: P,
@@ -181,6 +190,7 @@ impl GroveDb {
     // ---------- sum axis ----------
 
     /// Prove the top-`k` entries of the sum axis.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_sum_top_k<'b, B, P>(
         &self,
         path: P,
@@ -207,6 +217,7 @@ impl GroveDb {
     /// Note: the secondary is a `ProvableSumTree`, which has no
     /// count-bound offset primitive, so the proof size is
     /// O(offset + k). Use sparingly with large offsets.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_sum_top_k_paginated<'b, B, P>(
         &self,
         path: P,
@@ -232,6 +243,7 @@ impl GroveDb {
     }
 
     /// Prove an arbitrary query against the sum-axis secondary.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_sum_query<'b, B, P>(
         &self,
         path: P,
@@ -256,6 +268,7 @@ impl GroveDb {
 
     /// Prove the aggregate sum of entries whose `sum_value` is in
     /// `[lo_sum, hi_sum]`.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_sum_range_aggregate<'b, B, P>(
         &self,
         path: P,
@@ -349,6 +362,7 @@ impl GroveDb {
     /// Prove the top-`k` entries of the avg axis. PCPSIT-only. No
     /// aggregate variant exists — averaging an average over a range is
     /// not closed-form.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_avg_top_k<'b, B, P>(
         &self,
         path: P,
@@ -372,6 +386,7 @@ impl GroveDb {
     }
 
     /// Prove an offset-paginated top-`k` window on the avg axis.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_avg_top_k_paginated<'b, B, P>(
         &self,
         path: P,
@@ -397,6 +412,7 @@ impl GroveDb {
     }
 
     /// Prove an arbitrary query against the avg-axis secondary.
+    #[cfg(feature = "minimal")]
     pub fn prove_indexed_avg_query<'b, B, P>(
         &self,
         path: P,

--- a/grovedb/src/operations/proof/indexed_axis/mod.rs
+++ b/grovedb/src/operations/proof/indexed_axis/mod.rs
@@ -63,6 +63,7 @@
 
 mod axis_api;
 mod envelope;
+#[cfg(feature = "minimal")]
 mod generate;
 mod verify;
 

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -10,7 +10,11 @@ mod aggregate_count_and_sum;
 mod aggregate_sum;
 #[cfg(feature = "minimal")]
 mod generate;
-#[cfg(feature = "minimal")]
+// The prover lives in `indexed_axis::generate` and is `minimal`-gated there;
+// the envelope types and verification entry points must be reachable from a
+// verifier-only build (Dash Platform's `drive` crate compiles its
+// proof-verification layer with `--no-default-features --features verify`).
+#[cfg(any(feature = "minimal", feature = "verify"))]
 pub mod indexed_axis;
 /// Utility functions for proof display and conversion.
 pub mod util;

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -675,6 +675,35 @@ impl GroveDb {
         }
     }
 
+    /// Derive a Merk layer's root hash without reporting any of its rows.
+    ///
+    /// Used when a subset verification stops at a tree ELEMENT that the proof
+    /// descended into: the parent still has to bind the element bytes with
+    /// `combine_hash(H(value), child_root)`, but none of the child layer's rows
+    /// belong in this query's result set. An empty query walks the proof for
+    /// its root and matches nothing, so no row is produced and no limit is
+    /// consumed.
+    ///
+    /// The layer's own `lower_layers` are deliberately not descended into. The
+    /// root returned here is computed from this layer's nodes alone, whose
+    /// value hashes already commit to everything beneath them; the deeper
+    /// layers exist only to authenticate rows that are not being reported.
+    fn merk_layer_root_hash(
+        merk_proof_bytes: &[u8],
+        query: &PathQuery,
+    ) -> Result<CryptoHash, Error> {
+        let (root_hash, _) = Query::new()
+            .execute_proof(merk_proof_bytes, None, true, PROOF_VERSION_LATEST)
+            .unwrap()
+            .map_err(|e| {
+                Error::InvalidProof(
+                    query.clone(),
+                    format!("Invalid V1 lower layer proof (root derivation): {}", e),
+                )
+            })?;
+        Ok(root_hash)
+    }
+
     /// Takes the layer's Merk proof BYTES and its lower layers separately
     /// rather than a `&LayerProof`.
     ///
@@ -1014,23 +1043,44 @@ impl GroveDb {
                             | Element::DenseAppendOnlyFixedSizeTree(..) => {
                                 path.push(key);
                                 *last_parent_tree_type = element.tree_feature_type();
-                                if query.query_items_at_path(&path, grove_version)?.is_none() {
-                                    // Query targets the tree itself, not its
-                                    // contents — but a lower layer was still
-                                    // supplied, which an honest prover never
-                                    // does (every `lower_layers.insert` site is
-                                    // gated on there being a subquery for this
-                                    // key). Pushing the value here would skip
-                                    // both binding mechanisms: the
-                                    // `combine_hash` chain check below (which
-                                    // needs a query at the lower path) and the
-                                    // `child_hash_verified` requirement applied
-                                    // on the no-lower-layer path. Since a
-                                    // `KVValueHash` node commits only to
-                                    // (key, value_hash), accepting it would let
-                                    // a prover attach a dummy lower layer and
-                                    // substitute forged element bytes under a
-                                    // genuine root hash. Fail closed.
+                                // Does the current query ask for anything BELOW
+                                // this tree, or only for the tree element
+                                // itself?
+                                //
+                                // "Only the element itself" while the proof
+                                // still carries a lower layer is the ordinary
+                                // shape of a SUBSET verification: the proof was
+                                // generated for a wider query that descended
+                                // here, and is now being re-verified against a
+                                // narrower one that stops at the tree. Dash
+                                // Platform does exactly this to read a
+                                // CommitmentTree's total note count out of the
+                                // note-fetch proof it already has.
+                                //
+                                // Either way the element bytes must stay bound
+                                // to the parent-committed `value_hash`: a
+                                // `KVValueHash`-family node hashes only
+                                // (key, value_hash), so reporting `value`
+                                // unchecked would let a prover attach a dummy
+                                // lower layer and substitute forged element
+                                // bytes under a genuine root hash. The
+                                // `combine_hash` chain check below is what binds
+                                // it, and it needs the lower layer's root — so
+                                // the lower layer is consumed for its root hash
+                                // in BOTH cases. Only the reporting differs:
+                                // with no query below, none of the lower layer's
+                                // rows belong in this query's result set, so the
+                                // tree element itself is reported instead.
+                                let has_query_below =
+                                    query.query_items_at_path(&path, grove_version)?.is_some();
+
+                                if !has_query_below && options.verify_proof_succinctness {
+                                    // Succinct mode demands the proof carry
+                                    // nothing beyond what the query needs, and
+                                    // an honest prover never emits this layer
+                                    // for this query (every `lower_layers.insert`
+                                    // site is gated on there being a subquery
+                                    // for the key). Reject as extra data.
                                     return Err(Error::InvalidProof(
                                         query.clone(),
                                         format!(
@@ -1040,15 +1090,19 @@ impl GroveDb {
                                             hex::encode(key),
                                         ),
                                     ));
-                                } else {
+                                }
+
+                                {
                                     // Known limitation: this parent tree result
                                     // is pushed without decrementing limit_left.
                                     // Will be addressed by per-level limits
                                     // redesign.
-                                    if query.should_add_parent_tree_at_path(
-                                        current_path,
-                                        grove_version,
-                                    )? {
+                                    if has_query_below
+                                        && query.should_add_parent_tree_at_path(
+                                            current_path,
+                                            grove_version,
+                                        )?
+                                    {
                                         let path_key_optional_value =
                                             ProvedPathKeyOptionalValue::from_proved_key_value(
                                                 path.iter().map(|p| p.to_vec()).collect(),
@@ -1060,23 +1114,34 @@ impl GroveDb {
                                         );
                                     }
 
-                                    // Dispatch based on lower layer proof type
+                                    // Dispatch based on lower layer proof type.
+                                    // `has_query_below == false` derives the
+                                    // layer's root WITHOUT reporting any of its
+                                    // contents — every lower-layer flavour
+                                    // computes its root independently of the
+                                    // query, which only ever selects rows.
                                     let lower_hash = match &lower_layer.merk_proof {
                                         ProofBytes::Merk(_) => {
                                             // Standard Merk subtree - recurse
-                                            Self::verify_layer_proof_v1(
-                                                Self::merk_bytes_of_layer(lower_layer, query)?,
-                                                &lower_layer.lower_layers,
-                                                prove_options,
-                                                query,
-                                                limit_left,
-                                                &path,
-                                                result,
-                                                last_parent_tree_type,
-                                                options,
-                                                current_depth + 1,
-                                                grove_version,
-                                            )?
+                                            let merk_bytes =
+                                                Self::merk_bytes_of_layer(lower_layer, query)?;
+                                            if has_query_below {
+                                                Self::verify_layer_proof_v1(
+                                                    merk_bytes,
+                                                    &lower_layer.lower_layers,
+                                                    prove_options,
+                                                    query,
+                                                    limit_left,
+                                                    &path,
+                                                    result,
+                                                    last_parent_tree_type,
+                                                    options,
+                                                    current_depth + 1,
+                                                    grove_version,
+                                                )?
+                                            } else {
+                                                Self::merk_layer_root_hash(merk_bytes, query)?
+                                            }
                                         }
                                         ProofBytes::MMR(mmr_bytes) => Self::verify_mmr_lower_layer(
                                             mmr_bytes,
@@ -1085,6 +1150,7 @@ impl GroveDb {
                                             limit_left,
                                             result,
                                             query,
+                                            has_query_below,
                                             grove_version,
                                         )?,
                                         ProofBytes::BulkAppendTree(bulk_bytes) => {
@@ -1095,6 +1161,7 @@ impl GroveDb {
                                                 limit_left,
                                                 result,
                                                 query,
+                                                has_query_below,
                                                 grove_version,
                                             )?
                                         }
@@ -1106,6 +1173,7 @@ impl GroveDb {
                                                 limit_left,
                                                 result,
                                                 query,
+                                                has_query_below,
                                                 grove_version,
                                             )?
                                         }
@@ -1117,6 +1185,7 @@ impl GroveDb {
                                                 limit_left,
                                                 result,
                                                 query,
+                                                has_query_below,
                                                 grove_version,
                                             )?
                                         }
@@ -1154,6 +1223,33 @@ impl GroveDb {
                                             ),
                                         ));
                                     }
+
+                                    if !has_query_below {
+                                        // The tree element itself is the
+                                        // result, now bound by the
+                                        // `combine_hash` check above. Report it
+                                        // under the PARENT path (not the path
+                                        // we pushed the key onto for the root
+                                        // derivation), matching query_raw and
+                                        // the no-lower-layer terminal arm —
+                                        // including the key would make
+                                        // `(path, key)` lookups miss.
+                                        let parent_path: Vec<Vec<u8>> =
+                                            current_path.iter().map(|p| p.to_vec()).collect();
+                                        let path_key_optional_value =
+                                            ProvedPathKeyOptionalValue::from_proved_key_value(
+                                                parent_path,
+                                                proved_key_value,
+                                            );
+                                        result.push(
+                                            path_key_optional_value
+                                                .try_into_versioned(grove_version)?,
+                                        );
+                                        limit_left
+                                            .iter_mut()
+                                            .for_each(|limit| *limit = limit.saturating_sub(1));
+                                    }
+
                                     if limit_left == &Some(0) {
                                         break;
                                     }
@@ -1346,6 +1442,7 @@ impl GroveDb {
     /// Returns the computed MMR root hash, which the caller uses as the
     /// child hash for Merk authentication (`combine_hash(value_hash ||
     /// mmr_root)`).
+    #[allow(clippy::too_many_arguments)]
     fn verify_mmr_lower_layer<T>(
         mmr_bytes: &[u8],
         element: &Element,
@@ -1353,6 +1450,7 @@ impl GroveDb {
         limit_left: &mut Option<u16>,
         result: &mut Vec<T>,
         query: &PathQuery,
+        report_contents: bool,
         grove_version: &GroveVersion,
     ) -> Result<CryptoHash, Error>
     where
@@ -1405,6 +1503,13 @@ impl GroveDb {
         let (mmr_root, verified_leaves) = mmr_proof
             .verify_and_get_root()
             .map_err(|e| Error::InvalidProof(query.clone(), format!("{}", e)))?;
+
+        // Root only: the caller is binding the parent element and does not
+        // report this layer's leaves, so there is no query at this path to
+        // check completeness/succinctness against.
+        if !report_contents {
+            return Ok(mmr_root);
+        }
 
         // Get the sub-query items for this path to enforce succinctness.
         let sub_query =
@@ -1477,6 +1582,7 @@ impl GroveDb {
     /// For both `BulkAppendTree` and `CommitmentTree` elements: verifies
     /// internal consistency and returns the computed state_root as the lower
     /// hash (authenticated via child Merk hash).
+    #[allow(clippy::too_many_arguments)]
     fn verify_bulk_append_lower_layer<T>(
         bulk_bytes: &[u8],
         element: &Element,
@@ -1484,6 +1590,7 @@ impl GroveDb {
         limit_left: &mut Option<u16>,
         result: &mut Vec<T>,
         query: &PathQuery,
+        report_contents: bool,
         grove_version: &GroveVersion,
     ) -> Result<CryptoHash, Error>
     where
@@ -1508,6 +1615,13 @@ impl GroveDb {
         let (bulk_state_root, proof_result) = bulk_proof
             .verify_and_compute_root(element_height, element_total_count)
             .map_err(|e| Error::InvalidProof(query.clone(), format!("{}", e)))?;
+
+        // Root only: the caller is binding the parent element and does not
+        // report this layer's entries, so there is no query at this path to
+        // extract a position range from.
+        if !report_contents {
+            return Ok(bulk_state_root);
+        }
 
         // Get the query range from the path query to extract matching values
         let sub_query =
@@ -1589,6 +1703,7 @@ impl GroveDb {
     /// Verifies the BulkAppendTree proof to get `bulk_state_root`, then returns
     /// `blake3("ct_state" || sinsemilla_root || bulk_state_root)` as the
     /// authenticated child hash.
+    #[allow(clippy::too_many_arguments)]
     fn verify_commitment_tree_lower_layer<T>(
         ct_bytes: &[u8],
         element: &Element,
@@ -1596,6 +1711,7 @@ impl GroveDb {
         limit_left: &mut Option<u16>,
         result: &mut Vec<T>,
         query: &PathQuery,
+        report_contents: bool,
         grove_version: &GroveVersion,
     ) -> Result<CryptoHash, Error>
     where
@@ -1622,6 +1738,7 @@ impl GroveDb {
             limit_left,
             result,
             query,
+            report_contents,
             grove_version,
         )?;
 
@@ -1638,6 +1755,7 @@ impl GroveDb {
 
     /// Verify a DenseAppendOnlyFixedSizeTree lower layer proof and add results.
     /// Returns NULL_HASH since DenseTree has no child Merk.
+    #[allow(clippy::too_many_arguments)]
     fn verify_dense_tree_lower_layer<T>(
         dense_bytes: &[u8],
         element: &Element,
@@ -1645,6 +1763,7 @@ impl GroveDb {
         limit_left: &mut Option<u16>,
         result: &mut Vec<T>,
         query: &PathQuery,
+        report_contents: bool,
         grove_version: &GroveVersion,
     ) -> Result<CryptoHash, Error>
     where
@@ -1665,6 +1784,16 @@ impl GroveDb {
         let dense_proof =
             grovedb_dense_fixed_sized_merkle_tree::DenseTreeProof::decode_from_slice(dense_bytes)
                 .map_err(|e| Error::CorruptedData(format!("{}", e)))?;
+
+        // Root only: the caller is binding the parent element and does not
+        // report this layer's entries, so there is no query at this path to
+        // check completeness/soundness against.
+        if !report_contents {
+            let (computed_root, _entries): ([u8; 32], Vec<(u16, Vec<u8>)>) = dense_proof
+                .verify_and_get_root(element_height, element_count)
+                .map_err(|e| Error::InvalidProof(query.clone(), format!("{}", e)))?;
+            return Ok(computed_root);
+        }
 
         // Get the sub-query items for this path to build a query for
         // verify_for_query, which enforces both completeness and soundness.

--- a/grovedb/src/tests/commitment_tree_tests.rs
+++ b/grovedb/src/tests/commitment_tree_tests.rs
@@ -2739,3 +2739,122 @@ fn replace_subtree_root_rejects_non_tree_element() {
         "expected InvalidInput for non-tree element, got {result:?}"
     );
 }
+
+/// Regression (Dash Platform shielded-notes shape): the note-count query.
+///
+/// Platform fetches shielded notes with one proof that subqueries INTO the
+/// `CommitmentTree`, then extracts the on-chain total note count from those
+/// SAME proof bytes by subset-verifying a single-key `PathQuery` that targets
+/// the `CommitmentTree` element itself — no subquery, limit 1 — and reading
+/// `Element::CommitmentTree(total_count, ..)`.
+///
+/// The proof therefore carries a lower layer at the tree's key while the
+/// count query has nothing below it. That must verify, and the element must
+/// come back bound to the parent-committed value hash via the lower layer's
+/// derived state root.
+#[test]
+fn test_commitment_tree_element_count_subset_query_against_note_fetch_proof() {
+    let grove_version = GroveVersion::latest();
+    let db = make_empty_grovedb();
+    let chunk_power: u8 = 2;
+
+    db.insert(
+        EMPTY_PATH,
+        b"root",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert root tree");
+
+    db.insert(
+        &[b"root"],
+        b"pool",
+        Element::empty_commitment_tree(chunk_power).expect("valid chunk_power"),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert commitment tree");
+
+    // 6 notes: one full chunk (4) plus 2 buffered.
+    const NOTE_COUNT: u64 = 6;
+    for i in 0..NOTE_COUNT as u8 {
+        db.commitment_tree_insert(
+            &[b"root"],
+            b"pool",
+            test_cmx(i),
+            test_rho(i),
+            test_cv_net(i),
+            test_ciphertext(i),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("commitment tree insert");
+    }
+
+    // The note-fetch proof: descends into the CommitmentTree.
+    let mut inner_query = Query::new();
+    inner_query.insert_range_inclusive(0u64.to_be_bytes().to_vec()..=5u64.to_be_bytes().to_vec());
+    let notes_query = PathQuery {
+        path: vec![b"root".to_vec()],
+        query: SizedQuery {
+            query: Query {
+                items: vec![QueryItem::Key(b"pool".to_vec())],
+                default_subquery_branch: SubqueryBranch {
+                    subquery_path: None,
+                    subquery: Some(inner_query.into()),
+                },
+                left_to_right: true,
+                conditional_subquery_branches: None,
+                add_parent_tree_on_subquery: false,
+            },
+            limit: None,
+            offset: None,
+        },
+    };
+
+    let proof_bytes = db
+        .prove_query(&notes_query, None, grove_version)
+        .unwrap()
+        .expect("generate note-fetch proof");
+
+    // The count query: the CommitmentTree element itself, no subquery.
+    let count_query = PathQuery {
+        path: vec![b"root".to_vec()],
+        query: SizedQuery {
+            query: Query::new_single_key(b"pool".to_vec()),
+            limit: Some(1),
+            offset: None,
+        },
+    };
+
+    let (count_root_hash, count_results) =
+        GroveDb::verify_subset_query(&proof_bytes, &count_query, grove_version)
+            .expect("count query must subset-verify against the note-fetch proof");
+
+    let expected_root = db.grove_db.root_hash(None, grove_version).unwrap().unwrap();
+    assert_eq!(
+        count_root_hash, expected_root,
+        "the count sub-proof must derive the same root as the note-fetch proof"
+    );
+    assert_eq!(count_results.len(), 1, "exactly the CommitmentTree element");
+
+    let (path, key, element) = &count_results[0];
+    assert_eq!(path, &vec![b"root".to_vec()]);
+    assert_eq!(key, b"pool");
+    match element.as_ref().expect("element present") {
+        Element::CommitmentTree(total_count, height, _) => {
+            assert_eq!(
+                *total_count, NOTE_COUNT,
+                "total_count must be the on-chain note count"
+            );
+            assert_eq!(*height, chunk_power);
+        }
+        other => panic!("expected CommitmentTree element, got {:?}", other),
+    }
+}

--- a/grovedb/src/tests/succinctness_gap_test.rs
+++ b/grovedb/src/tests/succinctness_gap_test.rs
@@ -10,7 +10,7 @@
 use grovedb_version::version::{v1::GROVE_V1, GroveVersion};
 
 use crate::{
-    operations::proof::GroveDBProof,
+    operations::proof::{GroveDBProof, LayerProof, ProofBytes},
     tests::{make_deep_tree, TEST_LEAF},
     GroveDb, PathQuery, Query,
 };
@@ -260,5 +260,170 @@ fn test_missing_lower_layer_for_non_empty_tree_is_rejected_v0() {
     assert!(
         result.is_err(),
         "V0: verify_subset_query must reject proof missing a non-empty subtree's lower layer"
+    );
+}
+
+/// Regression: a subset verification whose query stops at a tree ELEMENT must
+/// still verify against a proof that descended INTO that tree.
+///
+/// This is the ordinary shape of `verify_subset_query`: a wide proof is
+/// generated once, then re-verified against a narrower query. Dash Platform
+/// reads a shielded `CommitmentTree`'s total note count exactly this way —
+/// single-key query, no subquery, against the note-fetch proof it already
+/// holds.
+///
+/// The tree element is the only result, and it must come back bound: the
+/// verifier derives the lower layer's root and checks
+/// `combine_hash(H(value), child_root)` against the parent-committed value
+/// hash, without reporting any of the lower layer's rows.
+#[test]
+fn test_subset_query_for_tree_element_itself_against_descending_proof() {
+    let grove_version = GroveVersion::latest();
+    let db = make_deep_tree(grove_version);
+    let expected_root = db.root_hash(None, grove_version).unwrap().unwrap();
+
+    // Wide proof: descends into innertree, so the proof carries a lower layer
+    // at that key.
+    let mut inner = Query::new();
+    inner.insert_all();
+    let mut outer = Query::new();
+    outer.insert_key(b"innertree".to_vec());
+    outer.set_subquery(inner);
+    let broad_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], outer);
+
+    let proof_bytes = db
+        .prove_query(&broad_query, None, grove_version)
+        .unwrap()
+        .expect("should generate descending proof");
+
+    // Narrow query: the innertree element itself, no subquery.
+    let narrow_query = PathQuery::new_single_key(vec![TEST_LEAF.to_vec()], b"innertree".to_vec());
+
+    let (subset_root, subset_results) =
+        GroveDb::verify_subset_query(&proof_bytes, &narrow_query, grove_version)
+            .expect("subset verification must accept a query that stops at the tree element");
+
+    assert_eq!(subset_root, expected_root);
+    assert_eq!(
+        subset_results.len(),
+        1,
+        "only the tree element itself is a result; the lower layer's rows are not reported"
+    );
+    let (path, key, element) = &subset_results[0];
+    assert_eq!(
+        path,
+        &vec![TEST_LEAF.to_vec()],
+        "the tree must be reported under its PARENT path, so (path, key) lookups hit"
+    );
+    assert_eq!(key, b"innertree");
+    assert!(
+        element
+            .as_ref()
+            .expect("element present")
+            .is_non_empty_merk_tree(),
+        "the reported element must be the innertree subtree itself"
+    );
+
+    // Succinct mode still refuses: for this narrow query the lower layer is
+    // data the query never asked for.
+    assert!(
+        GroveDb::verify_query(&proof_bytes, &narrow_query, grove_version).is_err(),
+        "verify_query must still reject a proof carrying an unrequested lower layer"
+    );
+}
+
+/// The element bytes reported by the subset path above stay BOUND.
+///
+/// A `KVValueHash`-family node hashes only `(key, value_hash)`, so a prover
+/// that could get a tree element reported without any child-hash check could
+/// swap in forged element bytes under a genuine root hash. Two tampers prove
+/// the binding is load-bearing rather than incidental:
+///
+///   1. a dummy lower layer attached where none belongs, and
+///   2. a real-but-wrong lower layer (a sibling subtree's proof).
+///
+/// Both must be rejected even though succinctness checking is OFF.
+#[test]
+fn test_subset_mode_still_binds_element_bytes_to_lower_layer() {
+    let grove_version = GroveVersion::latest();
+    let db = make_deep_tree(grove_version);
+    let config = bincode::config::standard()
+        .with_big_endian()
+        .with_no_limit();
+
+    // Wide proof descending into BOTH innertree and innertree4, so the two
+    // sibling lower layers are available to swap.
+    let mut inner = Query::new();
+    inner.insert_all();
+    let mut outer = Query::new();
+    outer.insert_all();
+    outer.set_subquery(inner);
+    let broad_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], outer);
+    let proof_bytes = db
+        .prove_query(&broad_query, None, grove_version)
+        .unwrap()
+        .expect("should generate descending proof");
+
+    let narrow_query = PathQuery::new_single_key(vec![TEST_LEAF.to_vec()], b"innertree".to_vec());
+
+    // Sanity: untampered, the narrow subset query verifies.
+    GroveDb::verify_subset_query(&proof_bytes, &narrow_query, grove_version)
+        .expect("honest proof must verify with the narrow query");
+
+    let decode = |bytes: &[u8]| -> GroveDBProof {
+        bincode::decode_from_slice(bytes, config)
+            .expect("should decode proof")
+            .0
+    };
+    let test_leaf_key = TEST_LEAF.to_vec();
+    let innertree_key = b"innertree".to_vec();
+    let innertree4_key = b"innertree4".to_vec();
+
+    // These proofs are V1 envelopes; only V1 carries the typed lower-layer
+    // proof bytes this test tampers with.
+    fn root_layer_mut(proof: &mut GroveDBProof) -> &mut LayerProof {
+        match proof {
+            GroveDBProof::V1(v1) => &mut v1.root_layer,
+            GroveDBProof::V0(_) => panic!("expected a V1 proof envelope"),
+        }
+    }
+
+    // Tamper 1: replace innertree's lower layer with an empty dummy.
+    let mut dummy = decode(&proof_bytes);
+    root_layer_mut(&mut dummy)
+        .lower_layers
+        .get_mut(&test_leaf_key)
+        .expect("TEST_LEAF layer")
+        .lower_layers
+        .insert(
+            innertree_key.clone(),
+            LayerProof {
+                merk_proof: ProofBytes::Merk(Vec::new()),
+                lower_layers: Default::default(),
+            },
+        );
+    let dummy_bytes = bincode::encode_to_vec(&dummy, config).expect("re-encode");
+    assert!(
+        GroveDb::verify_subset_query(&dummy_bytes, &narrow_query, grove_version).is_err(),
+        "a dummy lower layer must not let unbound element bytes through in subset mode"
+    );
+
+    // Tamper 2: give innertree its SIBLING's lower layer — a structurally
+    // valid Merk proof that commits to a different root.
+    let mut swapped = decode(&proof_bytes);
+    let leaf_layers = &mut root_layer_mut(&mut swapped)
+        .lower_layers
+        .get_mut(&test_leaf_key)
+        .expect("TEST_LEAF layer")
+        .lower_layers;
+    let sibling = leaf_layers
+        .get(&innertree4_key)
+        .expect("innertree4 lower layer")
+        .clone();
+    leaf_layers.insert(innertree_key, sibling);
+    let swapped_bytes = bincode::encode_to_vec(&swapped, config).expect("re-encode");
+    assert!(
+        GroveDb::verify_subset_query(&swapped_bytes, &narrow_query, grove_version).is_err(),
+        "the reported element must be bound to ITS OWN child root, not any valid subtree proof"
     );
 }


### PR DESCRIPTION
## Summary

Two follow-ups to the indexed-tree family (#657), found while integrating it into Dash Platform:

### 1. Expose indexed-axis proof verification to verify-only builds

The verify-side entry points of the indexed-axis proof envelope (`verify_indexed_axis_top_k` and friends) were `minimal`-gated at the module level, so a consumer compiling with `--no-default-features --features verify` (exactly what Dash Platform's `drive` crate does for its proof-verification layer) could not reach them. The prove-side items are now gated individually and the module is open to both feature sets, mirroring how the rest of the proof code splits prover from verifier. Verified with a reachability probe: without the change, `GroveDb::verify_indexed_count_top_k` and the other verify entry points fail to resolve under a verify-only build.

### 2. Bind, don't reject, a lower layer with no query below it

#657 added a hard rejection in `verify_layer_proof_v1`: a V1 proof supplying a lower layer for a tree the query doesn't descend into errored with *"the element bytes would be unbound"*. The underlying concern is real — a `KVValueHash`-family node hashes only `(key, value_hash)`, so reporting the element without binding it would let a prover attach a dummy layer and swap in forged bytes under a genuine root hash.

But the check conflates that attack with the **normal shape of a subset verification**: `verify_subset_query` exists precisely to run a narrow query against a proof generated for a wider one, and any such proof legitimately descends below the narrow query. The rejection broke previously-passing verifications downstream (Dash Platform extracts a commitment tree's `total_count` from the same proof bytes that prove a note fetch — a single-key, no-subquery subset query that stops at the tree element).

The fix binds instead of rejecting: the lower layer is consumed for its root hash and the existing `combine_hash(H(value), child_root)` chain check does the binding; only the reporting differs. Succinct mode still rejects outright with the original message. The result is strictly stronger than v5.0.1, which bound nothing on this path — pinned by two tamper tests (a dummy layer, and a sibling subtree's real-but-wrong layer, both rejected in subset mode).

## Tests

- 3 new tests (plain-Tree repro, two-tamper binding test, and the exact commitment-tree subset shape that broke downstream), all failing before the fix with the reported error verbatim
- `cargo test -p grovedb --lib`: 2535 passed, 0 failed
- `cargo test --workspace`, `cargo clippy --workspace --all-features -- -D warnings`, `cargo check -p grovedb --no-default-features --features verify`: all clean

## Known related gap (not addressed here)

Terminally-reported `CommitmentTree` / `MmrTree` / `BulkAppendTree` / `DenseAppendOnlyFixedSizeTree` elements (no lower layer at all) are bound by nothing in V1 proofs — pre-existing at v5.0.1, independent of this change, and being worked separately since the fix touches the proof format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proof verification for parent-level queries and lower-layer root validation.
  * Ensured subset verification correctly reports requested elements while rejecting mismatched or unrequested proof layers.
  * Preserved authentication for empty targets through the verification chain.

* **Compatibility**
  * Made verification-only builds available without enabling proof generation.

* **Tests**
  * Added regression coverage for commitment-tree queries, nested proofs, strict verification, and invalid lower-layer proofs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->