### PR TITLE
feat: dual-aggregate count secondary — count+Total served (closes #806)

### DIFF
--- a/grovedb-query/src/axis_query.rs
+++ b/grovedb-query/src/axis_query.rs
@@ -249,14 +249,7 @@ pub enum AxisTraversal {
     /// The same pair over sums `[40, -10, 25]` with band `[0, 100]`
     /// selects `40` and `25`: `Population` answers `2`, `Total` answers
     /// `65`.
-    ///
-    /// **Currently unsupported: `Total` on the count axis.** The query
-    /// validates and serializes (the vocabulary is stable), but every
-    /// execution surface — trusted read, embedded prover/verifier,
-    /// standalone prover/verifier — refuses it with a typed
-    /// `NotSupported` naming issue #806 until the count secondary
-    /// becomes sum-bearing (#806 part 2, which removes this paragraph).
-    /// The other three (axis, fold) cells are served today.
+
     ///
     /// **Cost** — `O(log n)` in every case, either fold. The walk
     /// classifies each subtree as fully Contained, Disjoint, or Partial

--- a/grovedb/src/batch/indexed_tree/mirror.rs
+++ b/grovedb/src/batch/indexed_tree/mirror.rs
@@ -23,17 +23,25 @@ use grovedb_storage::StorageContext;
 use grovedb_version::version::GroveVersion;
 
 use super::{read_entry_aggregates, AggregatePair, AggregateTransition};
-use crate::{operations::indexed_tree::make_axis_secondary_key, Element, Error};
+use crate::{
+    operations::indexed_tree::{count_value_as_sum, make_axis_secondary_key},
+    Element, Error,
+};
 
 /// The per-axis payload stored alongside the sort key. The key encodes the
 /// ordering value; the payload carries what the secondary's own aggregate
-/// must sum to, which is why the sum and avg axes cannot store a bare item.
-fn axis_row_payload(axis: IndexAxis, sum: i64) -> Element {
-    match axis {
-        IndexAxis::Count => Element::new_item(Vec::new()),
+/// must sum to, which is why NO axis can store a bare item: every
+/// secondary is a dual-aggregate `ProvableCountProvableSumTree`, and the
+/// count axis mirrors its `count_value` into the sum half so a band
+/// TOTAL is one committed scalar (issue #806).
+///
+/// Fallible only through [`count_value_as_sum`]'s fail-closed guard.
+fn axis_row_payload(axis: IndexAxis, count: u64, sum: i64) -> Result<Element, Error> {
+    Ok(match axis {
+        IndexAxis::Count => Element::new_sum_item(count_value_as_sum(count)?),
         IndexAxis::Sum => Element::new_sum_item(sum),
         IndexAxis::Avg => Element::new_item_with_sum_item(Vec::new(), sum),
-    }
+    })
 }
 
 /// Enforce the precise per-axis item-key bound: avg prepends a 16-byte sort
@@ -101,18 +109,18 @@ fn build_axis_mirror_batch(
     let secondary_tree_type = crate::operations::indexed_tree::axis_secondary_tree_type(axis);
     let mut secondary_batch: Vec<BatchEntry<Vec<u8>>> = Vec::with_capacity(transitions.len() * 2);
     for (key, old_aggregates, new_aggregates) in transitions {
-        let old_entry = old_aggregates.map(|(c, s)| {
-            (
-                make_axis_secondary_key(axis, c, s, key),
-                axis_row_payload(axis, s),
-            )
-        });
-        let new_entry = new_aggregates.map(|(c, s)| {
-            (
-                make_axis_secondary_key(axis, c, s, key),
-                axis_row_payload(axis, s),
-            )
-        });
+        let entry_for = |aggregates: &AggregatePair| -> Result<_, Error> {
+            aggregates
+                .map(|(c, s)| {
+                    Ok((
+                        make_axis_secondary_key(axis, c, s, key),
+                        axis_row_payload(axis, c, s)?,
+                    ))
+                })
+                .transpose()
+        };
+        let old_entry = cost_return_on_error_no_add!(cost, entry_for(old_aggregates));
+        let new_entry = cost_return_on_error_no_add!(cost, entry_for(new_aggregates));
         if old_entry == new_entry {
             continue;
         }

--- a/grovedb/src/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/estimated_costs/average_case_costs.rs
@@ -550,7 +550,7 @@ impl GroveDb {
             // their fixed worst-case varint width, so `i64::MAX` here is the
             // upper bound, not an average.
             let worst_case_row = match axis {
-                grovedb_element::indexed::IndexAxis::Count => Element::new_item(vec![]),
+                grovedb_element::indexed::IndexAxis::Count => Element::new_sum_item(i64::MAX),
                 grovedb_element::indexed::IndexAxis::Sum => Element::new_sum_item(i64::MAX),
                 grovedb_element::indexed::IndexAxis::Avg => {
                     Element::new_item_with_sum_item(vec![], i64::MAX)

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -1692,7 +1692,9 @@ impl GroveDb {
             // under the right key but carrying the wrong value is caught too
             // — the key alone does not pin the stored aggregate.
             let payload = match axis {
-                grovedb_element::indexed::IndexAxis::Count => Element::new_item(Vec::new()),
+                grovedb_element::indexed::IndexAxis::Count => Element::new_sum_item(
+                    crate::operations::indexed_tree::count_value_as_sum(count)?,
+                ),
                 grovedb_element::indexed::IndexAxis::Sum => Element::new_sum_item(sum),
                 grovedb_element::indexed::IndexAxis::Avg => {
                     Element::new_item_with_sum_item(Vec::new(), sum)

--- a/grovedb/src/operations/get/run_path_query.rs
+++ b/grovedb/src/operations/get/run_path_query.rs
@@ -458,12 +458,23 @@ impl GroveDb {
                     )))
                     .wrap_with_cost(cost)
                 }
-                (IndexAxis::Count, AggregateFold::Total) => Err(Error::NotSupported(
-                    "a TOTAL over the count axis needs a sum-bearing count secondary; \
-                     tracked in issue #806"
-                        .to_string(),
-                ))
-                .wrap_with_cost(cost),
+                (IndexAxis::Count, AggregateFold::Total) => {
+                    let (lo_count, hi_count) = clamp_count_bounds(*lo, *hi);
+                    let value = cost_return_on_error!(
+                        &mut cost,
+                        self.indexed_count_total_over_value_range(
+                            path,
+                            lo_count,
+                            hi_count,
+                            transaction,
+                            grove_version
+                        )
+                    );
+                    Ok(PathQueryRun::AxisAggregate(AxisAggregateValue::Total(
+                        value,
+                    )))
+                    .wrap_with_cost(cost)
+                }
                 // classify rejects value-range aggregates on the Avg axis.
                 (IndexAxis::Avg, _) => Err(Error::CorruptedCodeExecution(
                     "value-range aggregate on the Avg axis survived classification",

--- a/grovedb/src/operations/indexed_tree.rs
+++ b/grovedb/src/operations/indexed_tree.rs
@@ -53,20 +53,41 @@ use grovedb_version::version::GroveVersion;
 use crate::{util::TxRef, Element, Error, GroveDb, Transaction, TransactionArg};
 
 /// Per-axis Merk tree type to open the secondary with.
+///
+/// Every axis uses the dual-aggregate
+/// [`TreeType::ProvableCountProvableSumTree`]: the count half is what
+/// makes positional queries provable in `O(log n)` (the count-offset
+/// proof primitive skips whole subtrees via counted node commitments),
+/// and the sum half is what makes a TOTAL over a value band answerable
+/// as one committed scalar ([`AggregateFold::Total`], issue #806).
 #[inline]
 pub(crate) fn axis_secondary_tree_type(axis: IndexAxis) -> TreeType {
     match axis {
-        // Each count entry contributes count = 1.
-        IndexAxis::Count => TreeType::ProvableCountTree,
-        // Each sum entry contributes (count = 1, sum = its own SumValue).
-        // The count half is what makes positional queries against the sum
-        // ranking provable in O(log n): the count-offset proof primitive
-        // skips whole subtrees via counted node commitments, which needs
-        // every secondary node to carry a hash-bound count aggregate.
+        // Each count entry contributes (count = 1, sum = its
+        // count_value as an i64) — the sum half is the band-total.
+        IndexAxis::Count => TreeType::ProvableCountProvableSumTree,
+        // Each sum entry contributes (count = 1, sum = its own
+        // SumValue).
         IndexAxis::Sum => TreeType::ProvableCountProvableSumTree,
         // Each avg entry contributes (count = 1, sum = item's SumValue).
         IndexAxis::Avg => TreeType::ProvableCountProvableSumTree,
     }
+}
+
+/// The count-axis secondary stores each entry's `count_value` as its
+/// sum item, and sum items are `i64`: a count above `i64::MAX` cannot
+/// be mirrored faithfully, so it FAILS CLOSED rather than clamping —
+/// a clamped total would silently lie through authenticated state.
+/// Unreachable for any real tree (a count is bounded by the number of
+/// elements), so the guard is a type-level seam, not a live limit.
+#[inline]
+pub(crate) fn count_value_as_sum(count: u64) -> Result<i64, Error> {
+    i64::try_from(count).map_err(|_| {
+        Error::CorruptedData(format!(
+            "count value {count} exceeds i64::MAX and cannot be mirrored into the \
+             count-axis secondary's sum aggregate"
+        ))
+    })
 }
 
 /// Build the secondary key bytes for an entry at `item_key` under the
@@ -1021,7 +1042,10 @@ impl GroveDb {
             for (key, (count, sum)) in &entries {
                 let secondary_key = make_axis_secondary_key(axis, *count, *sum, key);
                 let payload = match axis {
-                    IndexAxis::Count => Element::new_item(Vec::new()),
+                    IndexAxis::Count => Element::new_sum_item(cost_return_on_error_no_add!(
+                        cost,
+                        count_value_as_sum(*count)
+                    )),
                     IndexAxis::Sum => Element::new_sum_item(*sum),
                     IndexAxis::Avg => Element::new_item_with_sum_item(Vec::new(), *sum),
                 };
@@ -1901,6 +1925,68 @@ impl GroveDb {
         Ok(population).wrap_with_cost(cost)
     }
 
+    /// The TOTAL of the count values of every entry whose `count_value`
+    /// falls in the inclusive band `[lo_count, hi_count]` — the
+    /// [`AggregateFold::Total`](grovedb_query::AggregateFold)
+    /// counterpart of [`Self::indexed_count_aggregate_over_value_range`]
+    /// (which answers the band's POPULATION), enabled by the count
+    /// secondary mirroring each entry's `count_value` into its sum half
+    /// (issue #806).
+    ///
+    /// `O(log n)`: the walk folds contained subtrees' stored sums and
+    /// descends only along the two band boundaries.
+    pub fn indexed_count_total_over_value_range<'b, B, P>(
+        &self,
+        path: P,
+        lo_count: u64,
+        hi_count: u64,
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> CostResult<i64, Error>
+    where
+        B: AsRef<[u8]> + 'b,
+        P: Into<SubtreePath<'b, B>>,
+    {
+        // The version gate precedes the degenerate-range fast path:
+        // every input to this entry point is held to the same version
+        // contract, inverted bounds included.
+        grovedb_version::check_grovedb_v0_with_cost!(
+            "indexed_count_total_over_value_range",
+            grove_version.grovedb_versions.operations.indexed_axis.read
+        );
+        use grovedb_merk::proofs::query::QueryItem as MerkQueryItemForRange;
+
+        let mut cost = OperationCost::default();
+        if lo_count > hi_count {
+            return Ok(0i64).wrap_with_cost(cost);
+        }
+        let path: SubtreePath<B> = path.into();
+        let tx = TxRef::new(&self.db, transaction);
+        let tx_ref = tx.as_ref();
+
+        let secondary_merk = cost_return_on_error!(
+            &mut cost,
+            self.open_validated_axis_secondary(path, IndexAxis::Count, tx_ref, grove_version)
+        );
+
+        let lo_bytes = encode_count_sort_key(lo_count).to_vec();
+        let inner_range = if hi_count == u64::MAX {
+            MerkQueryItemForRange::RangeFrom(lo_bytes..)
+        } else {
+            let upper_bytes = encode_count_sort_key(hi_count + 1).to_vec();
+            MerkQueryItemForRange::Range(lo_bytes..upper_bytes)
+        };
+
+        let total = cost_return_on_error!(
+            &mut cost,
+            secondary_merk
+                .sum_aggregate_on_range(&inner_range, grove_version)
+                .map_err(|e| Error::CorruptedData(format!("indexed count total on range: {e}")))
+        );
+
+        Ok(total).wrap_with_cost(cost)
+    }
+
     // ---- avg axis (PCPSIT-only) ----
 
     /// Iterate the avg-axis secondary in avg-order and return the
@@ -2335,12 +2421,16 @@ pub(crate) fn mirror_indexed_axis_to_secondary<'db, S: StorageContext<'db>>(
     // - Count → constant empty Item (contributes count = 1)
     // - Sum   → SumItem(sum)
     // - Avg   → ItemWithSumItem(empty, sum) (contributes (1, sum))
-    let axis_payload = |sum: i64| -> Element {
-        match axis {
-            IndexAxis::Count => Element::new_item(Vec::new()),
+    // The payload is a function of BOTH aggregates now: the count axis
+    // mirrors count_value into its sum half, so a closure over `sum`
+    // alone could not see a count-only change and the fast path below
+    // would silently skip a real payload update.
+    let axis_payload = |count: u64, sum: i64| -> Result<Element, Error> {
+        Ok(match axis {
+            IndexAxis::Count => Element::new_sum_item(count_value_as_sum(count)?),
             IndexAxis::Sum => Element::new_sum_item(sum),
             IndexAxis::Avg => Element::new_item_with_sum_item(Vec::new(), sum),
-        }
+        })
     };
 
     // Compute old and new sort keys. Either may be None (no entry).
@@ -2366,8 +2456,11 @@ pub(crate) fn mirror_indexed_axis_to_secondary<'db, S: StorageContext<'db>>(
     // former key-only check and preserves the fast path for the common
     // case.
     if old_key == new_key && new_key.is_some() {
-        let payload_unchanged = match (old_sum, new_sum) {
-            (Some(os), Some(ns)) => axis_payload(os) == axis_payload(ns),
+        let payload_unchanged = match ((old_count, old_sum), (new_count, new_sum)) {
+            ((Some(oc), Some(os)), (Some(nc), Some(ns))) => {
+                cost_return_on_error_no_add!(cost, axis_payload(oc, os))
+                    == cost_return_on_error_no_add!(cost, axis_payload(nc, ns))
+            }
             _ => false,
         };
         if payload_unchanged {
@@ -2392,16 +2485,16 @@ pub(crate) fn mirror_indexed_axis_to_secondary<'db, S: StorageContext<'db>>(
             .map_err(Error::MerkError)
         );
     }
-    if let (Some(nk), Some(new_sum_val)) = (&new_key, new_sum) {
+    if let (Some(nk), Some(new_count_val), Some(new_sum_val)) = (&new_key, new_count, new_sum) {
         // Derived by the same `axis_payload` closure the fast-path
-        // equality check above uses, so the two stay in lockstep:
-        // - Count → empty Item (secondary is a ProvableCountTree; every
-        //   entry contributes count = 1)
-        // - Sum   → SumItem(sum) (secondary is a
-        //   ProvableCountProvableSumTree; contributes (1, sum))
-        // - Avg   → ItemWithSumItem(empty, sum) (secondary is a
-        //   ProvableCountProvableSumTree; contributes (1, sum))
-        let entry = axis_payload(new_sum_val);
+        // equality check above uses, so the two stay in lockstep.
+        // Every axis's secondary is a dual-aggregate
+        // ProvableCountProvableSumTree:
+        // - Count → SumItem(count_value) — contributes (1, count), so a
+        //   band TOTAL is one committed scalar (issue #806)
+        // - Sum   → SumItem(sum) — contributes (1, sum)
+        // - Avg   → ItemWithSumItem(empty, sum) — contributes (1, sum)
+        let entry = cost_return_on_error_no_add!(cost, axis_payload(new_count_val, new_sum_val));
         cost_return_on_error!(
             &mut cost,
             entry
@@ -2519,6 +2612,27 @@ fn corrupted_secondary_key_error(axis: IndexAxis, secondary_key: &[u8]) -> Error
         axis_sort_prefix_len(axis),
         secondary_key
     ))
+}
+
+#[cfg(test)]
+mod count_value_as_sum_tests {
+    //! The count-axis secondary stores count_value as an i64 sum item;
+    //! the conversion FAILS CLOSED above i64::MAX rather than clamping,
+    //! because a clamped value would flow into hash-bound authenticated
+    //! state as a silently wrong total.
+
+    use super::count_value_as_sum;
+
+    #[test]
+    fn converts_in_domain_and_fails_closed_above_i64_max() {
+        assert_eq!(count_value_as_sum(0).unwrap(), 0);
+        assert_eq!(count_value_as_sum(8).unwrap(), 8);
+        assert_eq!(count_value_as_sum(i64::MAX as u64).unwrap(), i64::MAX);
+        let err = count_value_as_sum(i64::MAX as u64 + 1)
+            .expect_err("one past i64::MAX must fail closed");
+        assert!(err.to_string().contains("cannot be mirrored"), "{err}");
+        count_value_as_sum(u64::MAX).expect_err("u64::MAX must fail closed");
+    }
 }
 
 #[cfg(test)]

--- a/grovedb/src/operations/proof/indexed_axis/envelope.rs
+++ b/grovedb/src/operations/proof/indexed_axis/envelope.rs
@@ -90,12 +90,11 @@ pub struct IndexedAxisRangeProof {
 /// indexed-tree's per-axis secondary.
 ///
 /// Every axis's secondary binds a count aggregate into its node hashes
-/// (count axis: `ProvableCountTree`; sum and avg axes: dual-axis
-/// `ProvableCountProvableSumTree`), so the secondary proof is always
-/// produced by `Merk::prove_count_offset_on_range`: the skipped prefix
-/// is attested by counted subtree commitments (`HashWithCount` /
-/// `HashWithCountAndSum`), giving `O(log n + k)` proof size regardless
-/// of `offset`.
+/// (every axis is a dual-aggregate `ProvableCountProvableSumTree`), so
+/// the secondary proof is always produced by
+/// `Merk::prove_count_offset_on_range`: the skipped prefix is attested
+/// by counted subtree commitments (`HashWithCountAndSum`), giving
+/// `O(log n + k)` proof size regardless of `offset`.
 #[derive(Encode, Decode, Debug)]
 pub struct IndexedAxisPaginatedProof {
     /// Echoed [`IndexAxis::tag`] of the queried axis. The verifier

--- a/grovedb/src/operations/proof/indexed_axis/generate.rs
+++ b/grovedb/src/operations/proof/indexed_axis/generate.rs
@@ -413,11 +413,11 @@ impl GroveDb {
     /// in the directional walk.
     ///
     /// Every axis's secondary carries a hash-bound count aggregate
-    /// (count axis: `ProvableCountTree`; sum and avg axes:
-    /// `ProvableCountProvableSumTree`), so the secondary proof always
-    /// uses `Merk::prove_count_offset_on_range` — the skipped prefix is
-    /// attested by counted subtree commitments (`HashWithCount` /
-    /// `HashWithCountAndSum`) instead of enumeration, giving
+    /// (every axis is a dual-aggregate `ProvableCountProvableSumTree`),
+    /// so the secondary proof always uses
+    /// `Merk::prove_count_offset_on_range` — the skipped prefix is
+    /// attested by counted subtree commitments (`HashWithCountAndSum`)
+    /// instead of enumeration, giving
     /// O(log n + k) proof size regardless of `offset`.
     ///
     /// Ties (equal axis values) break by `original_key` in walk
@@ -1396,11 +1396,10 @@ where
 /// follows the FOLD ([`AggregateFold::Population`] proves the count
 /// aggregate, [`AggregateFold::Total`] the sum aggregate).
 ///
-/// `(Count, Total)` is refused until the count secondary carries a sum
-/// aggregate (issue #806): the walker would need
-/// `prove_aggregate_sum_on_range` against a tree type that is not
-/// sum-bearing. `Avg` is refused for both folds, mirroring
-/// `AxisQuery::validate`.
+/// Every (Count/Sum, fold) cell is served: all secondaries are
+/// dual-aggregate `ProvableCountProvableSumTree`s, the count axis
+/// mirroring its `count_value` into the sum half (issue #806). `Avg`
+/// is refused for both folds, mirroring `AxisQuery::validate`.
 fn build_aggregate_secondary_proof<'db, S>(
     secondary_merk: &grovedb_merk::Merk<S>,
     axis: IndexAxis,
@@ -1414,16 +1413,7 @@ where
     S: grovedb_storage::StorageContext<'db>,
 {
     let inner_range = match axis {
-        IndexAxis::Count => {
-            if fold == AggregateFold::Total {
-                return Err(Error::NotSupported(
-                    "a TOTAL over the count axis needs a sum-bearing count secondary; \
-                     tracked in issue #806"
-                        .to_string(),
-                ));
-            }
-            count_aggregate_inner_range(lo, hi)
-        }
+        IndexAxis::Count => count_aggregate_inner_range(lo, hi),
         IndexAxis::Sum => sum_aggregate_inner_range(lo, hi),
         IndexAxis::Avg => {
             return Err(Error::NotSupported(

--- a/grovedb/src/operations/proof/indexed_axis/verify.rs
+++ b/grovedb/src/operations/proof/indexed_axis/verify.rs
@@ -682,7 +682,7 @@ fn verify_indexed_axis_paginated_inner(
     }
 
     // Every axis's secondary binds a count aggregate into its node
-    // hashes (count axis: ProvableCountTree; sum and avg axes:
+    // hashes (every axis is a dual-aggregate
     // ProvableCountProvableSumTree), so all three verify through the
     // count-offset primitive: the skipped prefix is independently
     // re-derived from the counted subtree commitments, making `skipped`
@@ -756,16 +756,7 @@ fn verify_indexed_axis_aggregate_inner(
     // makes, sharing these exact range reconstructors so the two sides
     // cannot drift on clamping, degenerate, or out-of-domain shapes.
     let inner_range = match axis {
-        IndexAxis::Count => {
-            if fold == AggregateFold::Total {
-                return Err(Error::NotSupported(
-                    "a TOTAL over the count axis needs a sum-bearing count secondary; \
-                     tracked in issue #806"
-                        .to_string(),
-                ));
-            }
-            count_aggregate_inner_range(envelope.lo, envelope.hi)
-        }
+        IndexAxis::Count => count_aggregate_inner_range(envelope.lo, envelope.hi),
         IndexAxis::Sum => sum_aggregate_inner_range(envelope.lo, envelope.hi),
         IndexAxis::Avg => {
             return Err(Error::NotSupported(

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -1022,13 +1022,6 @@ impl GroveDb {
                 // out-of-domain shapes.
                 let inner_range = match axis {
                     grovedb_merk::proofs::query::IndexAxis::Count => {
-                        if *fold == grovedb_merk::proofs::query::AggregateFold::Total {
-                            return Err(Error::NotSupported(
-                                "a TOTAL over the count axis needs a sum-bearing count \
-                                 secondary; tracked in issue #806"
-                                    .to_string(),
-                            ));
-                        }
                         count_aggregate_inner_range(*lo, *hi)
                     }
                     grovedb_merk::proofs::query::IndexAxis::Sum => {

--- a/grovedb/src/query/mod.rs
+++ b/grovedb/src/query/mod.rs
@@ -630,9 +630,7 @@ impl PathQuery {
     /// answers `2`, [`AggregateFold::Total`](grovedb_query::AggregateFold)
     /// answers `8`. See
     /// [`AxisTraversal::AggregateOverValueRange`](grovedb_query::AxisTraversal::AggregateOverValueRange)
-    /// for the full matrix — including the one cell every execution
-    /// surface currently refuses with `NotSupported`: `Total` on the
-    /// count axis, pending issue #806 part 2.
+    /// for the full matrix; every (Count/Sum, fold) cell is served.
     pub fn new_axis_aggregate_over_value_range(
         path: Vec<Vec<u8>>,
         axis: IndexAxis,

--- a/grovedb/src/tests/axis_descent_proof_tests.rs
+++ b/grovedb/src/tests/axis_descent_proof_tests.rs
@@ -1563,30 +1563,38 @@ mod tests {
     }
 
     #[test]
-    fn count_total_is_refused_by_name_until_the_secondary_is_sum_bearing() {
-        // (Count, Total) is the missing cell of the matrix until issue
-        // #806's secondary upgrade lands: every surface must refuse it
-        // by name, not silently answer the population instead.
+    fn count_total_over_value_range_round_trips_everywhere() {
+        // Issue #806, closed: the count secondary mirrors each entry's
+        // count_value into its sum half, so the TOTAL of the counts in
+        // a band is one committed scalar. This is the original example
+        // from the issue verbatim: counts [3, 1, 5], band [2, 10]
+        // selects the 3 and the 5 — Population answers 2, Total
+        // answers 8.
         let grove_version = GroveVersion::latest();
         let db = make_test_grovedb(grove_version);
-        build_pcpsit(&db, grove_version, PSIT_ENTRIES);
-        let pcpsit_path = vec![TEST_LEAF.to_vec(), b"pcpsit".to_vec()];
+        build_pcit(
+            &db,
+            grove_version,
+            &[(b"alpha", 3), (b"beta", 1), (b"gamma", 5)],
+        );
+        let root = root_hash(&db, grove_version);
+        let path = [TEST_LEAF, b"pcit"];
 
+        // Trusted read.
+        let direct = db
+            .indexed_count_total_over_value_range(path.as_ref(), 2, 10, None, grove_version)
+            .unwrap()
+            .expect("trusted count total");
+        assert_eq!(direct, 8);
+
+        // Unified read dispatch.
         let pq = PathQuery::new_axis_aggregate_over_value_range(
-            pcpsit_path,
+            pcit_path(),
             IndexAxis::Count,
-            0,
+            2,
             10,
             AggregateFold::Total,
         );
-        // The prover refuses...
-        match db.prove_query(&pq, None, grove_version).unwrap() {
-            Err(Error::NotSupported(message)) => {
-                assert!(message.contains("806"), "got: {message}")
-            }
-            other => panic!("count+Total proving must be refused, got {other:?}"),
-        }
-        // ...the trusted read refuses...
         match db
             .run_path_query(
                 &pq,
@@ -1598,95 +1606,95 @@ mod tests {
                 grove_version,
             )
             .unwrap()
+            .expect("unified count total")
         {
-            Err(Error::NotSupported(message)) => {
-                assert!(message.contains("806"), "got: {message}")
-            }
-            other => panic!("count+Total reading must be refused, got {other:?}"),
+            crate::operations::get::PathQueryRun::AxisAggregate(
+                crate::operations::get::AxisAggregateValue::Total(total),
+            ) => assert_eq!(total, 8),
+            other => panic!("expected AxisAggregate(Total), got {other:?}"),
         }
-        // ...and the standalone family refuses on both sides.
-        db.prove_indexed_axis_aggregate_over_value_range(
-            [TEST_LEAF, b"pcpsit"].as_ref(),
-            IndexAxis::Count,
-            0,
-            10,
-            AggregateFold::Total,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect_err("standalone count+Total proving must be refused");
-        GroveDb::verify_indexed_axis_aggregate_over_value_range(
-            &[0u8; 4],
-            &[TEST_LEAF, b"pcpsit"],
-            IndexAxis::Count,
-            0,
-            10,
-            AggregateFold::Total,
-            grove_version,
-        )
-        .expect_err("standalone count+Total verification must be refused");
 
-        // The refusal must also fire in the VERIFIERS' own arms, not
-        // just upstream of them. Embedded: a genuine count+Population
-        // proof against a count+Total query reaches the descent
-        // verifier's (Count, Total) arm — the query is where the fold
-        // lives, so this is the exact shape a confused (or hostile)
-        // client would produce.
+        // Embedded proof round trip.
+        match GroveDb::verify_path_query(&prove(&db, &pq, grove_version), &pq, grove_version)
+            .expect("embedded count total verifies")
+        {
+            VerifiedPathQuery::AxisAggregate { root_hash, value } => {
+                assert_eq!(root_hash, root);
+                assert_eq!(value, 8);
+            }
+            other => panic!("expected AxisAggregate, got {other:?}"),
+        }
+
+        // The Population fold over the same band still answers 2 — the
+        // two questions stay distinct.
         let population_pq = PathQuery::new_axis_aggregate_over_value_range(
-            vec![TEST_LEAF.to_vec(), b"pcpsit".to_vec()],
+            pcit_path(),
             IndexAxis::Count,
-            0,
+            2,
             10,
             AggregateFold::Population,
         );
-        let population_proof = prove(&db, &population_pq, grove_version);
-        match GroveDb::verify_path_query(&population_proof, &pq, grove_version) {
-            Err(Error::NotSupported(message)) => {
-                assert!(message.contains("806"), "got: {message}")
-            }
-            other => panic!("the descent verifier must refuse count+Total, got {other:?}"),
+        match GroveDb::verify_path_query(
+            &prove(&db, &population_pq, grove_version),
+            &population_pq,
+            grove_version,
+        )
+        .expect("embedded count population verifies")
+        {
+            VerifiedPathQuery::AxisAggregate { value, .. } => assert_eq!(value, 2),
+            other => panic!("expected AxisAggregate, got {other:?}"),
         }
 
-        // Standalone: relabel a genuine count+Population envelope's
-        // fold echo to Total. The echo check passes (expected == echo),
-        // so the inner dispatch's (Count, Total) rejection is what must
-        // stop it.
+        // Standalone envelope round trip, with the fold echo honest.
         let standalone = db
             .prove_indexed_axis_aggregate_over_value_range(
-                [TEST_LEAF, b"pcpsit"].as_ref(),
+                path.as_ref(),
                 IndexAxis::Count,
-                0,
+                2,
                 10,
-                AggregateFold::Population,
+                AggregateFold::Total,
                 None,
                 grove_version,
             )
             .unwrap()
-            .expect("standalone count+Population prove");
-        let config = bincode::config::standard().with_limit::<{ 16 * 1024 * 1024 }>();
-        let (mut envelope, _): (
-            crate::operations::proof::indexed_axis::IndexedAxisAggregateProof,
-            usize,
-        ) = bincode::decode_from_slice(&standalone, config).expect("decode envelope");
-        envelope.fold_tag = AggregateFold::Total.tag();
-        let relabeled = bincode::encode_to_vec(&envelope, config).expect("re-encode");
-        match GroveDb::verify_indexed_axis_aggregate_over_value_range(
-            &relabeled,
-            &[TEST_LEAF, b"pcpsit"],
+            .expect("standalone count total prove");
+        let result = GroveDb::verify_indexed_axis_aggregate_over_value_range(
+            &standalone,
+            &path,
             IndexAxis::Count,
-            0,
+            2,
             10,
             AggregateFold::Total,
             grove_version,
-        ) {
-            Err(Error::NotSupported(message)) => {
-                assert!(message.contains("806"), "got: {message}")
-            }
-            other => panic!(
-                "a relabeled count envelope must hit the inner count+Total refusal: {other:?}"
-            ),
-        }
+        )
+        .expect("standalone count total verifies");
+        assert_eq!(result.root_hash, root);
+        assert_eq!(result.aggregate, 8);
+
+        // Deleting gamma (count 5) drops the band total to 3 — the
+        // mirror keeps the sum half live through mutations, not just at
+        // first insert.
+        db.delete_from_count_indexed_tree(path.as_ref(), b"gamma", None, grove_version)
+            .unwrap()
+            .expect("delete gamma");
+        let after = db
+            .indexed_count_total_over_value_range(path.as_ref(), 2, 10, None, grove_version)
+            .unwrap()
+            .expect("trusted count total after delete");
+        assert_eq!(after, 3);
+
+        // The reader's own edge shapes: inverted bounds answer an empty
+        // total, and hi = u64::MAX takes the unbounded upper branch.
+        let inverted = db
+            .indexed_count_total_over_value_range(path.as_ref(), 10, 2, None, grove_version)
+            .unwrap()
+            .expect("inverted bounds are a valid empty answer");
+        assert_eq!(inverted, 0);
+        let unbounded = db
+            .indexed_count_total_over_value_range(path.as_ref(), 0, u64::MAX, None, grove_version)
+            .unwrap()
+            .expect("full-domain total");
+        assert_eq!(unbounded, 4, "alpha(3) + beta(1) after gamma's deletion");
     }
 
     #[test]
@@ -1738,5 +1746,187 @@ mod tests {
             }
             other => panic!("a fold-mismatched envelope must be rejected, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn the_full_axis_fold_matrix_is_served_and_consistent() {
+        // All four (Count/Sum, fold) cells, each read three ways —
+        // trusted, embedded proof, standalone envelope — must agree.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        build_pcit(
+            &db,
+            grove_version,
+            &[(b"alpha", 3), (b"beta", 1), (b"gamma", 5)],
+        );
+        build_psit(&db, grove_version, PSIT_ENTRIES);
+
+        // (path, axis, lo, hi, fold, expected)
+        let matrix: Vec<(Vec<Vec<u8>>, IndexAxis, i128, i128, AggregateFold, i128)> = vec![
+            // counts [3, 1, 5], band [2, 10] selects 3 and 5.
+            (
+                pcit_path(),
+                IndexAxis::Count,
+                2,
+                10,
+                AggregateFold::Population,
+                2,
+            ),
+            (
+                pcit_path(),
+                IndexAxis::Count,
+                2,
+                10,
+                AggregateFold::Total,
+                8,
+            ),
+            // sums [40, -10, 25, 40, 5], band [0, 40] selects 40, 25, 40, 5.
+            (
+                psit_path(),
+                IndexAxis::Sum,
+                0,
+                40,
+                AggregateFold::Population,
+                4,
+            ),
+            (
+                psit_path(),
+                IndexAxis::Sum,
+                0,
+                40,
+                AggregateFold::Total,
+                110,
+            ),
+        ];
+        for (path, axis, lo, hi, fold, expected) in matrix {
+            let pq =
+                PathQuery::new_axis_aggregate_over_value_range(path.clone(), axis, lo, hi, fold);
+            let verified =
+                GroveDb::verify_path_query(&prove(&db, &pq, grove_version), &pq, grove_version)
+                    .unwrap_or_else(|e| panic!("({axis:?}, {fold}) must verify: {e}"));
+            let VerifiedPathQuery::AxisAggregate { value, .. } = verified else {
+                panic!("({axis:?}, {fold}): expected AxisAggregate");
+            };
+            assert_eq!(value, expected, "embedded ({axis:?}, {fold})");
+
+            let path_refs: Vec<&[u8]> = path.iter().map(|segment| segment.as_slice()).collect();
+            let standalone_bytes = db
+                .prove_indexed_axis_aggregate_over_value_range(
+                    path_refs.as_slice(),
+                    axis,
+                    lo,
+                    hi,
+                    fold,
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .unwrap_or_else(|e| panic!("({axis:?}, {fold}) standalone prove: {e}"));
+            let standalone = GroveDb::verify_indexed_axis_aggregate_over_value_range(
+                &standalone_bytes,
+                path_refs.as_slice(),
+                axis,
+                lo,
+                hi,
+                fold,
+                grove_version,
+            )
+            .unwrap_or_else(|e| panic!("({axis:?}, {fold}) standalone verify: {e}"));
+            assert_eq!(
+                standalone.aggregate, expected,
+                "standalone ({axis:?}, {fold})"
+            );
+        }
+    }
+
+    #[test]
+    fn verify_grovedb_holds_across_count_secondary_mutations() {
+        // The PCPS count secondary — payload = SumItem(count_value) —
+        // must satisfy verify_grovedb's primary<->secondary walk through
+        // inserts, count changes, and deletes; the expected-payload
+        // check in verify_indexed_axis_content is what would flag a
+        // drifted mirror.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        build_pcit(
+            &db,
+            grove_version,
+            &[(b"alpha", 3), (b"beta", 1), (b"gamma", 5)],
+        );
+        let clean = db
+            .verify_grovedb(None, true, true, grove_version)
+            .expect("verify runs");
+        assert!(clean.is_empty(), "fresh PCIT verifies: {clean:?}");
+
+        // Change alpha's count by adding a child (3 -> 4), then delete
+        // beta outright.
+        db.insert(
+            [TEST_LEAF, b"pcit", b"alpha"].as_ref(),
+            b"extra",
+            Element::new_item(b"v".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("grow alpha");
+        db.delete_from_count_indexed_tree(
+            [TEST_LEAF, b"pcit"].as_ref(),
+            b"beta",
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("delete beta");
+
+        let after = db
+            .verify_grovedb(None, true, true, grove_version)
+            .expect("verify runs");
+        assert!(after.is_empty(), "mutated PCIT verifies: {after:?}");
+        // And the totals moved with the mutations: counts are now
+        // [4, 5]; band [2, 10] totals 9.
+        let total = db
+            .indexed_count_total_over_value_range(
+                [TEST_LEAF, b"pcit"].as_ref(),
+                2,
+                10,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("total after mutations");
+        assert_eq!(total, 9);
+    }
+
+    #[test]
+    fn a_tampered_count_secondary_sum_fails_the_descent_binding() {
+        // The count secondary's sum half is hash-bound: a prover cannot
+        // overstate a band total by tampering the sum inside the carried
+        // secondary proof, because the recomputed secondary root then
+        // breaks the combine_hash_three parent binding.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        build_pcit(
+            &db,
+            grove_version,
+            &[(b"alpha", 3), (b"beta", 1), (b"gamma", 5)],
+        );
+        let pq = PathQuery::new_axis_aggregate_over_value_range(
+            pcit_path(),
+            IndexAxis::Count,
+            2,
+            10,
+            AggregateFold::Total,
+        );
+        let proof = prove(&db, &pq, grove_version);
+        GroveDb::verify_path_query(&proof, &pq, grove_version).expect("untampered verifies");
+
+        // Flip one byte in the middle of the secondary proof bytes.
+        let tampered = tamper_axis_payload(&proof, |payload| {
+            let len = payload.secondary_proof.len();
+            payload.secondary_proof[len / 2] ^= 0x01;
+        });
+        GroveDb::verify_path_query(&tampered, &pq, grove_version)
+            .expect_err("a tampered count-secondary sum must be rejected");
     }
 }

--- a/grovedb/src/tests/coverage_misc_tests.rs
+++ b/grovedb/src/tests/coverage_misc_tests.rs
@@ -416,16 +416,16 @@ mod tests {
         // mirror writes.
         assert_eq!(k16_count - k8_count, 16);
         // A 8-byte primary + the avg axis and a 16-byte primary + the
-        // count axis both produce a 24-byte secondary key, so what is
-        // left is the avg secondary's two widenings: its count-AND-sum
-        // merk nodes carry a 16-byte-wider aggregate, and its row payload
-        // is an `ItemWithSumItem` (12 bytes at worst sum width) where the
-        // count axis stores a 3-byte empty `Item` — the mirror estimator
-        // sizes each axis's row with its REAL payload shape, since sizing
-        // all three as an empty item put the PCPSIT estimate under actual
-        // `added_bytes`.
-        assert_eq!(k8_avg - k16_count, 16 + 9);
-        assert_eq!(k8_avg - k8_count, 32 + 9);
+        // count axis both produce a 24-byte secondary key, and since
+        // issue #806 EVERY axis is a dual-aggregate
+        // ProvableCountProvableSumTree (the count axis mirrors its
+        // count_value into the sum half), the merk-node aggregate width
+        // is identical across axes. What is left is only the payload
+        // shape: avg stores an `ItemWithSumItem` (12 bytes at worst sum
+        // width) where count stores a `SumItem` (11) — the mirror
+        // estimator sizes each axis's row with its REAL payload shape.
+        assert_eq!(k8_avg - k16_count, 1);
+        assert_eq!(k8_avg - k8_count, 16 + 1);
         let count_axis = narrow;
 
         let sizes = EstimatedLayerSizes::AllItems(8, 100, None);

--- a/grovedb/src/tests/coverage_round7_tests.rs
+++ b/grovedb/src/tests/coverage_round7_tests.rs
@@ -1482,7 +1482,7 @@ mod tests {
                 &secondary_key,
                 None,
                 false,
-                TreeType::ProvableCountTree,
+                TreeType::ProvableCountProvableSumTree,
                 grove_version,
             )
             .unwrap()
@@ -1620,7 +1620,7 @@ mod tests {
                 &secondary_key,
                 None,
                 false,
-                TreeType::ProvableCountTree,
+                TreeType::ProvableCountProvableSumTree,
                 grove_version,
             )
             .unwrap()

--- a/grovedb/src/tests/indexed_tree_secondary_drift_tests.rs
+++ b/grovedb/src/tests/indexed_tree_secondary_drift_tests.rs
@@ -171,7 +171,7 @@ mod tests {
                     key.as_slice(),
                     None,
                     false,
-                    TreeType::ProvableCountTree,
+                    TreeType::ProvableCountProvableSumTree,
                     gv,
                 )
                 .unwrap()

--- a/grovedb/src/tests/merge_versioning_tests.rs
+++ b/grovedb/src/tests/merge_versioning_tests.rs
@@ -218,6 +218,10 @@ mod tests {
             db.indexed_sum_population_over_value_range(path.as_ref(), 0, 100, None, &bad)
         );
         assert_version_rejected!(
+            "indexed_count_total_over_value_range",
+            db.indexed_count_total_over_value_range(path.as_ref(), 0, 100, None, &bad)
+        );
+        assert_version_rejected!(
             "indexed_count_aggregate_over_value_range",
             db.indexed_count_aggregate_over_value_range(path.as_ref(), 0, 100, None, &bad)
         );
@@ -492,6 +496,10 @@ mod tests {
         assert_version_rejected!(
             "indexed_sum_population_over_value_range",
             db.indexed_sum_population_over_value_range(path.as_ref(), 100, 0, None, &bad)
+        );
+        assert_version_rejected!(
+            "indexed_count_total_over_value_range",
+            db.indexed_count_total_over_value_range(path.as_ref(), 100, 0, None, &bad)
         );
         assert_version_rejected!(
             "indexed_count_aggregate_over_value_range",

--- a/grovedb/src/tests/verify_grovedb_indexed_tests.rs
+++ b/grovedb/src/tests/verify_grovedb_indexed_tests.rs
@@ -90,7 +90,7 @@ mod tests {
                 secondary_key,
                 None,
                 false,
-                TreeType::ProvableCountTree,
+                TreeType::ProvableCountProvableSumTree,
                 grove_version,
             )
             .unwrap()


### PR DESCRIPTION
Part 2 of #806 (part 1 was #808). Closes #806.

## The flip

`axis_secondary_tree_type(Count)` → `ProvableCountProvableSumTree`, with each entry's `count_value` mirrored into the sum half. **"Total of the counts in a band" is now one committed scalar, O(log n), provable** through both the embedded V1 descent and the standalone envelope. Every axis's secondary now has the same dual-aggregate shape, and the (axis × fold) matrix is complete:

| | `Population` | `Total` |
|---|---|---|
| **count** | ✅ | ✅ **turned on here** |
| **sum** | ✅ | ✅ |

The issue's own example, verbatim, is the headline test: counts `[3, 1, 5]`, band `[2, 10]` → `Population` 2, `Total` **8** — read three ways (trusted, embedded proof, standalone envelope) and re-checked after a delete.

## Integrity mechanics

- **Four lockstep payload sites** (batch mirror row, mirror closure, reconcile's desired map, `verify_grovedb`'s expected payload) all go through one fail-closed conversion: `count > i64::MAX` is a typed error, **never a clamp** — a clamped total would lie through authenticated state. Unreachable for real trees; unit-tested at the boundary.
- **The mirror closure's signature widens to `|count, sum|`**: the count-axis payload is now a function of the count, which the old `|sum|`-only fast-path equality check could not see — left alone it would have silently skipped real payload updates.
- `verify_grovedb` holds across count-changing mutations and deletes (its expected-payload check doubles as the drift detector); a tampered sum inside the carried secondary proof breaks the `combine_hash_three` binding.
- TopK / RankOfKey / Bounded proofs survive with **zero merk changes** — the count-offset verifier was already dual-flavor (`HashWithCount` / `HashWithCountAndSum`).
- Cost estimator sizes the count row as `SumItem(i64::MAX)`; the count axis now sizes exactly like the sum axis, which the mirror-scaling cost test pins (the old count-vs-avg deltas collapse to the 1-byte payload-shape difference).

Wire-affecting but free: indexed trees are GROVE_V4-gated and V4 has not activated — no migration, no new version slots. The "currently unsupported" doc paragraphs from #808 are deleted, per their own text.

## Verification

`cargo test --workspace --all-features` green, clippy `-D warnings` clean, verify-only build clean. Local llvm-cov patch ~94% (remaining lines are `?`-region artifacts in closures plus the overflow arm, which the unit test covers). New tests: the 2×2 matrix differential across all three read paths, count+Total round trip incl. post-delete, `verify_grovedb` across mutations, secondary-sum tamper rejection, overflow fail-closed, gate + inverted-bounds gate for the new reader.

A blockchain-security-auditor pass over this diff is running and its findings will be posted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)