### PR TITLE
feat(query): route carrier sum and count+sum reads through run_path_query

### DIFF
--- a/grovedb/src/operations/get/run_path_query.rs
+++ b/grovedb/src/operations/get/run_path_query.rs
@@ -4,10 +4,15 @@
 //! [`GroveDb::run_path_query`] classifies the query once
 //! ([`PathQuery::classify`]) and routes it to the engine that already
 //! serves that shape — the key-selection reader, the aggregate-on-range
-//! readers, the indexed-axis primitives, or the budgeted sum reader.
-//! It returns a [`PathQueryRun`] whose variant mirrors the shape, so a
-//! caller holding an arbitrary `PathQuery` gets a typed answer without
-//! knowing in advance which of the specialized entry points serves it.
+//! readers (leaf and per-key carrier, on all three axes), the
+//! indexed-axis primitives, or the budgeted sum reader. It returns a
+//! [`PathQueryRun`] whose variant mirrors the shape, so a caller holding
+//! an arbitrary `PathQuery` gets a typed answer without knowing in
+//! advance which of the specialized entry points serves it.
+//!
+//! Every classified shape now has a reader behind it: the dispatch
+//! returns no `NotSupported` of its own except the read-mode version
+//! gate below.
 //!
 //! Read-mode shapes (axis and sum-budget reads) are gated on
 //! `path_query_methods.unified_read_mode` — `0` before GROVE_V4 means
@@ -72,6 +77,12 @@ pub enum PathQueryRun {
     },
     /// Carrier `AggregateCountOnRange`: one count per matched outer key.
     AggregateCountPerKey(Vec<(Vec<u8>, u64)>),
+    /// Carrier `AggregateSumOnRange`: one signed sum per matched outer
+    /// key.
+    AggregateSumPerKey(Vec<(Vec<u8>, i64)>),
+    /// Carrier `AggregateCountAndSumOnRange`: both metrics per matched
+    /// outer key, each from one walk over that key's leaf.
+    AggregateCountAndSumPerKey(Vec<(Vec<u8>, u64, i64)>),
     /// Single-path axis read (`TopK` / `Bounded` traversals): the
     /// entries in walk order.
     AxisEntries(AxisEntries),
@@ -201,13 +212,24 @@ impl GroveDb {
                     );
                     Ok(PathQueryRun::AggregateCountPerKey(per_key)).wrap_with_cost(cost)
                 }
-                AggregateKind::Sum | AggregateKind::CountAndSum => Err(Error::NotSupported(
-                    "carrier aggregate-sum reads have no trusted per-key read primitive; use \
-                     prove_query with verify_aggregate_sum_query_per_key / \
-                     verify_aggregate_count_and_sum_query_per_key"
-                        .to_string(),
-                ))
-                .wrap_with_cost(cost),
+                AggregateKind::Sum => {
+                    let per_key = cost_return_on_error!(
+                        &mut cost,
+                        self.query_aggregate_sum_per_key(path_query, transaction, grove_version)
+                    );
+                    Ok(PathQueryRun::AggregateSumPerKey(per_key)).wrap_with_cost(cost)
+                }
+                AggregateKind::CountAndSum => {
+                    let per_key = cost_return_on_error!(
+                        &mut cost,
+                        self.query_aggregate_count_and_sum_per_key(
+                            path_query,
+                            transaction,
+                            grove_version
+                        )
+                    );
+                    Ok(PathQueryRun::AggregateCountAndSumPerKey(per_key)).wrap_with_cost(cost)
+                }
             },
             PathQueryShape::AxisRead { axis } => {
                 let path_refs: Vec<&[u8]> = path_query

--- a/grovedb/src/tests/run_path_query_tests.rs
+++ b/grovedb/src/tests/run_path_query_tests.rs
@@ -898,7 +898,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_carrier_count_matches_per_key_reader_and_others_are_refused() {
+    fn aggregate_carrier_all_kinds_match_their_per_key_readers() {
         let grove_version = GroveVersion::latest();
         let db = make_test_grovedb(grove_version);
         // Two outer keys, each holding a provable count tree.
@@ -957,22 +957,222 @@ mod tests {
             other => panic!("expected AggregateCountPerKey, got {other:?}"),
         }
 
-        // The sum and combined carriers have no trusted per-key reader
-        // yet; the dispatch must refuse them by name rather than
-        // silently answering something else.
-        for subquery in [
-            Query::new_aggregate_sum_on_range(QueryItem::Range(b"a".to_vec()..b"z".to_vec())),
-            Query::new_aggregate_count_and_sum_on_range(QueryItem::Range(
-                b"a".to_vec()..b"z".to_vec(),
-            )),
-        ] {
-            let mut carrier = Query::new();
-            carrier.insert_key(b"one".to_vec());
-            carrier.set_subquery(subquery);
-            let pq = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], carrier);
-            match db
+        // Sum carrier: outer keys holding ProvableSumTrees. Before the
+        // per-key sum reader existed this arm returned NotSupported;
+        // now it must route and agree with the dedicated reader.
+        for outer in [b"sone", b"stwo"] {
+            db.insert(
+                [TEST_LEAF].as_ref(),
+                outer,
+                Element::empty_provable_sum_tree(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("create sum carrier outer");
+            for (key, sum) in [(b"a", 11i64), (b"b", -4)] {
+                db.insert(
+                    [TEST_LEAF, outer].as_ref(),
+                    key,
+                    Element::new_sum_item(sum),
+                    None,
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("insert carrier sum item");
+            }
+        }
+        let mut sum_carrier = Query::new();
+        sum_carrier.insert_key(b"sone".to_vec());
+        sum_carrier.insert_key(b"stwo".to_vec());
+        sum_carrier.set_subquery(Query::new_aggregate_sum_on_range(QueryItem::Range(
+            b"a".to_vec()..b"z".to_vec(),
+        )));
+        let sum_carrier_pq = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], sum_carrier);
+
+        let direct_sums = db
+            .query_aggregate_sum_per_key(&sum_carrier_pq, None, grove_version)
+            .unwrap()
+            .expect("direct per-key sums");
+        match db
+            .run_path_query(
+                &sum_carrier_pq,
+                true,
+                true,
+                true,
+                QueryResultType::QueryKeyElementPairResultType,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("unified per-key sums")
+        {
+            PathQueryRun::AggregateSumPerKey(per_key) => {
+                assert_eq!(per_key, direct_sums);
+                // Sanity-check the value itself, not just the agreement:
+                // 11 + (-4) = 7 per outer key.
+                assert_eq!(
+                    per_key,
+                    vec![(b"sone".to_vec(), 7i64), (b"stwo".to_vec(), 7)]
+                );
+            }
+            other => panic!("expected AggregateSumPerKey, got {other:?}"),
+        }
+
+        // Combined carrier: outer keys holding PCPS trees — the only
+        // tree type that can terminate a dual-axis walk.
+        for outer in [b"cone", b"ctwo"] {
+            db.insert(
+                [TEST_LEAF].as_ref(),
+                outer,
+                Element::empty_provable_count_provable_sum_tree(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("create combined carrier outer");
+            for (key, sum) in [(b"a", 11i64), (b"b", -4)] {
+                db.insert(
+                    [TEST_LEAF, outer].as_ref(),
+                    key,
+                    Element::new_sum_item(sum),
+                    None,
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("insert carrier PCPS sum item");
+            }
+        }
+        let mut combined_carrier = Query::new();
+        combined_carrier.insert_key(b"cone".to_vec());
+        combined_carrier.insert_key(b"ctwo".to_vec());
+        combined_carrier.set_subquery(Query::new_aggregate_count_and_sum_on_range(
+            QueryItem::Range(b"a".to_vec()..b"z".to_vec()),
+        ));
+        let combined_carrier_pq =
+            PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], combined_carrier);
+
+        let direct_combined = db
+            .query_aggregate_count_and_sum_per_key(&combined_carrier_pq, None, grove_version)
+            .unwrap()
+            .expect("direct per-key combined");
+        match db
+            .run_path_query(
+                &combined_carrier_pq,
+                true,
+                true,
+                true,
+                QueryResultType::QueryKeyElementPairResultType,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("unified per-key combined")
+        {
+            PathQueryRun::AggregateCountAndSumPerKey(per_key) => {
+                assert_eq!(per_key, direct_combined);
+                assert_eq!(
+                    per_key,
+                    vec![
+                        (b"cone".to_vec(), 2u64, 7i64),
+                        (b"ctwo".to_vec(), 2u64, 7i64)
+                    ]
+                );
+            }
+            other => panic!("expected AggregateCountAndSumPerKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn aggregate_carrier_per_key_dispatch_surfaces_reader_errors() {
+        // The dispatch must not paper over the readers' rejections: a
+        // carrier whose outer match is a non-tree element, and a
+        // combined carrier terminating in a single-axis host, must fail
+        // through `run_path_query` exactly as they fail through the
+        // dedicated readers.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"item",
+            Element::new_item(b"not a tree".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert non-tree outer");
+        // Single-axis host under a combined carrier.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"pst",
+            Element::empty_provable_sum_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create single-axis host");
+        db.insert(
+            [TEST_LEAF, b"pst"].as_ref(),
+            b"a",
+            Element::new_sum_item(5),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert sum item");
+
+        let mut non_tree_carrier = Query::new();
+        non_tree_carrier.insert_key(b"item".to_vec());
+        non_tree_carrier.set_subquery(Query::new_aggregate_sum_on_range(QueryItem::Range(
+            b"a".to_vec()..b"z".to_vec(),
+        )));
+        let non_tree_pq = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], non_tree_carrier);
+
+        let mut single_axis_carrier = Query::new();
+        single_axis_carrier.insert_key(b"pst".to_vec());
+        single_axis_carrier.set_subquery(Query::new_aggregate_count_and_sum_on_range(
+            QueryItem::Range(b"a".to_vec()..b"z".to_vec()),
+        ));
+        let single_axis_pq = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], single_axis_carrier);
+
+        // Pair each query with the reader the dispatch should route it
+        // to, so the comparison is explicit rather than inferred from
+        // the query's shape.
+        let cases: [(&PathQuery, Box<dyn Fn() -> Error>, &str); 2] = [
+            (
+                &non_tree_pq,
+                Box::new(|| {
+                    db.query_aggregate_sum_per_key(&non_tree_pq, None, grove_version)
+                        .unwrap()
+                        .map(|_| ())
+                        .expect_err("non-tree outer must be rejected")
+                }),
+                "non-tree outer match",
+            ),
+            (
+                &single_axis_pq,
+                Box::new(|| {
+                    db.query_aggregate_count_and_sum_per_key(&single_axis_pq, None, grove_version)
+                        .unwrap()
+                        .map(|_| ())
+                        .expect_err("single-axis host must be rejected")
+                }),
+                "single-axis host under combined carrier",
+            ),
+        ];
+
+        for (pq, direct_reader, label) in cases {
+            let direct = direct_reader();
+            let unified = db
                 .run_path_query(
-                    &pq,
+                    pq,
                     true,
                     true,
                     true,
@@ -981,12 +1181,13 @@ mod tests {
                     grove_version,
                 )
                 .unwrap()
-            {
-                Err(Error::NotSupported(message)) => {
-                    assert!(message.contains("per-key"), "got: {message}")
-                }
-                other => panic!("sum/combined carriers must be refused, got {other:?}"),
-            }
+                .map(|_| ())
+                .expect_err(label);
+            assert_eq!(
+                unified.to_string(),
+                direct.to_string(),
+                "dispatch must surface the reader's error verbatim for {label}"
+            );
         }
     }
 


### PR DESCRIPTION
Follow-up to #803 (merged) and #798 (merged) — the dispatch wiring both PRs left open.

## What this closes

`run_path_query`'s `AggregateCarrier` arm served only the count axis and refused the other two by name:

```rust
AggregateKind::Sum | AggregateKind::CountAndSum => Err(Error::NotSupported(
    "carrier aggregate-sum reads have no trusted per-key read primitive; use \
     prove_query with verify_aggregate_sum_query_per_key / ..."
))
```

That was accurate when #798 landed — the readers didn't exist. #803 added them, so the arm now routes all three axes:

| `AggregateKind` | reader |
|---|---|
| `Count` | `query_aggregate_count_per_key` |
| `Sum` | `query_aggregate_sum_per_key` *(newly reachable)* |
| `CountAndSum` | `query_aggregate_count_and_sum_per_key` *(newly reachable)* |

**Every shape `classify()` can produce now has a reader behind it.** The only `NotSupported` the dispatch still raises is the read-mode version gate, which is intentional and unrelated. Module doc updated to say so.

## The result-type decision

`PathQueryRun` gains two variants rather than collapsing the carrier family:

```rust
AggregateCountPerKey(Vec<(Vec<u8>, u64)>),             // existed
AggregateSumPerKey(Vec<(Vec<u8>, i64)>),               // new
AggregateCountAndSumPerKey(Vec<(Vec<u8>, u64, i64)>),  // new
```

The plan for this follow-up was to mirror a `VerifiedPathQuery::AggregatePerKey { per_key: Vec<(Vec<u8>, Option<u64>, Option<i64>)> }`. **That type does not exist anywhere in the repo** — #798 shipped the read dispatch only, and its own module doc notes that \"the unified proof dispatch arrives separately.\" With no mirror target, three typed variants win on every axis I can find:

- **Consistent with this enum's own leaf family** one screen above: `AggregateCount(u64)` / `AggregateSum(i64)` / `AggregateCountAndSum { count, sum }`. Collapsing only the carrier half would make the two halves disagree.
- **Honest types.** A sum carrier can never produce a count, so `Option<u64>` would be statically always-`None` on that axis — the collapsed shape encodes a value that can't occur.
- **Additive.** `AggregateCountPerKey` is already public on develop; collapsing it is a breaking change to a just-shipped variant.
- **1:1 with the readers**, so the routing is a straight hand-off with no reshaping.

When the unified *verify* dispatch lands, it should mirror these three variants rather than the collapsed shape.

## Tests

`aggregate_carrier_count_matches_per_key_reader_and_others_are_refused` existed to assert the refusal, so it is now `aggregate_carrier_all_kinds_match_their_per_key_readers`: a differential assertion per axis (unified answer == dedicated reader) over `ProvableSumTree` and PCPS carrier fixtures, plus a check of the values themselves so the test would catch both readers being wrong in the same way.

New: `aggregate_carrier_per_key_dispatch_surfaces_reader_errors`. Routing must not paper over a reader's rejection, so a non-tree outer match and a single-axis host under a combined carrier each have to fail through `run_path_query` with the same error text the dedicated reader produces.

## Validation

- `cargo clippy --workspace --all-features -- -D warnings` — clean (exit 0, zero diagnostics)
- `cargo test -p grovedb -p grovedb-query --all-features` — 2633 + 255 pass, 0 fail
- `cargo build --no-default-features --features verify -p grovedb` — clean
- `cargo fmt --check` — clean

No version gating: purely additive routing over readers that are already gated on their own existing slots (`query_aggregate_{sum,count_and_sum}_on_range`), so no new slots and no V4 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)